### PR TITLE
Fix bug SF-816 - DevShort attribute change event has wrong data_type

### DIFF
--- a/cppapi/client/event.cpp
+++ b/cppapi/client/event.cpp
@@ -1,4 +1,4 @@
-static const char *RcsId = "$Id$";
+static const char *RcsId = "$Id: event.cpp 30155 2016-09-16 15:31:47Z bourtemb $";
 
 //====================================================================================================================
 //
@@ -27,7 +27,7 @@ static const char *RcsId = "$Id$";
 // You should have received a copy of the GNU Lesser General Public License along with Tango.
 // If not, see <http://www.gnu.org/licenses/>.
 //
-// $Revision$
+// $Revision: 30155 $
 //
 //
 //====================================================================================================================
@@ -797,6 +797,14 @@ void EventConsumer::attr_to_device(const AttributeValue_4 *attr_value_4,DeviceAt
 void EventConsumer::attr_to_device(const ZmqAttributeValue_4 *attr_value_4,DeviceAttribute *dev_attr)
 {
 	base_attr_to_device(attr_value_4,dev_attr);
+	
+	//
+	// Warning: Since Tango 9, data type SHORT is used for both short attribute and enumeration attribute!
+	// Therefore, we need to store somewhere which exact type it is. With IDL 5, it is easy, because the data type is
+	// transferred on the network (modified IDL), For previous release, we do not have enumerated data type and therefore
+	// the data type could be used only for SHORT.
+	//
+	dev_attr->data_type = Tango::DEV_SHORT;
 }
 
 void EventConsumer::attr_to_device(const ZmqAttributeValue_5 *attr_value_5,DeviceAttribute *dev_attr)


### PR DESCRIPTION
If a tango-9 client subscribed for change_event of a DevShort
attribute on a tango-8 server, the event_type returned by
attr_value->get_type() was DATA_TYPE_UNKNOWN (100), except the first
event and events triggered by automatic re-subscription.