### PR TITLE
When pushing event, init data nb for ATT_NO_DATA

### DIFF
--- a/cppapi/server/zmqeventsupplier.cpp
+++ b/cppapi/server/zmqeventsupplier.cpp
@@ -1222,6 +1222,10 @@ void ZmqEventSupplier::push_event(DeviceImpl *device_impl,string event_type,
 					if (nb_data > LARGE_DATA_THRESHOLD_ENCODED)
 						large_data = true;
 				}
+				else if (data_discr == ATT_NO_DATA)
+				{
+                    nb_data = 0;
+				}
 				else
 				{
 					nb_data = ((int *)mess_ptr)[1];

--- a/cppapi/server/zmqeventsupplier.cpp
+++ b/cppapi/server/zmqeventsupplier.cpp
@@ -1224,7 +1224,7 @@ void ZmqEventSupplier::push_event(DeviceImpl *device_impl,string event_type,
 				}
 				else if (data_discr == ATT_NO_DATA)
 				{
-                    nb_data = 0;
+					nb_data = 0;
 				}
 				else
 				{


### PR DESCRIPTION
When pushing event, don't forget to init data nb in attribute even when for ATT_NO_DATA