### PR TITLE
Generates files from IDL only at compilation time and only if necessary

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.0)
 project(libtango)
 include(CTest)
 
@@ -20,7 +20,8 @@ include(configure/CMakeLists.txt)
 include_directories(cppapi/client)
 include_directories(cppapi/client/helpers)
 include_directories(cppapi/server)
-include_directories(cppapi/server/idl)
+#required for idl/tango.h
+include_directories(${CMAKE_CURRENT_BINARY_DIR}/cppapi/server)
 include_directories(log4tango/include)
 #required for generated config.h
 include_directories(${CMAKE_CURRENT_BINARY_DIR}/log4tango/include)
@@ -54,3 +55,10 @@ configure_file(tango.pc.cmake tango.pc @ONLY)
 
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/tango.pc"
         DESTINATION "${CMAKE_INSTALL_FULL_LIBDIR}/pkgconfig")
+
+# This is a convenient target to be able to test the installation part from CLion IDE
+# Just select the install_libtango target and build (not execute) this target
+# This will do the equivalent of make install from CLion
+add_custom_target(install_${PROJECT_NAME}
+        $(MAKE) install
+        COMMENT "Installing ${PROJECT_NAME}")

--- a/cppapi/client/CMakeLists.txt
+++ b/cppapi/client/CMakeLists.txt
@@ -60,5 +60,6 @@ add_subdirectory(helpers)
 
 add_library(client_objects OBJECT ${SOURCES})
 target_compile_options(client_objects PRIVATE -fPIC)
+add_dependencies(client_objects idl_objects)
 
 install(FILES ${HEADERS} DESTINATION "${CMAKE_INSTALL_FULL_INCLUDEDIR}")

--- a/cppapi/server/CMakeLists.txt
+++ b/cppapi/server/CMakeLists.txt
@@ -137,5 +137,6 @@ add_subdirectory(jpeg_mmx)
 
 add_library(server_objects OBJECT ${SOURCES})
 target_compile_options(server_objects PRIVATE -fPIC)
+add_dependencies(server_objects idl_objects)
 
 install(FILES ${HEADERS} DESTINATION "${CMAKE_INSTALL_FULL_INCLUDEDIR}")

--- a/cppapi/server/idl/CMakeLists.txt
+++ b/cppapi/server/idl/CMakeLists.txt
@@ -1,29 +1,9 @@
-message("Generate tango.h, tangoSK.cpp and tangoDybSK.cpp from idl")
-
-message("Using OMNIIDL_PATH=${OMNIIDL_PATH}")
-message("Using IDL=${IDL_PKG_INCLUDE_DIRS}")
-
-execute_process(COMMAND ${OMNIIDL_PATH}omniidl -I${IDL_PKG_INCLUDE_DIRS} -bcxx -Wbh=.h -Wbs=SK.cpp -Wbd=DynSK.cpp -Wba ${IDL_PKG_INCLUDE_DIRS}/tango.idl
-                WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-                RESULT_VARIABLE FAILED)
-
-if(${FAILED})
-    message(SEND_ERROR " Failed to generate source files from idl. rv=${FAILED}")
-endif()
-
-FILE(GLOB ENHANCEMENTS Enhance*)
-
-foreach(ENHANCEMENT ${ENHANCEMENTS})
-    message("Applying enhancement ${ENHANCEMENT}")
-    execute_process(COMMAND sed -i -f ${ENHANCEMENT} tango.h
-                WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-                RESULT_VARIABLE FAILED)
-
-        #non-zero
-    if(${FAILED})
-        message(SEND_ERROR " Failed to apply ${ENHANCEMENT}. rv=${FAILED}")
-    endif()
-endforeach(ENHANCEMENT)
+add_custom_command(
+	OUTPUT tango.h tangoSK.cpp tangoDynSK.cpp
+	COMMAND ${CMAKE_COMMAND} -DOMNIIDL_PATH=${OMNIIDL_PATH} -DIDL_PKG_INCLUDE_DIRS=${IDL_PKG_INCLUDE_DIRS} 
+	-DCMAKE_INSTALL_FULL_INCLUDEDIR=${CMAKE_INSTALL_FULL_INCLUDEDIR} -DPATCHES_SOURCE_DIR=${CMAKE_CURRENT_SOURCE_DIR} -P ${CMAKE_CURRENT_SOURCE_DIR}/generate/CMakeLists.txt
+	WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+)
 
 set(SOURCES tangoSK.cpp
             tangoDynSK.cpp)
@@ -31,4 +11,5 @@ set(SOURCES tangoSK.cpp
 add_library(idl_objects OBJECT ${SOURCES} tango.h)
 target_compile_options(idl_objects PRIVATE -fPIC)
 
-install(FILES tango.h DESTINATION "${CMAKE_INSTALL_FULL_INCLUDEDIR}/idl")
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/tango.h DESTINATION "${CMAKE_INSTALL_FULL_INCLUDEDIR}/idl")
+

--- a/cppapi/server/idl/generate/CMakeLists.txt
+++ b/cppapi/server/idl/generate/CMakeLists.txt
@@ -1,0 +1,27 @@
+message("Generate tango.h, tangoSK.cpp and tangoDybSK.cpp from idl")
+message("Using OMNIIDL_PATH=${OMNIIDL_PATH}")
+message("Using IDL=${IDL_PKG_INCLUDE_DIRS}")
+
+execute_process(COMMAND ${OMNIIDL_PATH}omniidl -I${IDL_PKG_INCLUDE_DIRS} -bcxx -Wbh=.h -Wbs=SK.cpp -Wbd=DynSK.cpp -Wba ${IDL_PKG_INCLUDE_DIRS}/tango.idl
+                WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+                RESULT_VARIABLE FAILED)
+
+if(${FAILED}) 
+	message(SEND_ERROR " Failed to generate source files from idl. rv=${FAILED}")
+endif()
+
+message("Using PATCHES_SOURCE_DIR=${PATCHES_SOURCE_DIR}")
+
+FILE(GLOB ENHANCEMENTS ${PATCHES_SOURCE_DIR}/Enhance*)
+
+foreach(ENHANCEMENT ${ENHANCEMENTS})
+	message("Applying enhancement ${ENHANCEMENT}")
+	execute_process(COMMAND sed -i -f ${ENHANCEMENT} tango.h
+		            WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+		            RESULT_VARIABLE FAILED)
+    #non-zero
+    if(${FAILED})
+       	message(SEND_ERROR " Failed to apply ${ENHANCEMENT}. rv=${FAILED}")
+    endif()
+endforeach(ENHANCEMENT)
+


### PR DESCRIPTION
(Before it was done when executing cmake, leading to tango.h which could be
patched several times and causing compilation errors).
The files generated from the IDL are now generated in CMAKE_CURRENT_BINARY_DIR
because they could depend on the version of omniORB used by the current config.
CMake minimum required version is now 3.0 instead of 2.8. (CMake was failing
with 2.8.11 version).
Added install_libtango custom target to be able to test the installation part
from CLion IDE.