### PR TITLE
Revert changes introduced in svn r28853 for Tango 9 LTS (git commit 5e12457fba3aa8ea462ff599c7697509ffb2cd52)

### DIFF
--- a/cppapi/server/blackbox.cpp
+++ b/cppapi/server/blackbox.cpp
@@ -1102,12 +1102,8 @@ void BlackBox::inc_indexes()
 void BlackBox::get_client_host()
 {
 	omni_thread *th_id = omni_thread::self();
-	bool dummy = false;
 	if (th_id == NULL)
-    {
 		th_id = omni_thread::create_dummy();
-		dummy = true;
-    }
 
 	omni_thread::value_t *ip = th_id->get_value(key);
 	if (ip == NULL)
@@ -1148,9 +1144,6 @@ void BlackBox::get_client_host()
     }
 	else
 		strcpy(box[insert_elt].host_ip_str,(static_cast<client_addr *>(ip))->client_ip);
-
-    if (dummy == true)
-        omni_thread::release_dummy();
 }
 
 //+-------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
This reintroduces a small memory leak but will avoid crashes reported in the following tickets: 
SF814(#247), SF823(#302) and SF827(#328).