### PR TITLE
Revert changes introduced in svn r28853 on master

### DIFF
--- a/src/server/blackbox.cpp
+++ b/src/server/blackbox.cpp
@@ -1100,12 +1100,8 @@ void BlackBox::inc_indexes()
 void BlackBox::get_client_host()
 {
 	omni_thread *th_id = omni_thread::self();
-	bool dummy = false;
 	if (th_id == NULL)
-    {
 		th_id = omni_thread::create_dummy();
-		dummy = true;
-    }
 
 	omni_thread::value_t *ip = th_id->get_value(key);
 	if (ip == NULL)
@@ -1146,9 +1142,6 @@ void BlackBox::get_client_host()
     }
 	else
 		strcpy(box[insert_elt].host_ip_str,(static_cast<client_addr *>(ip))->client_ip);
-
-    if (dummy == true)
-        omni_thread::release_dummy();
 }
 
 //+-------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
This reintroduces a small memory leak but will avoid crashes reported in the
following tickets: SF814 (#247), SF823 (#302) and SF827 (#328)