### PR TITLE
Forwarded dynamic attributes implementation

### DIFF
--- a/cppapi/server/fwdattrdesc.cpp
+++ b/cppapi/server/fwdattrdesc.cpp
@@ -180,7 +180,10 @@ bool FwdAttr::validate_fwd_att(vector<AttrProperty> &prop_list,const string &dev
 	}
 	catch (...) {}
 
-	if (root_att_db_defined == true)
+	//check if full_root_att is already set
+	if (full_root_att.size()!=0 and full_root_att.compare(RootAttNotDef)!=0)
+		;
+	else if (root_att_db_defined == true)
 		full_root_att = root_att_db;
     else
         full_root_att = RootAttNotDef;

--- a/cppapi/server/multiattribute.cpp
+++ b/cppapi/server/multiattribute.cpp
@@ -915,6 +915,12 @@ void MultiAttribute::add_fwd_attribute(string &dev_name,DeviceClass *dev_class_p
 			alarm_attr_list.push_back(index);
 	}
 
+//
+// Check if the writable_attr_name property is set and in this case, check if the associated attribute exists and is
+// writable
+//
+	check_associated(index,dev_name);
+
 	cout4 << "Leaving MultiAttribute::add_fwd_attribute" << endl;
 }
 


### PR DESCRIPTION
Hi,

Using branch "tango-9-lts" of github cppTango I noticed that tango doesn't seem to properly manage the creation of forwarded attributes when they are dynamically created. In my opinion, there are 3 different scenarios in which forwarded attributes can be created:

1.- Static creation. This is what pogo does, for example. This seems to already be properly managed.
2.- Dynamic creation with root_attribute specified in constructor. In this case the root attribute used will be the one passed in the constructor (tango DB value, if defined, should be always ignored).
3.- Dynamic creation without root_attribute specified in constructor. In this case the root attribute will be the one defined in tango DB.

In cases 2 and 3 if root attribute is not correctly defined then the device will got to Alarm state and status will give a clue of what is wrong: all dynamic attributes will be created, but the ones with incorrect root attribute definition will throw an exception when read or written.

You can easily test the all above options using the attached TestFwd device server (ziped in "TestFwd.zip"). You will have to play with their root attribute definition (for example using jive) in order to reproduce all cases mentioned above. IT assumes that "sys/tg_test/1/double_scalar" is available. It defines 3 forwarded attributes:
- TestFwdAttr: this is a static attribute defined using pogo (it can be used for testing case 1 above).
- TestFwdDyn1: this is a dynamic attribute with root attribute defined in the constructor (it can be used for testing case 2 above).
- TestFwdDyn2: this is a dynamic attribute with root attribute not defined in the constructor (it can be used for testing case 3 above).

The patch seems to work fine in my case. I propose to merge it into tango-9-lts and master or use it as a first approach for developing a better patch (I'm far from a tango core expert, so I may have introduced other bugs while trying to solve this issue).

NOTE that it also fixes a bug I found when the dynamic forwarded attributes are created (this is the patch for "multiattribute.cpp" file): it looks like the write value is not correctly initialized and you can randomly get a coredump when reading them (you may need to restart the server several times to reproduce the error).

Regards,
Jairo Moldes

[TestFwd.zip](https://github.com/tango-controls/cppTango/files/661494/TestFwd.zip)
