### PR TITLE
Forwarded dynamic attributes

### DIFF
--- a/cppapi/server/fwdattrdesc.cpp
+++ b/cppapi/server/fwdattrdesc.cpp
@@ -182,8 +182,7 @@ bool FwdAttr::validate_fwd_att(vector<AttrProperty> &prop_list,const string &dev
 	catch (...) {}
 
 	//check if full_root_att is already set
-	if (full_root_att.size()!=0 && full_root_att.compare(RootAttNotDef)!=0)
-		is_full_root_att_set = true;
+	is_full_root_att_set = full_root_att.size()!=0 && full_root_att.compare(RootAttNotDef)!=0;
 
 	if(is_full_root_att_set)
 		; // root attribute was defined in constructor: do not overwrite it

--- a/cppapi/server/fwdattrdesc.cpp
+++ b/cppapi/server/fwdattrdesc.cpp
@@ -126,6 +126,7 @@ bool FwdAttr::validate_fwd_att(vector<AttrProperty> &prop_list,const string &dev
 
 	string root_att_db;
 	bool root_att_db_defined = false;
+	bool is_full_root_att_set = false;
 
     Util *tg = Util::instance();
     Database *db = tg->get_database();
@@ -180,7 +181,13 @@ bool FwdAttr::validate_fwd_att(vector<AttrProperty> &prop_list,const string &dev
 	}
 	catch (...) {}
 
-	if (root_att_db_defined == true)
+	//check if full_root_att is already set
+	if (full_root_att.size()!=0 && full_root_att.compare(RootAttNotDef)!=0)
+		is_full_root_att_set = true;
+
+	if(is_full_root_att_set)
+		; // root attribute was defined in constructor: do not overwrite it
+	else if (root_att_db_defined)
 		full_root_att = root_att_db;
     else
         full_root_att = RootAttNotDef;

--- a/cppapi/server/fwdattrdesc.cpp
+++ b/cppapi/server/fwdattrdesc.cpp
@@ -184,12 +184,12 @@ bool FwdAttr::validate_fwd_att(vector<AttrProperty> &prop_list,const string &dev
 	//check if full_root_att is already set
 	is_full_root_att_set = full_root_att.size()!=0 && full_root_att.compare(RootAttNotDef)!=0;
 
-	if(is_full_root_att_set)
-		; // root attribute was defined in constructor: do not overwrite it
-	else if (root_att_db_defined)
-		full_root_att = root_att_db;
-    else
-        full_root_att = RootAttNotDef;
+	if(!is_full_root_att_set) {
+		if (root_att_db_defined)
+			full_root_att = root_att_db;
+		else
+			full_root_att = RootAttNotDef;
+	}
 
 //
 // Check root att syntax and add TANGO_HOST info in root device name of not given

--- a/cppapi/server/multiattribute.cpp
+++ b/cppapi/server/multiattribute.cpp
@@ -884,6 +884,53 @@ void MultiAttribute::add_fwd_attribute(string &dev_name,DeviceClass *dev_class_p
 	add_default(prop_list,dev_name,attr.get_name(),attr.get_type());
 
 //
+// Validate and register the root attribute configuration
+//
+	if (new_attr->is_fwd() == true)
+	{
+		Tango::FwdAttr *fwd_attr = (Tango::FwdAttr *) new_attr;
+		// If forwarded attribute is dynamically created and was constructed without specifying
+		// the root_attribute parameter then we have to get its __root_att property from tango DB
+		// prior to calling validate_fwd_att()
+		vector<AttrProperty> dev_prop;
+		Tango::Util *tg = Tango::Util::instance();
+		if ((tg->_UseDb==true) && (fwd_attr->get_full_root_att()==RootAttNotDef))
+		{
+			Tango::DbData db_list;
+			db_list.push_back(DbDatum(fwd_attr->get_name()));
+			tg->get_database()->get_device_attribute_property(dev_name,db_list,tg->get_db_cache());
+			for (unsigned int ind=0 ; ind<db_list.size() ; ind++)
+			{
+				if (db_list[ind].name == RootAttrPropName)
+				{
+					dev_prop.push_back(AttrProperty(db_list[ind].name, db_list[ind].value_string[0]));
+					break;
+				}
+			}
+		}
+
+		// Validate the __root_att property of the attribute
+		fwd_attr->validate_fwd_att(dev_prop, dev_name);
+
+		// Register the root attribute configuration
+		Tango::DeviceImpl *device = tg->get_device_by_name(dev_name);
+		try
+		{
+			fwd_attr->get_root_conf(dev_name,device);
+		}
+		catch (...)
+		{
+			// If any error add this attribute to the device list of wrong configured attributes
+			DeviceImpl::FwdWrongConf fwc;
+			fwc.att_name = fwd_attr->get_name();
+			fwc.full_root_att_name = fwd_attr->get_full_root_att();
+			fwc.fae = fwd_attr->get_err_kind();
+			vector<DeviceImpl::FwdWrongConf> &fwd_att_wrong_conf = device->get_fwd_att_wrong_conf();
+			fwd_att_wrong_conf.push_back(fwc);
+		}
+	}
+
+//
 // Create an Attribute instance and insert it in the attribute list. If the device implement IDL 3
 // (with state and status as attributes), add it at the end of the list but before state and status.
 //
@@ -914,6 +961,12 @@ void MultiAttribute::add_fwd_attribute(string &dev_name,DeviceClass *dev_class_p
 		if (w_type != Tango::WRITE)
 			alarm_attr_list.push_back(index);
 	}
+
+//
+// Check if the writable_attr_name property is set and in this case, check if the associated attribute exists and is
+// writable
+//
+	check_associated(index,dev_name);
 
 	cout4 << "Leaving MultiAttribute::add_fwd_attribute" << endl;
 }


### PR DESCRIPTION
Hi,

I rebuilt the code of the previous pull request. I hope its cleaner and clearer.
Using branch "tango-9-lts" of github cppTango I noticed that tango doesn't seem to properly manage the creation of forwarded attributes when they are dynamically created. In my opinion, there are 3 different scenarios in which forwarded attributes can be created:

1.- Static creation. This is what pogo does, for example. This seems to already be properly managed.
2.- Dynamic creation with root_attribute specified in constructor. In this case the root attribute used will be the one passed in the constructor (tango DB value, if defined, should be always ignored).
3.- Dynamic creation without root_attribute specified in constructor. In this case the root attribute will be the one defined in tango DB.

In cases 2 and 3 if root attribute is not correctly defined then the device will got to Alarm state and status will give a clue of what is wrong: all dynamic attributes will be created, but the ones with incorrect root attribute definition will throw an exception when read or written.

You can easily test the all above options using the attached TestFwd device server (gziped in "TestFwd.tgz"). You will have to play with their root attribute definition (for example using jive) in order to reproduce all cases mentioned above. If assusmes that "sys/tg_test/1/double_scalar" is available. It defines 3 forwarded attributes:
- TestFwdAttr: this is a static attribute defined using pogo (it can be used for testing case 1 above).
- TestFwdDyn1: this is a dynamic attribute with root attribute defined in the constructor (it can be used for testing case 2 above).
- TestFwdDyn2: this is a dynamic attribute with root attribute not defined in the constructor (it can be used for testing case 3 above).

The patch seems to work fine in my case. I propose to include it into tango-9-lts and master or use it as a first approach for developing a better patch (I'm far from a tango core expert, so I may have introduced other bugs while trying to solve this issue).

NOTE that it also fixes a bug I found when the dynamic forwarded attributes are created (this is last patch for "multiattribute.cpp" file): it looks like the write value is not correctly initialized and you can randomly get a coredump when reading them (you may need to restart the server several times to reproduce the error).

Regards,
Jairo Moldes





[TestFwd.zip](https://github.com/tango-controls/cppTango/files/663910/TestFwd.zip)
