### PR TITLE
resolve #349: add missing event loop implementation in Windows builds

### DIFF
--- a/cppapi/server/utils.h
+++ b/cppapi/server/utils.h
@@ -968,6 +968,7 @@ private:
 	void create_CORBA_objects();
 	void misc_init();
 	void init_host_name();
+	void server_perform_work();
 	void server_already_running();
 	void print_usage(char *);
 	static void print_err_message(const char *,Tango::MessBoxType type = Tango::STOP);


### PR DESCRIPTION
Refactored the while loop that calls orb->perform_work() and the even loop function into a private method called Util::server_perform_work() and added calls to this method in the Windows #ifdef section