### PR TITLE
Fix issues due to Travis CI upgrade to Ubuntu Trusty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,6 @@ env:
 #    - OS_TYPE=win32
 # etc
 
-# Temporary fix to work-around Travis update with Trusty 'sudo:required' environment
-# TODO To be fixed before September 2017
-group: deprecated-2017Q2
-
 notifications:
   email: false
 
@@ -31,7 +27,7 @@ before_script:
   - CONTAINER=$(docker run --name tango_cs -e TANGO_HOST=127.0.0.1:10000 -e MYSQL_HOST=mysql_db:3306 -e MYSQL_USER=tango -e MYSQL_PASSWORD=tango -e MYSQL_DATABASE=tango --link mysql_db:mysql_db -d tangocs/tango-cs:latest)
   - IPADDR=$(docker inspect -f '{{ .NetworkSettings.IPAddress }}' $CONTAINER)
   - TANGO_HOST=${IPADDR}:10000
-  - docker build -t cpp_tango .travis/${OS_TYPE}
+  - docker build --build-arg APP_UID=$(id -u) --build-arg APP_GID=$(id -g) -t cpp_tango .travis/${OS_TYPE}
   - docker run --name cpp_tango -e TANGO_HOST=${TANGO_HOST} --link tango_cs:tango_cs -v `pwd`:/home/tango/src -v `pwd`/idl:/home/tango/idl -dit cpp_tango
 
 script:

--- a/.travis/debian7/Dockerfile
+++ b/.travis/debian7/Dockerfile
@@ -12,9 +12,9 @@ RUN apt-get update && apt-get install -y build-essential cmake
 
 RUN apt-get update && apt-get install -y omniidl libomniorb4-dev libcos4-dev libomnithread3-dev libzmq3-dev
 
-RUN groupadd -g $APP_GID tango
+RUN groupadd -g "$APP_GID" tango
 
-RUN useradd -u $APP_UID -g $APP_GID -ms /bin/bash tango
+RUN useradd -u "$APP_UID" -g "$APP_GID" -ms /bin/bash tango
 
 ENV PKG_CONFIG_PATH=/home/tango/lib/pkgconfig
 

--- a/.travis/debian7/Dockerfile
+++ b/.travis/debian7/Dockerfile
@@ -1,5 +1,9 @@
 FROM debian:wheezy-backports
 
+ARG APP_UID=2000
+
+ARG APP_GID=2000
+
 MAINTAINER TANGO Controls team <tango@esrf.fr>
 
 RUN apt-get update && apt-get install -y apt-utils
@@ -8,7 +12,9 @@ RUN apt-get update && apt-get install -y build-essential cmake
 
 RUN apt-get update && apt-get install -y omniidl libomniorb4-dev libcos4-dev libomnithread3-dev libzmq3-dev
 
-RUN useradd -ms /bin/bash tango
+RUN groupadd -g $APP_GID tango
+
+RUN useradd -u $APP_UID -g $APP_GID -ms /bin/bash tango
 
 ENV PKG_CONFIG_PATH=/home/tango/lib/pkgconfig
 

--- a/.travis/debian8/Dockerfile
+++ b/.travis/debian8/Dockerfile
@@ -12,9 +12,9 @@ RUN apt-get update && apt-get install -y build-essential cmake
 
 RUN apt-get update && apt-get install -y omniidl libomniorb4-dev libcos4-dev libomnithread3-dev libzmq3-dev
 
-RUN groupadd -g $APP_GID tango
+RUN groupadd -g "$APP_GID" tango
 
-RUN useradd -u $APP_UID -g $APP_GID -ms /bin/bash tango
+RUN useradd -u "$APP_UID" -g "$APP_GID" -ms /bin/bash tango
 
 ENV PKG_CONFIG_PATH=/home/tango/lib/pkgconfig
 

--- a/.travis/debian8/Dockerfile
+++ b/.travis/debian8/Dockerfile
@@ -1,5 +1,9 @@
 FROM debian:jessie
 
+ARG APP_UID=2000
+
+ARG APP_GID=2000
+
 MAINTAINER TANGO Controls team <tango@esrf.fr>
 
 RUN apt-get update && apt-get install -y apt-utils
@@ -8,7 +12,9 @@ RUN apt-get update && apt-get install -y build-essential cmake
 
 RUN apt-get update && apt-get install -y omniidl libomniorb4-dev libcos4-dev libomnithread3-dev libzmq3-dev
 
-RUN useradd -ms /bin/bash tango
+RUN groupadd -g $APP_GID tango
+
+RUN useradd -u $APP_UID -g $APP_GID -ms /bin/bash tango
 
 ENV PKG_CONFIG_PATH=/home/tango/lib/pkgconfig
 


### PR DESCRIPTION
Travis CI started to upgrade the default Linux distribution to Ubuntu Trusty as described on 
[Travis CI blog](https://blog.travis-ci.com/2017-07-11-trusty-as-default-linux-is-coming)
Permissions denied errors occurred with Trusty while trying to create
/home/tango/idl/build and /home/tango/src/build directories in the docker
containers.
This error was due to the fact that UID_MIN is now 2000 on Ubuntu.
travis user is now having uid=2000 instead of 1000.
tango user is created with uid=1000 on Debian 8 docker container.
This commit allows creating tango user in the docker container with the same
uid and gid as travis user.