### PR TITLE
Fix warnings reported by gcc 6.3 related to misleading indentations.

### DIFF
--- a/.idea/codeStyleSettings.xml
+++ b/.idea/codeStyleSettings.xml
@@ -62,6 +62,10 @@
           <option name="BINARY_OPERATION_SIGN_ON_NEXT_LINE" value="true" />
           <option name="FOR_STATEMENT_WRAP" value="1" />
           <option name="ASSIGNMENT_WRAP" value="1" />
+          <option name="IF_BRACE_FORCE" value="3" />
+          <option name="DOWHILE_BRACE_FORCE" value="3" />
+          <option name="WHILE_BRACE_FORCE" value="3" />
+          <option name="FOR_BRACE_FORCE" value="3" />
           <indentOptions>
             <option name="CONTINUATION_INDENT_SIZE" value="4" />
           </indentOptions>

--- a/.idea/codeStyleSettings.xml
+++ b/.idea/codeStyleSettings.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectCodeStyleSettingsManager">
+    <option name="PER_PROJECT_SETTINGS">
+      <value>
+        <option name="LINE_SEPARATOR" value="&#10;" />
+        <Objective-C>
+          <option name="INDENT_NAMESPACE_MEMBERS" value="0" />
+          <option name="KEEP_STRUCTURES_IN_ONE_LINE" value="true" />
+          <option name="NAMESPACE_BRACE_PLACEMENT" value="2" />
+          <option name="FUNCTION_BRACE_PLACEMENT" value="2" />
+          <option name="BLOCK_BRACE_PLACEMENT" value="2" />
+          <option name="FUNCTION_PARAMETERS_WRAP" value="5" />
+          <option name="FUNCTION_CALL_ARGUMENTS_WRAP" value="5" />
+          <option name="TEMPLATE_CALL_ARGUMENTS_WRAP" value="5" />
+          <option name="TEMPLATE_CALL_ARGUMENTS_ALIGN_MULTILINE" value="true" />
+          <option name="CLASS_CONSTRUCTOR_INIT_LIST_NEW_LINE_BEFORE_COLON" value="1" />
+          <option name="ALIGN_INIT_LIST_IN_COLUMNS" value="false" />
+          <option name="SPACE_BEFORE_SUPERCLASS_COLON" value="false" />
+        </Objective-C>
+        <Objective-C-extensions>
+          <file>
+            <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Import" />
+            <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Macro" />
+            <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Typedef" />
+            <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Enum" />
+            <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Constant" />
+            <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Global" />
+            <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Struct" />
+            <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="FunctionPredecl" />
+            <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Function" />
+          </file>
+          <class>
+            <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Property" />
+            <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="Synthesize" />
+            <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="InitMethod" />
+            <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="StaticMethod" />
+            <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="InstanceMethod" />
+            <option name="com.jetbrains.cidr.lang.util.OCDeclarationKind" value="DeallocMethod" />
+          </class>
+          <extensions>
+            <pair source="cpp" header="h" />
+            <pair source="c" header="h" />
+          </extensions>
+        </Objective-C-extensions>
+        <codeStyleSettings language="ObjectiveC">
+          <option name="KEEP_BLANK_LINES_IN_DECLARATIONS" value="1" />
+          <option name="KEEP_BLANK_LINES_BEFORE_RBRACE" value="1" />
+          <option name="BLANK_LINES_BEFORE_IMPORTS" value="0" />
+          <option name="BLANK_LINES_AFTER_IMPORTS" value="0" />
+          <option name="BLANK_LINES_AROUND_CLASS" value="0" />
+          <option name="BLANK_LINES_AROUND_FIELD" value="1" />
+          <option name="BLANK_LINES_AROUND_METHOD" value="0" />
+          <option name="BLANK_LINES_AROUND_METHOD_IN_INTERFACE" value="0" />
+          <option name="BRACE_STYLE" value="2" />
+          <option name="CLASS_BRACE_STYLE" value="2" />
+          <option name="ELSE_ON_NEW_LINE" value="true" />
+          <option name="WHILE_ON_NEW_LINE" value="true" />
+          <option name="CATCH_ON_NEW_LINE" value="true" />
+          <option name="ALIGN_MULTILINE_BINARY_OPERATION" value="false" />
+          <option name="METHOD_CALL_CHAIN_WRAP" value="1" />
+          <option name="BINARY_OPERATION_SIGN_ON_NEXT_LINE" value="true" />
+          <option name="FOR_STATEMENT_WRAP" value="1" />
+          <option name="ASSIGNMENT_WRAP" value="1" />
+          <indentOptions>
+            <option name="CONTINUATION_INDENT_SIZE" value="4" />
+          </indentOptions>
+        </codeStyleSettings>
+      </value>
+    </option>
+    <option name="USE_PER_PROJECT_SETTINGS" value="true" />
+  </component>
+</project>

--- a/cpp_test_suite/cxxtest/include/cxxtest/TangoPrinter.h
+++ b/cpp_test_suite/cxxtest/include/cxxtest/TangoPrinter.h
@@ -37,772 +37,814 @@
 // This is a trick to deal with compiler warnings while catching DevFailed multiple times
 // TODO: Remove this code when issue #53 (https://github.com/CxxTest/cxxtest/issues/53) is fixed
 #undef ___TS_ASSERT_THROWS_ASSERT
-#define ___TS_ASSERT_THROWS_ASSERT(f,l,e,t,a,m) { \
-		bool _ts_threw_expected = false, _ts_threw_else = false; \
-		_TS_TRY { _TS_TRY { e; } _TS_CATCH_TYPE( (t), { a; _ts_threw_expected = true; } ) } \
-		_TS_CATCH_ABORT( { throw; } ) \
-		_TS_LAST_CATCH( { _ts_threw_else = true; } ) \
-		if ( !_ts_threw_expected ) { CxxTest::doFailAssertThrows( (f), (l), #e, #t, _ts_threw_else, (m) ); } }
+#define ___TS_ASSERT_THROWS_ASSERT(f, l, e, t, a, m) { \
+        bool _ts_threw_expected = false, _ts_threw_else = false; \
+        _TS_TRY { _TS_TRY { e; } _TS_CATCH_TYPE( (t), { a; _ts_threw_expected = true; } ) } \
+        _TS_CATCH_ABORT( { throw; } ) \
+        _TS_LAST_CATCH( { _ts_threw_else = true; } ) \
+        if ( !_ts_threw_expected ) { CxxTest::doFailAssertThrows( (f), (l), #e, #t, _ts_threw_else, (m) ); } }
 
 namespace CxxTest
 {
-	using namespace std;
+using namespace std;
 
-    class TangoPrinter : public ErrorFormatter
+class TangoPrinter: public ErrorFormatter
+{
+private:
+    /*
+     * command line parameters counter
+     */
+    static int argc;
+    /*
+     * command line parameters array
+     */
+    static char **argv;
+    /*
+     * user arguments counter
+     */
+    static int uargc;
+    /*
+     * vector of user arguments detected automatically from the
+     * command line arguments and interpreted as those which are not declared in
+     * the 'params' map
+     * (example: ./run_tests user_param_1 user_param_2 --loop=10 ==> uargv[0] == "user_param_1"; uargv[1] == "user_param_2")
+     */
+    static vector<string> uargv;
+    /*
+     * parameter arguments counter
+     */
+    static int pargc;
+    /*
+     * map of parameter arguments and their values obtained automatically
+     * from the command line arguments as those declared in the 'params' map
+     * (example: ./run_tests user_param --loop=10 ==> pargv["loop"] == "10")
+     */
+    static map<string, string> pargv;
+    /*
+     * number of times each test with '__loop' suffix is to be executed
+     */
+    static int loop;
+    /*
+     * number of times each suite with '__loop' suffix is to be executed
+     */
+    static int suite_loop;
+    /*
+     * number of times current suite with '__loop' suffix was executed
+     */
+    static int suite_counter;
+    /*
+     * map of predefined parameter names and their declarations (the way of usage in the command line)
+     * (example: params["loop"] = "--loop=" ==> ./run_tests user_param --loop=10)
+     */
+    static map<string, vector<string> > params;
+    /*
+     * executable name
+     */
+    static string executable_name;
+    /*
+     * list of expected user arguments; printed out if provided arguments do not match the expected in quantity
+     */
+    static vector<string> uargs_validate;
+    /*
+     * descriptions of expected user arguments; printed out if provided arguments do not match the expected in quantity
+     */
+    static vector<string> uargs_desc;
+    /*
+     * list of expected mandatory parameters; printed out if provided arguments do not match the expected in quantity
+     */
+    static set<string> params_validate;
+    /*
+     * list of expected optional parameters; printed out if provided arguments do not match the expected in quantity
+     */
+    static set<string> params_opt_validate;
+    /*
+     * list of expected local parameters; printed out if provided arguments do not match the expected in quantity
+     */
+    static map<string, string> params_loc_validate;
+    /*
+     * flag indicating if provided arguments are valid (in terms of quantity)
+     */
+    static bool args_valid;
+    /*
+     * set containing registered names of the methods which are to be called to restore original device settings
+     * in case a test case fails before restoring these settings by itself
+     */
+    static set<string> restore_points;
+
+public:
+    TangoPrinter(CXXTEST_STD(ostream) &o = CXXTEST_STD(cout), const char *preLine = ":", const char *postLine = "")
+        :
+        ErrorFormatter(new Adapter(o), preLine, postLine)
+    {}
+    virtual ~TangoPrinter()
+    { delete outputStream(); }
+
+    /*
+     * Prints out formatted name of each test suite.
+     * Use the following test suite naming convention:
+     * 		MySuiteNameTestSuite
+     * The suffix TestSuite is removed, prefix Testing is prepended
+     * and spaces are added before each capital letter.
+     * As the effect we get:
+     * 		Testing My Suite Name :
+     */
+    void enterSuite(const SuiteDescription &)
     {
-    private:
-    	/*
-    	 * command line parameters counter
-    	 */
-        static int argc;
-        /*
-         * command line parameters array
-         */
-        static char **argv;
-        /*
-         * user arguments counter
-         */
-        static int uargc;
-        /*
-         * vector of user arguments detected automatically from the
-         * command line arguments and interpreted as those which are not declared in
-         * the 'params' map
-         * (example: ./run_tests user_param_1 user_param_2 --loop=10 ==> uargv[0] == "user_param_1"; uargv[1] == "user_param_2")
-         */
-        static vector<string> uargv;
-        /*
-         * parameter arguments counter
-         */
-        static int pargc;
-        /*
-         * map of parameter arguments and their values obtained automatically
-         * from the command line arguments as those declared in the 'params' map
-         * (example: ./run_tests user_param --loop=10 ==> pargv["loop"] == "10")
-         */
-        static map<string,string> pargv;
-        /*
-         * number of times each test with '__loop' suffix is to be executed
-         */
-        static int loop;
-        /*
-         * number of times each suite with '__loop' suffix is to be executed
-         */
-        static int suite_loop;
-        /*
-         * number of times current suite with '__loop' suffix was executed
-         */
-        static int suite_counter;
-        /*
-         * map of predefined parameter names and their declarations (the way of usage in the command line)
-         * (example: params["loop"] = "--loop=" ==> ./run_tests user_param --loop=10)
-         */
-        static map<string,vector<string> > params;
-        /*
-         * executable name
-         */
-        static string executable_name;
-        /*
-         * list of expected user arguments; printed out if provided arguments do not match the expected in quantity
-         */
-        static vector<string> uargs_validate;
-        /*
-         * descriptions of expected user arguments; printed out if provided arguments do not match the expected in quantity
-         */
-        static vector<string> uargs_desc;
-        /*
-         * list of expected mandatory parameters; printed out if provided arguments do not match the expected in quantity
-         */
-        static set<string> params_validate;
-        /*
-         * list of expected optional parameters; printed out if provided arguments do not match the expected in quantity
-         */
-        static set<string> params_opt_validate;
-        /*
-         * list of expected local parameters; printed out if provided arguments do not match the expected in quantity
-         */
-        static map<string,string> params_loc_validate;
-        /*
-         * flag indicating if provided arguments are valid (in terms of quantity)
-         */
-        static bool args_valid;
-        /*
-         * set containing registered names of the methods which are to be called to restore original device settings
-         * in case a test case fails before restoring these settings by itself
-         */
-        static set<string> restore_points;
+        params_opt_validate.clear();
+        params_validate.clear();
+        uargs_validate.clear();
+        uargs_desc.clear();
+        restore_points.clear();
+        args_valid = true;
+        string suite_name = tracker().suite().suiteName();
+        size_t suffix_pos = suite_name.rfind("TestSuite");
+        size_t suite_name_len = suite_name.length();
+        string loop_str = "__loop";
+        size_t loop_str_len = loop_str.length();
+        bool is_suite_loop = suite_name_len >= loop_str_len
+            && suite_name.substr(suite_name_len - loop_str_len, loop_str_len).compare(loop_str) == 0;
 
-    public:
-        TangoPrinter( CXXTEST_STD(ostream) &o = CXXTEST_STD(cout), const char *preLine = ":", const char *postLine = "" ) :
-            ErrorFormatter( new Adapter(o), preLine, postLine ) {}
-        virtual ~TangoPrinter() { delete outputStream(); }
-
-        /*
-         * Prints out formatted name of each test suite.
-         * Use the following test suite naming convention:
-         * 		MySuiteNameTestSuite
-         * The suffix TestSuite is removed, prefix Testing is prepended
-         * and spaces are added before each capital letter.
-         * As the effect we get:
-         * 		Testing My Suite Name :
-         */
-        void enterSuite( const SuiteDescription & )
-		{
-        	params_opt_validate.clear();
-        	params_validate.clear();
-        	uargs_validate.clear();
-        	uargs_desc.clear();
-        	restore_points.clear();
-        	args_valid = true;
-        	string suite_name = tracker().suite().suiteName();
-        	size_t suffix_pos = suite_name.rfind("TestSuite");
-        	size_t suite_name_len = suite_name.length();
-			string loop_str = "__loop";
-			size_t loop_str_len = loop_str.length();
-			bool is_suite_loop = suite_name_len >= loop_str_len && suite_name.substr(suite_name_len - loop_str_len, loop_str_len).compare(loop_str) == 0;
-
-        	if(suffix_pos != string::npos)
-        	{
+        if (suffix_pos != string::npos)
+        {
 //        		suite_name.erase(suffix_pos,9);
-        		suite_name.erase(suffix_pos);
-        	}
-        	for(size_t i = 1; i < suite_name.size(); i++)
-        	{
-        		if(isupper(suite_name[i]) && islower(suite_name[i-1]))
-				{
-        			suite_name.insert(i," ");
-				}
-        	}
-        	if(!is_suite_loop || suite_loop < 2)
-        		cout << "\nTesting " << suite_name << " :\n\n";
-        	else
-        		cout << "\nTesting " << suite_name << ", " << suite_loop << " iterations :\n\n";
-		}
-
-        /*
-         * Checks if a test failed and exits.
-         * If not, checks if the "loop" parameter has been defined
-         * and runs all tests which names end with "__loop"
-         * the number of times indicated by the parameter.
-         */
-        void leaveTest( const TestDescription &test )
+            suite_name.erase(suffix_pos);
+        }
+        for (size_t i = 1; i < suite_name.size(); i++)
         {
-        	static int counter = loop - 1;
-        	if ( tracker().testFailed() )
-        	{
-        		const SuiteDescription &suite_tmp = tracker().suite();
-        		(const_cast<SuiteDescription &>(suite_tmp)).tearDown();
-        		cout <<  "TEST FAILED in:\n" << loop - counter << " iteration of test case\n" << suite_counter << " iteration of test suite\n\n" ;
-        		exit(-1);
-            }
-        	else
-        	{
-        		string test_name = test.testName();
-        		size_t test_name_len = test_name.length();
-        		string loop_str = "__loop";
-        		size_t loop_str_len = loop_str.length();
-        		bool is_loop = false;
-        		if(test_name_len >= loop_str_len)
-        			is_loop = test_name.substr(test_name_len - loop_str_len, loop_str_len).compare(loop_str) == 0;
-        		if(counter > 0 && is_loop)
-        		{
-        			counter--;
-					(const_cast<TestDescription &>(test)).setUp();
-					(const_cast<TestDescription &>(test)).run();
-					(const_cast<TestDescription &>(test)).tearDown();
-					leaveTest(test);
-        		}
-        		else
-        		{
-        			// removes 'test' prefix from the test name
-					if(test_name.find("test_") == 0)
-						test_name.erase(0,5);
-					else if(test_name.find("test") == 0)
-						test_name.erase(0,4);
-
-					// removes the "__loop" suffix from the test name
-					size_t loop_pos = test_name.rfind(loop_str);
-					if(loop_pos != string::npos && loop_pos == test_name.length() - loop_str.length())
-						test_name.erase(loop_pos,loop_str.length());
-
-					// replaces underscores '_' with spaces ' ' in the test name
-					for(size_t i = 0; i < test_name.size(); i++)
-					{
-						if(test_name[i] == '_')
-							test_name[i] = ' ';
-					}
-
-					// prints out the the success notice only after the last iteration
-					// of test case execution in the last iteration of the test suite run
-					string suite_name = tracker().suite().suiteName();
-					size_t suite_name_len = suite_name.length();
-					string loop_str = "__loop";
-					size_t loop_str_len = loop_str.length();
-					bool is_suite_loop = false;
-					if(suite_name_len >= loop_str_len)
-						is_suite_loop = suite_name.substr(suite_name_len - loop_str_len, loop_str_len).compare(loop_str) == 0;
-					if(!is_suite_loop || (is_suite_loop && suite_counter >= suite_loop))
-					{
-						if(!is_loop || loop < 2)
-							cout << "\t" << test_name << " --> OK\n";
-						else
-							cout << "\t" << test_name << ", " << loop << " iterations --> OK\n";
-					}
-
-        			counter = loop - 1;
-        		}
-        	}
-        }
-
-        void leaveSuite( const SuiteDescription &suite )
-        {
-    		string suite_name = suite.suiteName();
-    		size_t suite_name_len = suite_name.length();
-    		string loop_str = "__loop";
-    		size_t loop_str_len = loop_str.length();
-    		if(suite_counter < suite_loop && suite_name_len >= loop_str_len && suite_name.substr(suite_name_len - loop_str_len, loop_str_len).compare(loop_str) == 0) {
-				unsigned int num_tests = (const_cast<SuiteDescription &>(suite)).numTests();
-    			while(suite_counter < suite_loop)
-    			{
-    	        	params_opt_validate.clear();
-    	        	params_validate.clear();
-    	        	uargs_validate.clear();
-    	        	restore_points.clear();
-    	        	args_valid = true;
-    				suite_counter++;
-    				TestDescription *test = (const_cast<SuiteDescription &>(suite)).firstTest();
-					(const_cast<SuiteDescription &>(suite)).setUp();
-					unsigned int test_counter = 0;
-					while(test_counter < num_tests && test != 0)
-					{
-						tracker().enterTest(*test);
-						test->setUp();
-						test->run();
-						leaveTest(*test);
-						test->tearDown();
-						test = test->next();
-						test_counter++;
-					}
-					(const_cast<SuiteDescription &>(suite)).tearDown();
-    			}
-    			suite_counter = 1;
-    		}
-        	cout << "\n";
-        }
-
-        int run( int argc_tmp, char **argv_tmp )
-		{
-        	argc = argc_tmp;
-        	argv = argv_tmp;
-
-        	if(argc >= 1)
-        		executable_name = argv[0];
-
-        	// compares if argument list contains any parameter from predefined list
-        	for(int i = 1; i < argc; i++)
-        	{
-        		string arg_tmp = argv[i];
-        		bool is_param = false;
-
-        		for(map<string,vector<string> >::iterator it = params.begin(); it != params.end(); ++it)
-        		{
-					string param_key = it->first;
-        			string param_value = it->second[0];
-        			string param_desc = it->second[1];
-
-        			int param_value_length = param_value.length();
-        			if(param_value.compare(arg_tmp.substr(0, param_value_length)) == 0)
-        			{
-        				// checks if the parameter has already been used to accept value of only the first occurrence of the parameter
-        				if(pargv.size() > 0 && pargv.find(param_key) != pargv.end())
-        				{
-        					is_param = true;
-							break;
-						}
-        				is_param = true;
-        				pargv[param_key] = arg_tmp.substr(param_value_length, arg_tmp.length() - param_value_length);
-        				pargc = pargv.size();
-        				break;
-        			}
-        		}
-        		if(!is_param)
-        			uargv.push_back(argv[i]);
-        	}
-        	uargc = uargv.size();
-
-        	// prints out the list of all parameters if required by user ("--?" or "--help")
-        	if(TangoPrinter::is_param_set("?") || TangoPrinter::is_param_set("help") || TangoPrinter::is_param_set("-?") || TangoPrinter::is_param_set("-help"))
-        	{
-        		cout << "\nAll parameters:";
-        		for(map<string,vector<string> >::iterator it = TangoPrinter::params.begin(); it != TangoPrinter::params.end(); ++it)
-        		{
-        			cout << "\n\t" << it->second[0] << " - " << it->second[1];
-        		}
-        		cout << "\n";
-        		exit(0);
-        	}
-
-        	// atoi() converts string into integer; if not possible, returns 0
-        	if(is_param_defined("loop"))
-        		loop = atoi(get_param_val("loop").c_str());
-
-        	// atoi() converts string into integer; if not possible, returns 0
-        	if(is_param_defined("suiteloop"))
-        		suite_loop = atoi(get_param_val("suiteloop").c_str());
-
-			TestRunner::runAllTests( *this );
-			return tracker().failedTests();
-		}
-
-        /*
-         * registers a restore point to take up an action in TestSuite tearDown method
-         * in case a test case does not restore the default device properties
-         */
-        static void restore_set(const char* name)
-        {
-        	restore_set(string(name));
-        }
-
-        /*
-         * registers a restore point to take up an action in TestSuite tearDown method
-         * in case a test case does not restore the default device properties
-         */
-        static void restore_set(const string &name)
-        {
-        	restore_points.insert(name);
-        }
-
-        /*
-		 * unregisters the restore point (after the test case had successfully restored the default device properties)
-		 */
-        static void restore_unset(const char* name)
-		{
-			restore_unset(string(name));
-		}
-
-        /*
-		 * unregisters the restore point (after the test case had successfully restored the default device properties)
-         */
-        static void restore_unset(const string &name)
-        {
-        	restore_points.erase(name);
-        }
-
-        /*
-         * checks if the restore point has been registered
-         */
-		static bool is_restore_set(const char* name)
-		{
-		   return is_restore_set(string(name));
-		}
-
-        /*
-         * checks if the restore point has been registered
-         */
-        static bool is_restore_set(const string &name)
-        {
-        	bool result = false;
-        	if(!restore_points.empty())
-        		if(restore_points.find(name) != restore_points.end())
-        			result = true;
-        	return result;
-        }
-
-        static unsigned int get_argc(void)
-        {
-        	return argc;
-        }
-
-        static char **get_argv(void)
-        {
-        	return argv;
-        }
-
-        static vector<string> &get_uargv(void)
-		{
-        	return uargv;
-        }
-
-        static unsigned int get_uargc(void)
-		{
-			return uargc;
-		}
-
-        /*
-         * returns number of predefined parameters used in command line by user
-         */
-        static unsigned int get_pargc(void)
-		{
-			return pargc;
-		}
-
-        /*
-         * checks if parameter of given name was used by user in command line
-         */
-        static bool is_param_set(const string &key)
-        {
-        	if(pargv.size() > 0 && pargv.find(key) != pargv.end())
-				return true;
-			else
-				return false;
-        }
-
-        /*
-         * checks if local parameter of given name was used by user in command line
-         */
-        static bool is_param_loc_set(const string &key)
-        {
-        	string def = "--" + key + "=";
-        	for(vector<string>::iterator it = uargv.begin(); it != uargv.end(); ++it)
-        	{
-        		if(def == (*it).substr(0,def.size()))
-        			return true;
-        	}
-        	return false;
-        }
-
-        /*
-         * returns value of the parameter of given name in the form of string
-         */
-        static string get_param_val(const string &key)
-        {
-        	if(pargv.size() > 0 && pargv.find(key) != pargv.end())
-        		return pargv[key];
-        	else
-        		return "";
-        }
-
-        /*
-         * returns value of the local parameter of given name in the form of string
-         */
-        static string get_param_loc_val(const string &key)
-        {
-        	string def = "--" + key + "=";
-        	for(vector<string>::iterator it = uargv.begin(); it != uargv.end(); ++it)
-        	{
-        		if(def == (*it).substr(0,def.size()))
-        			return (*it).substr(def.size(),(*it).size() - def.size());
-        	}
-        	return "";
-        }
-
-        /*
-         * checks if parameter of given name was defined
-         */
-        static bool is_param_defined(const string &key)
-		{
-			if(params.size() > 0 && params.find(key) != params.end())
-				return true;
-			else
-				return false;
-		}
-
-        /*
-         * returns parameter definition based on it's name
-         */
-        static string get_param_def(const string &key)
-		{
-			if(params.size() > 0 && params.find(key) != params.end())
-				return params[key][0];
-			else
-				return "";
-		}
-
-        /*
-         * returns parameter description based on it's name
-         */
-        static string get_param_desc(const string &def)
-		{
-			if(params.size())// > 0 && params.find(key) != params.end())
-				for(map<string,vector<string> >::iterator it = params.begin(); it != params.end(); ++it)
-					if(it->second[0] == def)
-						return it->second[1];
-			return "";
-		}
-
-        /*
-         * returns local parameter description based on it's name
-         */
-        static string get_param_loc_desc(const string &param)
-		{
-			if(params_loc_validate.size())
-			{
-				map<string,string>::iterator it = params_loc_validate.find(param);
-				if(it != params_loc_validate.end())
-					return it->second;
-			}
-			return "";
-		}
-
-        /*
-         * returns user argument description based on it's name
-         */
-        static string get_uarg_desc(const string &uarg)
-		{
-			if(uargs_validate.size() && uargs_validate.size() == uargs_desc.size())// > 0 && params.find(key) != params.end())
-				for(size_t i = 0; i < uargs_validate.size(); i++)
-					if(uargs_validate[i] == uarg)
-						return uargs_desc[i];
-			return "";
-		}
-
-        static map<string,vector<string> > &get_params(void)
-		{
-			return params;
-		}
-
-        static string &get_executable_name(void)
-        {
-        	return executable_name;
-        }
-
-
-        /*
-         * registers user argument on the list, returns its value (if set) or empty string
-         */
-        static string get_uarg(const string &uarg)
-        {
-        	string desc = "user defined argument";
-        	return get_uarg(uarg,desc);
-        }
-
-        /*
-         * registers user argument and its description on the list, returns its value (if set) or empty string
-         */
-        static string get_uarg(const string &uarg, const string &desc)
-        {
-        	string uarg_val = "";
-        	uargs_validate.push_back(uarg);
-        	uargs_desc.push_back(desc);
-        	if(get_uargc() >= uargs_validate.size())
-        		uarg_val = get_uargv()[uargs_validate.size()-1];
-        	else
-        		args_valid = false;
-        	return uarg_val;
-        }
-
-        /*
-         * registers description of mandatory parameter on the list, returns its value (if set) or empty string
-         */
-        static string get_param(const string &param)
-        {
-        	string param_val = "";
-        	if(is_param_defined(param))
-        	{
-				params_validate.insert(get_param_def(param));
-				if(!is_param_set(param))
-					args_valid = false;
-				param_val = get_param_val(param);
-        	}
-        	return param_val;
-        }
-
-        /*
-         * registers description of optional parameter on the list, returns its value (if set) or empty string
-         */
-        static string get_param_opt(const string &param)
-        {
-        	string param_val = "";
-        	if(is_param_defined(param))
-        	{
-				params_opt_validate.insert(get_param_def(param));
-				param_val = get_param_val(param);
-        	}
-        	return param_val;
-        }
-
-
-        /*
-         * registers description of optional parameter on the list, returns its value (if set) or empty string
-         */
-        static string get_param_loc(const string &param)
-        {
-        	string desc = "user defined parameter";
-        	return get_param_loc(param,desc);
-        }
-
-        /*
-         * registers description of optional parameter on the list, returns its value (if set) or empty string
-         */
-        static string get_param_loc(const string &param, const string &desc)
-        {
-        	string param_val = "";
-        	if(!is_param_defined(param))
-        	{
-				params_loc_validate["--" + param + "="] = desc;
-				if(!is_param_loc_set(param))
-					args_valid = false;
-				param_val = get_param_loc_val(param);
-        	}
-        	else
-        	{
-        		// the parameter has already been defined as mandatory
-        		cout << "Parameter '" << param << "' is one of the predefined parameters.\nUse CxxTest::TangoPrinter::get_param(\"" << param << "\") method instead.\n";
-        		exit(-1);
-        	}
-        	return param_val;
-        }
-
-        /*
-         * registers description of optional parameter on the list, returns true if parameter has been set
-         * (useful when no value for parameter is expected e.g. "--v")
-         */
-        static bool is_param_opt_set(const string &param)
-        {
-        	bool param_opt_set = false;
-        	if(is_param_defined(param))
-        	{
-				params_opt_validate.insert(get_param_def(param));
-				if(is_param_set(param))
-					param_opt_set = true;
-        	}
-        	return param_opt_set;
-        }
-
-        /*
-         * checks if all required arguments have been properly set, if not prints out usage hint and terminates
-         */
-        static void validate_args()
-        {
-        	if(!args_valid)
-        	{
-    			cout << "Usage: " << get_executable_name();
-
-    			for(size_t i = 0; i < uargs_validate.size(); i++)
-    				cout << " " << uargs_validate[i];
-
-    			for(map<string,string>::iterator it = params_loc_validate.begin(); it != params_loc_validate.end(); ++it)
-    				cout << " " << it->first;
-
-    			for(set<string>::iterator it = params_validate.begin(); it != params_validate.end(); ++it)
-    				cout << " " << *it;
-
-    			for(set<string>::iterator it = params_opt_validate.begin(); it != params_opt_validate.end(); ++it)
-    				cout << " [" << *it << "]";
-
-    			if(uargs_validate.size() != 0)
-    			{
-					cout << "\nExplanation:";
-    				if(uargs_validate.size() != 0 && uargs_validate.size() == uargs_desc.size())
-    				{
-						cout << "\nUser arguments:";
-            			for(size_t i = 0; i < uargs_validate.size(); i++)
-            				cout << "\n\t" << uargs_validate[i] << " - " << uargs_desc[i];
-    				}
-    			}
-
-    			if(params_validate.size() != 0 || params_opt_validate.size() != 0 || params_loc_validate.size() != 0)
-    			{
-    				cout << "\nParameters:";
-    				if(params_loc_validate.size() != 0)
-    				{
-    					cout << "\nLocal:";
-            			for(map<string,string>::iterator it = params_loc_validate.begin(); it != params_loc_validate.end(); ++it)
-            				cout << "\n\t" << it->first << " - " << get_param_loc_desc(it->first);
-    				}
-
-    				if(params_validate.size() != 0)
-    				{
-    					cout << "\nMandatory:";
-            			for(set<string>::iterator it = params_validate.begin(); it != params_validate.end(); ++it)
-            				cout << "\n\t" << *it << " - " << get_param_desc(*it);
-    				}
-
-    				if(params_opt_validate.size() != 0)
-    				{
-    					cout << "\nOptional:";
-            			for(set<string>::iterator it = params_opt_validate.begin(); it != params_opt_validate.end(); ++it)
-            				cout << "\n\t" << *it << " - " << get_param_desc(*it);
-    				}
-    			}
-
-    			cout  << "\n";
-    			exit(-1);
-        	}
-        }
-
-
-        /*
-         * helper function to create a vector containing a parameter description
-         */
-        static vector<string> param_desc(string param, string desc)
-    	{
-        	vector<string> param_desc_tmp;
-        	param_desc_tmp.push_back(param);
-        	param_desc_tmp.push_back(desc);
-        	return param_desc_tmp;
-    	}
-
-        /*
-         * declare predefined parameters here
-         */
-        static map<string,vector<string> > create_params()
-		{
-        	map<string,vector<string> > params_tmp;
-        	params_tmp["?"] = param_desc("--?", "help, lists all possible parameters");
-        	params_tmp["-?"] = param_desc("-?", "help, lists all possible parameters");
-        	params_tmp["help"] = param_desc("--help", "help, lists all possible parameters");
-        	params_tmp["-help"] = param_desc("-help", "help, lists all possible parameters");
-        	params_tmp["verbose"] = param_desc("--v", "verbose mode");
-        	params_tmp["loop"] = param_desc("--loop=","execute test cases marked with '__loop' suffix the indicated number of times");
-        	params_tmp["suiteloop"] = param_desc("--suiteloop=", "execute test suites marked with '__loop' suffix the indicated number of times"); // executes suite in a loop
-        	params_tmp["device1"] = param_desc("--device1=", "device1 name, e.g. test/device/1");
-        	params_tmp["device2"] = param_desc("--device2=", "device2 name, e.g. test/device/2");
-        	params_tmp["device3"] = param_desc("--device3=", "device3 name, e.g. test/device/3");
-        	params_tmp["fulldsname"] = param_desc("--fulldsname=", "full device server name, e.g. devTest/myserver");
-        	params_tmp["clienthost"] = param_desc("--clienthost=", "client host's fully qualified domain name, e.g. mypc.myinstitute.com (small caps)");
-        	params_tmp["serverhost"] = param_desc("--serverhost=", "fully qualified domain name of the host on which the server is running, e.g. myserver.myinstitute.com (small caps)");
-        	params_tmp["serverversion"] = param_desc("--serverversion=", "IDL version, e.g. 4");
-        	params_tmp["dbserver"] = param_desc("--dbserver=", "database server name, e.g. sys/database/2");
-        	params_tmp["loglevel"] = param_desc("--loglevel=", "default device logging level, e.g. 0"); // default device logging level, e.g. 0
-        	params_tmp["dsloglevel"] = param_desc("--dsloglevel=", "default device server logging level, e.g. 3"); // default device server logging level, e.g. 3
-        	params_tmp["devtype"] = param_desc("--devtype=", "device type, e.g. TestDevice");
-        	params_tmp["docurl"] = param_desc("--docurl=", "current documentation URL, e.g. http://www.tango-controls.org");
-        	params_tmp["outpath"] = param_desc("--outpath=", "device server logging target directory, e.g. /tmp/"); // device server logging target directory, e.g. /tmp/
-        	params_tmp["refpath"] = param_desc("--refpath=", "directory where the 'compare test' reference files (*.out) are stored"); // directory where the compare test reference files (*.out) are stored
-        	params_tmp["devicealias"] = param_desc("--devicealias=", "device1 alias"); // device1 alias
-        	params_tmp["attributealias"] = param_desc("--attributealias=", "Short_attr alias"); // Short_attr alias
-        	return params_tmp;
-        }
-
-    private:
-        class Adapter : public OutputStream
-        {
-            CXXTEST_STD(ostream) &_o;
-        public:
-            Adapter( CXXTEST_STD(ostream) &o ) : _o(o) {}
-            void flush() { _o.flush(); }
-            OutputStream &operator<<( const char *s ) { _o << s; return *this; }
-            OutputStream &operator<<( Manipulator m ) { return OutputStream::operator<<( m ); }
-            OutputStream &operator<<( unsigned i )
+            if (isupper(suite_name[i]) && islower(suite_name[i - 1]))
             {
-                char s[1 + 3 * sizeof(unsigned)];
-                numberToString( i, s );
-                _o << s;
-                return *this;
+                suite_name.insert(i, " ");
             }
-        };
+        }
+        if (!is_suite_loop || suite_loop < 2)
+            cout << "\nTesting " << suite_name << " :\n\n";
+        else
+            cout << "\nTesting " << suite_name << ", " << suite_loop << " iterations :\n\n";
+    }
+
+    /*
+     * Checks if a test failed and exits.
+     * If not, checks if the "loop" parameter has been defined
+     * and runs all tests which names end with "__loop"
+     * the number of times indicated by the parameter.
+     */
+    void leaveTest(const TestDescription &test)
+    {
+        static int counter = loop - 1;
+        if (tracker().testFailed())
+        {
+            const SuiteDescription &suite_tmp = tracker().suite();
+            (const_cast<SuiteDescription &>(suite_tmp)).tearDown();
+            cout << "TEST FAILED in:\n" << loop - counter << " iteration of test case\n" << suite_counter
+                 << " iteration of test suite\n\n";
+            exit(-1);
+        }
+        else
+        {
+            string test_name = test.testName();
+            size_t test_name_len = test_name.length();
+            string loop_str = "__loop";
+            size_t loop_str_len = loop_str.length();
+            bool is_loop = false;
+            if (test_name_len >= loop_str_len)
+                is_loop = test_name.substr(test_name_len - loop_str_len, loop_str_len).compare(loop_str) == 0;
+            if (counter > 0 && is_loop)
+            {
+                counter--;
+                (const_cast<TestDescription &>(test)).setUp();
+                (const_cast<TestDescription &>(test)).run();
+                (const_cast<TestDescription &>(test)).tearDown();
+                leaveTest(test);
+            }
+            else
+            {
+                // removes 'test' prefix from the test name
+                if (test_name.find("test_") == 0)
+                    test_name.erase(0, 5);
+                else if (test_name.find("test") == 0)
+                    test_name.erase(0, 4);
+
+                // removes the "__loop" suffix from the test name
+                size_t loop_pos = test_name.rfind(loop_str);
+                if (loop_pos != string::npos && loop_pos == test_name.length() - loop_str.length())
+                    test_name.erase(loop_pos, loop_str.length());
+
+                // replaces underscores '_' with spaces ' ' in the test name
+                for (size_t i = 0; i < test_name.size(); i++)
+                {
+                    if (test_name[i] == '_')
+                        test_name[i] = ' ';
+                }
+
+                // prints out the the success notice only after the last iteration
+                // of test case execution in the last iteration of the test suite run
+                string suite_name = tracker().suite().suiteName();
+                size_t suite_name_len = suite_name.length();
+                string loop_str = "__loop";
+                size_t loop_str_len = loop_str.length();
+                bool is_suite_loop = false;
+                if (suite_name_len >= loop_str_len)
+                    is_suite_loop =
+                        suite_name.substr(suite_name_len - loop_str_len, loop_str_len).compare(loop_str) == 0;
+                if (!is_suite_loop || (is_suite_loop && suite_counter >= suite_loop))
+                {
+                    if (!is_loop || loop < 2)
+                        cout << "\t" << test_name << " --> OK\n";
+                    else
+                        cout << "\t" << test_name << ", " << loop << " iterations --> OK\n";
+                }
+
+                counter = loop - 1;
+            }
+        }
+    }
+
+    void leaveSuite(const SuiteDescription &suite)
+    {
+        string suite_name = suite.suiteName();
+        size_t suite_name_len = suite_name.length();
+        string loop_str = "__loop";
+        size_t loop_str_len = loop_str.length();
+        if (suite_counter < suite_loop && suite_name_len >= loop_str_len
+            && suite_name.substr(suite_name_len - loop_str_len, loop_str_len).compare(loop_str) == 0)
+        {
+            unsigned int num_tests = (const_cast<SuiteDescription &>(suite)).numTests();
+            while (suite_counter < suite_loop)
+            {
+                params_opt_validate.clear();
+                params_validate.clear();
+                uargs_validate.clear();
+                restore_points.clear();
+                args_valid = true;
+                suite_counter++;
+                TestDescription *test = (const_cast<SuiteDescription &>(suite)).firstTest();
+                (const_cast<SuiteDescription &>(suite)).setUp();
+                unsigned int test_counter = 0;
+                while (test_counter < num_tests && test != 0)
+                {
+                    tracker().enterTest(*test);
+                    test->setUp();
+                    test->run();
+                    leaveTest(*test);
+                    test->tearDown();
+                    test = test->next();
+                    test_counter++;
+                }
+                (const_cast<SuiteDescription &>(suite)).tearDown();
+            }
+            suite_counter = 1;
+        }
+        cout << "\n";
+    }
+
+    int run(int argc_tmp, char **argv_tmp)
+    {
+        argc = argc_tmp;
+        argv = argv_tmp;
+
+        if (argc >= 1)
+            executable_name = argv[0];
+
+        // compares if argument list contains any parameter from predefined list
+        for (int i = 1; i < argc; i++)
+        {
+            string arg_tmp = argv[i];
+            bool is_param = false;
+
+            for (map<string, vector<string> >::iterator it = params.begin(); it != params.end(); ++it)
+            {
+                string param_key = it->first;
+                string param_value = it->second[0];
+                string param_desc = it->second[1];
+
+                int param_value_length = param_value.length();
+                if (param_value.compare(arg_tmp.substr(0, param_value_length)) == 0)
+                {
+                    // checks if the parameter has already been used to accept value of only the first occurrence of the parameter
+                    if (pargv.size() > 0 && pargv.find(param_key) != pargv.end())
+                    {
+                        is_param = true;
+                        break;
+                    }
+                    is_param = true;
+                    pargv[param_key] = arg_tmp.substr(param_value_length, arg_tmp.length() - param_value_length);
+                    pargc = pargv.size();
+                    break;
+                }
+            }
+            if (!is_param)
+                uargv.push_back(argv[i]);
+        }
+        uargc = uargv.size();
+
+        // prints out the list of all parameters if required by user ("--?" or "--help")
+        if (TangoPrinter::is_param_set("?") || TangoPrinter::is_param_set("help") || TangoPrinter::is_param_set("-?")
+            || TangoPrinter::is_param_set("-help"))
+        {
+            cout << "\nAll parameters:";
+            for (map<string, vector<string> >::iterator it = TangoPrinter::params.begin();
+                 it != TangoPrinter::params.end(); ++it)
+            {
+                cout << "\n\t" << it->second[0] << " - " << it->second[1];
+            }
+            cout << "\n";
+            exit(0);
+        }
+
+        // atoi() converts string into integer; if not possible, returns 0
+        if (is_param_defined("loop"))
+            loop = atoi(get_param_val("loop").c_str());
+
+        // atoi() converts string into integer; if not possible, returns 0
+        if (is_param_defined("suiteloop"))
+            suite_loop = atoi(get_param_val("suiteloop").c_str());
+
+        TestRunner::runAllTests(*this);
+        return tracker().failedTests();
+    }
+
+    /*
+     * registers a restore point to take up an action in TestSuite tearDown method
+     * in case a test case does not restore the default device properties
+     */
+    static void restore_set(const char *name)
+    {
+        restore_set(string(name));
+    }
+
+    /*
+     * registers a restore point to take up an action in TestSuite tearDown method
+     * in case a test case does not restore the default device properties
+     */
+    static void restore_set(const string &name)
+    {
+        restore_points.insert(name);
+    }
+
+    /*
+     * unregisters the restore point (after the test case had successfully restored the default device properties)
+     */
+    static void restore_unset(const char *name)
+    {
+        restore_unset(string(name));
+    }
+
+    /*
+     * unregisters the restore point (after the test case had successfully restored the default device properties)
+     */
+    static void restore_unset(const string &name)
+    {
+        restore_points.erase(name);
+    }
+
+    /*
+     * checks if the restore point has been registered
+     */
+    static bool is_restore_set(const char *name)
+    {
+        return is_restore_set(string(name));
+    }
+
+    /*
+     * checks if the restore point has been registered
+     */
+    static bool is_restore_set(const string &name)
+    {
+        bool result = false;
+        if (!restore_points.empty())
+            if (restore_points.find(name) != restore_points.end())
+                result = true;
+        return result;
+    }
+
+    static unsigned int get_argc(void)
+    {
+        return argc;
+    }
+
+    static char **get_argv(void)
+    {
+        return argv;
+    }
+
+    static vector<string> &get_uargv(void)
+    {
+        return uargv;
+    }
+
+    static unsigned int get_uargc(void)
+    {
+        return uargc;
+    }
+
+    /*
+     * returns number of predefined parameters used in command line by user
+     */
+    static unsigned int get_pargc(void)
+    {
+        return pargc;
+    }
+
+    /*
+     * checks if parameter of given name was used by user in command line
+     */
+    static bool is_param_set(const string &key)
+    {
+        if (pargv.size() > 0 && pargv.find(key) != pargv.end())
+            return true;
+        else
+            return false;
+    }
+
+    /*
+     * checks if local parameter of given name was used by user in command line
+     */
+    static bool is_param_loc_set(const string &key)
+    {
+        string def = "--" + key + "=";
+        for (vector<string>::iterator it = uargv.begin(); it != uargv.end(); ++it)
+        {
+            if (def == (*it).substr(0, def.size()))
+                return true;
+        }
+        return false;
+    }
+
+    /*
+     * returns value of the parameter of given name in the form of string
+     */
+    static string get_param_val(const string &key)
+    {
+        if (pargv.size() > 0 && pargv.find(key) != pargv.end())
+            return pargv[key];
+        else
+            return "";
+    }
+
+    /*
+     * returns value of the local parameter of given name in the form of string
+     */
+    static string get_param_loc_val(const string &key)
+    {
+        string def = "--" + key + "=";
+        for (vector<string>::iterator it = uargv.begin(); it != uargv.end(); ++it)
+        {
+            if (def == (*it).substr(0, def.size()))
+                return (*it).substr(def.size(), (*it).size() - def.size());
+        }
+        return "";
+    }
+
+    /*
+     * checks if parameter of given name was defined
+     */
+    static bool is_param_defined(const string &key)
+    {
+        if (params.size() > 0 && params.find(key) != params.end())
+            return true;
+        else
+            return false;
+    }
+
+    /*
+     * returns parameter definition based on it's name
+     */
+    static string get_param_def(const string &key)
+    {
+        if (params.size() > 0 && params.find(key) != params.end())
+            return params[key][0];
+        else
+            return "";
+    }
+
+    /*
+     * returns parameter description based on it's name
+     */
+    static string get_param_desc(const string &def)
+    {
+        if (params.size())// > 0 && params.find(key) != params.end())
+            for (map<string, vector<string> >::iterator it = params.begin(); it != params.end(); ++it)
+                if (it->second[0] == def)
+                    return it->second[1];
+        return "";
+    }
+
+    /*
+     * returns local parameter description based on it's name
+     */
+    static string get_param_loc_desc(const string &param)
+    {
+        if (params_loc_validate.size())
+        {
+            map<string, string>::iterator it = params_loc_validate.find(param);
+            if (it != params_loc_validate.end())
+                return it->second;
+        }
+        return "";
+    }
+
+    /*
+     * returns user argument description based on it's name
+     */
+    static string get_uarg_desc(const string &uarg)
+    {
+        if (uargs_validate.size()
+            && uargs_validate.size() == uargs_desc.size())// > 0 && params.find(key) != params.end())
+            for (size_t i = 0; i < uargs_validate.size(); i++)
+                if (uargs_validate[i] == uarg)
+                    return uargs_desc[i];
+        return "";
+    }
+
+    static map<string, vector<string> > &get_params(void)
+    {
+        return params;
+    }
+
+    static string &get_executable_name(void)
+    {
+        return executable_name;
+    }
+
+    /*
+     * registers user argument on the list, returns its value (if set) or empty string
+     */
+    static string get_uarg(const string &uarg)
+    {
+        string desc = "user defined argument";
+        return get_uarg(uarg, desc);
+    }
+
+    /*
+     * registers user argument and its description on the list, returns its value (if set) or empty string
+     */
+    static string get_uarg(const string &uarg, const string &desc)
+    {
+        string uarg_val = "";
+        uargs_validate.push_back(uarg);
+        uargs_desc.push_back(desc);
+        if (get_uargc() >= uargs_validate.size())
+            uarg_val = get_uargv()[uargs_validate.size() - 1];
+        else
+            args_valid = false;
+        return uarg_val;
+    }
+
+    /*
+     * registers description of mandatory parameter on the list, returns its value (if set) or empty string
+     */
+    static string get_param(const string &param)
+    {
+        string param_val = "";
+        if (is_param_defined(param))
+        {
+            params_validate.insert(get_param_def(param));
+            if (!is_param_set(param))
+                args_valid = false;
+            param_val = get_param_val(param);
+        }
+        return param_val;
+    }
+
+    /*
+     * registers description of optional parameter on the list, returns its value (if set) or empty string
+     */
+    static string get_param_opt(const string &param)
+    {
+        string param_val = "";
+        if (is_param_defined(param))
+        {
+            params_opt_validate.insert(get_param_def(param));
+            param_val = get_param_val(param);
+        }
+        return param_val;
+    }
+
+    /*
+     * registers description of optional parameter on the list, returns its value (if set) or empty string
+     */
+    static string get_param_loc(const string &param)
+    {
+        string desc = "user defined parameter";
+        return get_param_loc(param, desc);
+    }
+
+    /*
+     * registers description of optional parameter on the list, returns its value (if set) or empty string
+     */
+    static string get_param_loc(const string &param, const string &desc)
+    {
+        string param_val = "";
+        if (!is_param_defined(param))
+        {
+            params_loc_validate["--" + param + "="] = desc;
+            if (!is_param_loc_set(param))
+                args_valid = false;
+            param_val = get_param_loc_val(param);
+        }
+        else
+        {
+            // the parameter has already been defined as mandatory
+            cout << "Parameter '" << param
+                 << "' is one of the predefined parameters.\nUse CxxTest::TangoPrinter::get_param(\"" << param
+                 << "\") method instead.\n";
+            exit(-1);
+        }
+        return param_val;
+    }
+
+    /*
+     * registers description of optional parameter on the list, returns true if parameter has been set
+     * (useful when no value for parameter is expected e.g. "--v")
+     */
+    static bool is_param_opt_set(const string &param)
+    {
+        bool param_opt_set = false;
+        if (is_param_defined(param))
+        {
+            params_opt_validate.insert(get_param_def(param));
+            if (is_param_set(param))
+                param_opt_set = true;
+        }
+        return param_opt_set;
+    }
+
+    /*
+     * checks if all required arguments have been properly set, if not prints out usage hint and terminates
+     */
+    static void validate_args()
+    {
+        if (!args_valid)
+        {
+            cout << "Usage: " << get_executable_name();
+
+            for (size_t i = 0; i < uargs_validate.size(); i++)
+                cout << " " << uargs_validate[i];
+
+            for (map<string, string>::iterator it = params_loc_validate.begin(); it != params_loc_validate.end(); ++it)
+                cout << " " << it->first;
+
+            for (set<string>::iterator it = params_validate.begin(); it != params_validate.end(); ++it)
+                cout << " " << *it;
+
+            for (set<string>::iterator it = params_opt_validate.begin(); it != params_opt_validate.end(); ++it)
+                cout << " [" << *it << "]";
+
+            if (uargs_validate.size() != 0)
+            {
+                cout << "\nExplanation:";
+                if (uargs_validate.size() != 0 && uargs_validate.size() == uargs_desc.size())
+                {
+                    cout << "\nUser arguments:";
+                    for (size_t i = 0; i < uargs_validate.size(); i++)
+                        cout << "\n\t" << uargs_validate[i] << " - " << uargs_desc[i];
+                }
+            }
+
+            if (params_validate.size() != 0 || params_opt_validate.size() != 0 || params_loc_validate.size() != 0)
+            {
+                cout << "\nParameters:";
+                if (params_loc_validate.size() != 0)
+                {
+                    cout << "\nLocal:";
+                    for (map<string, string>::iterator it = params_loc_validate.begin();
+                         it != params_loc_validate.end(); ++it)
+                        cout << "\n\t" << it->first << " - " << get_param_loc_desc(it->first);
+                }
+
+                if (params_validate.size() != 0)
+                {
+                    cout << "\nMandatory:";
+                    for (set<string>::iterator it = params_validate.begin(); it != params_validate.end(); ++it)
+                        cout << "\n\t" << *it << " - " << get_param_desc(*it);
+                }
+
+                if (params_opt_validate.size() != 0)
+                {
+                    cout << "\nOptional:";
+                    for (set<string>::iterator it = params_opt_validate.begin(); it != params_opt_validate.end(); ++it)
+                        cout << "\n\t" << *it << " - " << get_param_desc(*it);
+                }
+            }
+
+            cout << "\n";
+            exit(-1);
+        }
+    }
+
+    /*
+     * helper function to create a vector containing a parameter description
+     */
+    static vector<string> param_desc(string param, string desc)
+    {
+        vector<string> param_desc_tmp;
+        param_desc_tmp.push_back(param);
+        param_desc_tmp.push_back(desc);
+        return param_desc_tmp;
+    }
+
+    /*
+     * declare predefined parameters here
+     */
+    static map<string, vector<string> > create_params()
+    {
+        map<string, vector<string> > params_tmp;
+        params_tmp["?"] = param_desc("--?", "help, lists all possible parameters");
+        params_tmp["-?"] = param_desc("-?", "help, lists all possible parameters");
+        params_tmp["help"] = param_desc("--help", "help, lists all possible parameters");
+        params_tmp["-help"] = param_desc("-help", "help, lists all possible parameters");
+        params_tmp["verbose"] = param_desc("--v", "verbose mode");
+        params_tmp["loop"] =
+            param_desc("--loop=", "execute test cases marked with '__loop' suffix the indicated number of times");
+        params_tmp["suiteloop"] = param_desc("--suiteloop=",
+                                             "execute test suites marked with '__loop' suffix the indicated number of times"); // executes suite in a loop
+        params_tmp["device1"] = param_desc("--device1=", "device1 name, e.g. test/device/1");
+        params_tmp["device2"] = param_desc("--device2=", "device2 name, e.g. test/device/2");
+        params_tmp["device3"] = param_desc("--device3=", "device3 name, e.g. test/device/3");
+        params_tmp["fulldsname"] = param_desc("--fulldsname=", "full device server name, e.g. devTest/myserver");
+        params_tmp["clienthost"] = param_desc("--clienthost=",
+                                              "client host's fully qualified domain name, e.g. mypc.myinstitute.com (small caps)");
+        params_tmp["serverhost"] = param_desc("--serverhost=",
+                                              "fully qualified domain name of the host on which the server is running, e.g. myserver.myinstitute.com (small caps)");
+        params_tmp["serverversion"] = param_desc("--serverversion=", "IDL version, e.g. 4");
+        params_tmp["dbserver"] = param_desc("--dbserver=", "database server name, e.g. sys/database/2");
+        params_tmp["loglevel"] =
+            param_desc("--loglevel=", "default device logging level, e.g. 0"); // default device logging level, e.g. 0
+        params_tmp["dsloglevel"] = param_desc("--dsloglevel=",
+                                              "default device server logging level, e.g. 3"); // default device server logging level, e.g. 3
+        params_tmp["devtype"] = param_desc("--devtype=", "device type, e.g. TestDevice");
+        params_tmp["docurl"] = param_desc("--docurl=", "current documentation URL, e.g. http://www.tango-controls.org");
+        params_tmp["outpath"] = param_desc("--outpath=",
+                                           "device server logging target directory, e.g. /tmp/"); // device server logging target directory, e.g. /tmp/
+        params_tmp["refpath"] = param_desc("--refpath=",
+                                           "directory where the 'compare test' reference files (*.out) are stored"); // directory where the compare test reference files (*.out) are stored
+        params_tmp["devicealias"] = param_desc("--devicealias=", "device1 alias"); // device1 alias
+        params_tmp["attributealias"] = param_desc("--attributealias=", "Short_attr alias"); // Short_attr alias
+        return params_tmp;
+    }
+
+private:
+    class Adapter: public OutputStream
+    {
+        CXXTEST_STD(ostream) &_o;
+    public:
+        Adapter(CXXTEST_STD(ostream) &o)
+            : _o(o)
+        {}
+        void flush()
+        { _o.flush(); }
+        OutputStream &operator<<(const char *s)
+        {
+            _o << s;
+            return *this;
+        }
+        OutputStream &operator<<(Manipulator m)
+        { return OutputStream::operator<<(m); }
+        OutputStream &operator<<(unsigned i)
+        {
+            char s[1 + 3 * sizeof(unsigned)];
+            numberToString(i, s);
+            _o << s;
+            return *this;
+        }
     };
+};
 
-    int TangoPrinter::argc = 0;
-    char **TangoPrinter::argv = 0;
-    int TangoPrinter::uargc = 0;
-	vector<string> TangoPrinter::uargv;
-    int TangoPrinter::pargc = 0;
-	map<string,string> TangoPrinter::pargv;
-    int TangoPrinter::loop = 0;
-    map<string,vector<string> > TangoPrinter::params = TangoPrinter::create_params();
-    string TangoPrinter::executable_name = "";
-    int TangoPrinter::suite_loop = 0;
-    int TangoPrinter::suite_counter = 1;
+int TangoPrinter::argc = 0;
 
-    vector<string> TangoPrinter::uargs_validate;
-    vector<string> TangoPrinter::uargs_desc;
-    set<string> TangoPrinter::params_validate;
-    set<string> TangoPrinter::params_opt_validate;
-    map<string,string> TangoPrinter::params_loc_validate;
-    bool TangoPrinter::args_valid = true;
+char **TangoPrinter::argv = 0;
 
-    set<string> TangoPrinter::restore_points = set<string>();
+int TangoPrinter::uargc = 0;
+
+vector<string> TangoPrinter::uargv;
+
+int TangoPrinter::pargc = 0;
+
+map<string, string> TangoPrinter::pargv;
+
+int TangoPrinter::loop = 0;
+
+map<string, vector<string> > TangoPrinter::params = TangoPrinter::create_params();
+
+string TangoPrinter::executable_name = "";
+
+int TangoPrinter::suite_loop = 0;
+
+int TangoPrinter::suite_counter = 1;
+
+vector<string> TangoPrinter::uargs_validate;
+
+vector<string> TangoPrinter::uargs_desc;
+
+set<string> TangoPrinter::params_validate;
+
+set<string> TangoPrinter::params_opt_validate;
+
+map<string, string> TangoPrinter::params_loc_validate;
+
+bool TangoPrinter::args_valid = true;
+
+set<string> TangoPrinter::restore_points = set<string>();
 }
 
 #endif // __cxxtest__TangoPrinter_h__

--- a/cpp_test_suite/event/event_lock.cpp
+++ b/cpp_test_suite/event/event_lock.cpp
@@ -23,7 +23,7 @@ const int NODATA = -9999;
 class EventCallback: public Tango::CallBack
 {
 public:
-    EventCallback()
+    EventCallback(): cb_executed(0),cb_err(0)
     {};
     ~EventCallback()
     {};
@@ -51,8 +51,6 @@ int main(int argc, char *argv[])
     int eventID;
     const vector<string> filters;
     EventCallback *eventCallback = new EventCallback();
-    eventCallback->cb_executed = 0;
-    eventCallback->cb_err = 0;
 
     if (argc != 2)
     {

--- a/cpp_test_suite/event/event_lock.cpp
+++ b/cpp_test_suite/event/event_lock.cpp
@@ -36,9 +36,13 @@ public:
 void EventCallback::push_event(Tango::EventData *ed)
 {
     if (0 == ed->err)
+    {
         cb_executed++;
+    }
     else
+    {
         cb_err++;
+    }
 }
 
 int main(int argc, char *argv[])
@@ -83,7 +87,9 @@ int main(int argc, char *argv[])
         cout << "   Device unlocked --> OK" << endl;
 
         if (eventID != NODATA)
+        {
             dev->unsubscribe_event(eventID);
+        }
 
         dev->stop_poll_attribute(att_name);
     }

--- a/cpp_test_suite/event/event_lock.cpp
+++ b/cpp_test_suite/event/event_lock.cpp
@@ -20,85 +20,85 @@ using namespace std;
 
 const int NODATA = -9999;
 
-class EventCallback : public Tango::CallBack
+class EventCallback: public Tango::CallBack
 {
 public:
-    EventCallback()  { };
-    ~EventCallback() { };
-    void push_event( Tango::EventData *ed );
+    EventCallback()
+    {};
+    ~EventCallback()
+    {};
+    void push_event(Tango::EventData *ed);
 
-	int cb_executed;
-	int cb_err;
+    int cb_executed;
+    int cb_err;
 };
 
-
-void EventCallback::push_event( Tango::EventData *ed )
+void EventCallback::push_event(Tango::EventData *ed)
 {
-    if( 0 == ed->err )
-		cb_executed++;
+    if (0 == ed->err)
+        cb_executed++;
     else
-		cb_err++;
+        cb_err++;
 }
 
-
-int main(int argc,char *argv[])
+int main(int argc, char *argv[])
 {
-    Tango::DeviceProxy * dev;
+    Tango::DeviceProxy *dev;
     int eventID;
-    const vector< string >  filters;
+    const vector<string> filters;
     EventCallback *eventCallback = new EventCallback();
-	eventCallback->cb_executed = 0;
-	eventCallback->cb_err = 0;
+    eventCallback->cb_executed = 0;
+    eventCallback->cb_err = 0;
 
-	if (argc != 2)
-	{
-		cout << "usage: event_lock <device>" << endl;
-		exit(-1);
-	}
+    if (argc != 2)
+    {
+        cout << "usage: event_lock <device>" << endl;
+        exit(-1);
+    }
 
     string devName(argv[1]);
-	string att_name ("event_change_tst");
+    string att_name("event_change_tst");
 
     try
     {
-        dev = new Tango::DeviceProxy( devName );
-		dev->poll_attribute(att_name,1000);
+        dev = new Tango::DeviceProxy(devName);
+        dev->poll_attribute(att_name, 1000);
 
         eventID = NODATA;
-        eventID = dev -> subscribe_event( att_name, Tango::CHANGE_EVENT, eventCallback, filters );
+        eventID = dev->subscribe_event(att_name, Tango::CHANGE_EVENT, eventCallback, filters);
 
         dev->lock();
 
-		cout << "   Device locked and subscribed to one change event --> OK" << endl;
-    
+        cout << "   Device locked and subscribed to one change event --> OK" << endl;
+
         int cnt = 0;
-        while( cnt < 3 )
+        while (cnt < 3)
         {
             dev->command_inout("IOIncValue");
-            Tango_sleep( 2 );
+            Tango_sleep(2);
             cnt++;
         }
 
         dev->unlock();
-		cout << "   Device unlocked --> OK" << endl;
+        cout << "   Device unlocked --> OK" << endl;
 
-    	if( eventID != NODATA )
-        	dev->unsubscribe_event( eventID );
+        if (eventID != NODATA)
+            dev->unsubscribe_event(eventID);
 
-		dev->stop_poll_attribute(att_name);
+        dev->stop_poll_attribute(att_name);
     }
-    catch( Tango::DevFailed &ex )
+    catch (Tango::DevFailed &ex)
     {
-        Tango::Except::print_exception( ex );
+        Tango::Except::print_exception(ex);
     }
-	catch(...)
-	{
-		cout << "Unknown exception....." << endl;
-	}
+    catch (...)
+    {
+        cout << "Unknown exception....." << endl;
+    }
 
     delete dev;
 
-	cout << "   Memory corruption at process exit--> ??" << endl;
+    cout << "   Memory corruption at process exit--> ??" << endl;
 
     return 0;
 }

--- a/cppapi/client/api_util.cpp
+++ b/cppapi/client/api_util.cpp
@@ -100,9 +100,13 @@ ApiUtil::ApiUtil()
 //
 
     if (Util::_constructed == true)
+    {
         in_serv = true;
+    }
     else
+    {
         in_serv = false;
+    }
 
 //
 // Create the Asynchronous polling request Id generator
@@ -144,7 +148,9 @@ ApiUtil::ApiUtil()
         istringstream iss(var);
         iss >> user_to;
         if (iss)
+        {
             user_connect_timeout = user_to;
+        }
     }
 
 //
@@ -158,7 +164,9 @@ ApiUtil::ApiUtil()
         istringstream iss(var);
         iss >> sub_hwm;
         if (iss)
+        {
             user_sub_hwm = sub_hwm;
+        }
     }
 }
 
@@ -270,13 +278,17 @@ void ApiUtil::set_sig_handler()
         if (sigaction(SIGTERM, NULL, &old_action) != -1)
         {
             if (old_action.sa_handler == NULL)
+            {
                 sigaction(SIGTERM, &sa, NULL);
+            }
         }
 
         if (sigaction(SIGINT, NULL, &old_action) != -1)
         {
             if (old_action.sa_handler == NULL)
+            {
                 sigaction(SIGINT, &sa, NULL);
+            }
         }
     }
 #endif
@@ -315,7 +327,9 @@ void ApiUtil::create_orb()
     sa.sa_handler = NULL;
 
     if (sigaction(SIGPIPE, NULL, &sa) == -1)
+    {
         sa.sa_handler = NULL;
+    }
 #endif
 
 //
@@ -326,7 +340,9 @@ void ApiUtil::create_orb()
     bool omni_42_compat = false;
     CORBA::ULong omni_vers_hex = omniORB::versionHex();
     if (omni_vers_hex > 0x04020000)
+    {
         omni_42_compat = true;
+    }
 
     const char *options[][2] = {
         {"clientCallTimeOutPeriod", CLNT_TIMEOUT_STR},
@@ -383,7 +399,9 @@ int ApiUtil::get_db_ind()
     for (unsigned int i = 0; i < db_vect.size(); i++)
     {
         if (db_vect[i]->get_from_env_var() == true)
+        {
             return i;
+        }
     }
 
 //
@@ -405,7 +423,9 @@ int ApiUtil::get_db_ind(string &host, int port)
         if (db_vect[i]->get_db_port_num() == port)
         {
             if (db_vect[i]->get_db_host() == host)
+            {
                 return i;
+            }
         }
     }
 
@@ -481,7 +501,9 @@ void ApiUtil::get_asynch_replies()
     catch (CORBA::BAD_INV_ORDER &e)
     {
         if (e.minor() != omni::BAD_INV_ORDER_RequestNotSentYet)
+        {
             throw;
+        }
     }
 
 //
@@ -642,7 +664,9 @@ void ApiUtil::get_asynch_replies(long call_timeout)
                 catch (CORBA::BAD_INV_ORDER &e)
                 {
                     if (e.minor() != omni::BAD_INV_ORDER_RequestNotSentYet)
+                    {
                         throw;
+                    }
                 }
             }
 
@@ -706,7 +730,9 @@ void ApiUtil::get_asynch_replies(long call_timeout)
                 catch (CORBA::BAD_INV_ORDER &e)
                 {
                     if (e.minor() != omni::BAD_INV_ORDER_RequestNotSentYet)
+                    {
                         throw;
+                    }
                 }
             }
         }
@@ -833,16 +859,22 @@ void ApiUtil::clean_locking_threads(bool clean)
 
                     pos->second.shared->cmd_pending = true;
                     if (clean == true)
+                    {
                         pos->second.shared->cmd_code = LOCK_UNLOCK_ALL_EXIT;
+                    }
                     else
+                    {
                         pos->second.shared->cmd_code = LOCK_EXIT;
+                    }
 
                     pos->second.mon->signal();
 
                     cout4 << "Cmd sent to locking thread" << endl;
 
                     if (pos->second.shared->cmd_pending == true)
+                    {
                         pos->second.mon->wait(DEFAULT_TIMEOUT);
+                    }
                 }
                 delete pos->second.shared;
                 delete pos->second.mon;
@@ -850,7 +882,9 @@ void ApiUtil::clean_locking_threads(bool clean)
         }
 
         if (clean == false)
+        {
             lock_threads.clear();
+        }
     }
 }
 
@@ -919,9 +953,13 @@ void ApiUtil::attr_to_device(const AttributeValue *attr_value, const AttributeVa
     {
         CORBA::TypeCode_var ty;
         if (vers == 3)
+        {
             ty = attr_value_3->value.type();
+        }
         else
+        {
             ty = attr_value->value.type();
+        }
 
         if (ty->kind() == CORBA::tk_enum)
         {
@@ -936,9 +974,13 @@ void ApiUtil::attr_to_device(const AttributeValue *attr_value, const AttributeVa
         {
             case CORBA::tk_long:
                 if (vers == 3)
+                {
                     attr_value_3->value >>= tmp_seq_lo;
+                }
                 else
+                {
                     attr_value->value >>= tmp_seq_lo;
+                }
                 max = tmp_seq_lo->maximum();
                 len = tmp_seq_lo->length();
                 if (tmp_seq_lo->release() == true)
@@ -955,9 +997,13 @@ void ApiUtil::attr_to_device(const AttributeValue *attr_value, const AttributeVa
 
             case CORBA::tk_longlong:
                 if (vers == 3)
+                {
                     attr_value_3->value >>= tmp_seq_64;
+                }
                 else
+                {
                     attr_value->value >>= tmp_seq_64;
+                }
                 max = tmp_seq_64->maximum();
                 len = tmp_seq_64->length();
                 if (tmp_seq_64->release() == true)
@@ -974,9 +1020,13 @@ void ApiUtil::attr_to_device(const AttributeValue *attr_value, const AttributeVa
 
             case CORBA::tk_short:
                 if (vers == 3)
+                {
                     attr_value_3->value >>= tmp_seq_sh;
+                }
                 else
+                {
                     attr_value->value >>= tmp_seq_sh;
+                }
                 max = tmp_seq_sh->maximum();
                 len = tmp_seq_sh->length();
                 if (tmp_seq_sh->release() == true)
@@ -993,9 +1043,13 @@ void ApiUtil::attr_to_device(const AttributeValue *attr_value, const AttributeVa
 
             case CORBA::tk_double:
                 if (vers == 3)
+                {
                     attr_value_3->value >>= tmp_seq_db;
+                }
                 else
+                {
                     attr_value->value >>= tmp_seq_db;
+                }
                 max = tmp_seq_db->maximum();
                 len = tmp_seq_db->length();
                 if (tmp_seq_db->release() == true)
@@ -1012,9 +1066,13 @@ void ApiUtil::attr_to_device(const AttributeValue *attr_value, const AttributeVa
 
             case CORBA::tk_string:
                 if (vers == 3)
+                {
                     attr_value_3->value >>= tmp_seq_str;
+                }
                 else
+                {
                     attr_value->value >>= tmp_seq_str;
+                }
                 max = tmp_seq_str->maximum();
                 len = tmp_seq_str->length();
                 if (tmp_seq_str->release() == true)
@@ -1031,9 +1089,13 @@ void ApiUtil::attr_to_device(const AttributeValue *attr_value, const AttributeVa
 
             case CORBA::tk_float:
                 if (vers == 3)
+                {
                     attr_value_3->value >>= tmp_seq_fl;
+                }
                 else
+                {
                     attr_value->value >>= tmp_seq_fl;
+                }
                 max = tmp_seq_fl->maximum();
                 len = tmp_seq_fl->length();
                 if (tmp_seq_fl->release() == true)
@@ -1050,9 +1112,13 @@ void ApiUtil::attr_to_device(const AttributeValue *attr_value, const AttributeVa
 
             case CORBA::tk_boolean:
                 if (vers == 3)
+                {
                     attr_value_3->value >>= tmp_seq_boo;
+                }
                 else
+                {
                     attr_value->value >>= tmp_seq_boo;
+                }
                 max = tmp_seq_boo->maximum();
                 len = tmp_seq_boo->length();
                 if (tmp_seq_boo->release() == true)
@@ -1069,9 +1135,13 @@ void ApiUtil::attr_to_device(const AttributeValue *attr_value, const AttributeVa
 
             case CORBA::tk_ushort:
                 if (vers == 3)
+                {
                     attr_value_3->value >>= tmp_seq_ush;
+                }
                 else
+                {
                     attr_value->value >>= tmp_seq_ush;
+                }
                 max = tmp_seq_ush->maximum();
                 len = tmp_seq_ush->length();
                 if (tmp_seq_ush->release() == true)
@@ -1088,9 +1158,13 @@ void ApiUtil::attr_to_device(const AttributeValue *attr_value, const AttributeVa
 
             case CORBA::tk_octet:
                 if (vers == 3)
+                {
                     attr_value_3->value >>= tmp_seq_uch;
+                }
                 else
+                {
                     attr_value->value >>= tmp_seq_uch;
+                }
                 max = tmp_seq_uch->maximum();
                 len = tmp_seq_uch->length();
                 if (tmp_seq_uch->release() == true)
@@ -1107,9 +1181,13 @@ void ApiUtil::attr_to_device(const AttributeValue *attr_value, const AttributeVa
 
             case CORBA::tk_ulong:
                 if (vers == 3)
+                {
                     attr_value_3->value >>= tmp_seq_ulo;
+                }
                 else
+                {
                     attr_value->value >>= tmp_seq_ulo;
+                }
                 max = tmp_seq_ulo->maximum();
                 len = tmp_seq_ulo->length();
                 if (tmp_seq_ulo->release() == true)
@@ -1126,9 +1204,13 @@ void ApiUtil::attr_to_device(const AttributeValue *attr_value, const AttributeVa
 
             case CORBA::tk_ulonglong:
                 if (vers == 3)
+                {
                     attr_value_3->value >>= tmp_seq_u64;
+                }
                 else
+                {
                     attr_value->value >>= tmp_seq_u64;
+                }
                 max = tmp_seq_u64->maximum();
                 len = tmp_seq_u64->length();
                 if (tmp_seq_u64->release() == true)
@@ -1145,9 +1227,13 @@ void ApiUtil::attr_to_device(const AttributeValue *attr_value, const AttributeVa
 
             case CORBA::tk_enum:
                 if (vers == 3)
+                {
                     attr_value_3->value >>= tmp_seq_state;
+                }
                 else
+                {
                     attr_value->value >>= tmp_seq_state;
+                }
                 max = tmp_seq_state->maximum();
                 len = tmp_seq_state->length();
                 if (tmp_seq_state->release() == true)
@@ -1214,31 +1300,57 @@ void ApiUtil::device_to_attr(const DeviceAttribute &dev_attr, AttributeValue_4 &
     att.data_format = Tango::FMT_UNKNOWN;
 
     if (dev_attr.LongSeq.operator->() != NULL)
+    {
         att.value.long_att_value(dev_attr.LongSeq.in());
+    }
     else if (dev_attr.ShortSeq.operator->() != NULL)
+    {
         att.value.short_att_value(dev_attr.ShortSeq.in());
+    }
     else if (dev_attr.DoubleSeq.operator->() != NULL)
+    {
         att.value.double_att_value(dev_attr.DoubleSeq.in());
+    }
     else if (dev_attr.StringSeq.operator->() != NULL)
+    {
         att.value.string_att_value(dev_attr.StringSeq.in());
+    }
     else if (dev_attr.FloatSeq.operator->() != NULL)
+    {
         att.value.float_att_value(dev_attr.FloatSeq.in());
+    }
     else if (dev_attr.BooleanSeq.operator->() != NULL)
+    {
         att.value.bool_att_value(dev_attr.BooleanSeq.in());
+    }
     else if (dev_attr.UShortSeq.operator->() != NULL)
+    {
         att.value.ushort_att_value(dev_attr.UShortSeq.in());
+    }
     else if (dev_attr.UCharSeq.operator->() != NULL)
+    {
         att.value.uchar_att_value(dev_attr.UCharSeq.in());
+    }
     else if (dev_attr.Long64Seq.operator->() != NULL)
+    {
         att.value.long64_att_value(dev_attr.Long64Seq.in());
+    }
     else if (dev_attr.ULongSeq.operator->() != NULL)
+    {
         att.value.ulong_att_value(dev_attr.ULongSeq.in());
+    }
     else if (dev_attr.ULong64Seq.operator->() != NULL)
+    {
         att.value.ulong64_att_value(dev_attr.ULong64Seq.in());
+    }
     else if (dev_attr.StateSeq.operator->() != NULL)
+    {
         att.value.state_att_value(dev_attr.StateSeq.in());
+    }
     else if (dev_attr.EncodedSeq.operator->() != NULL)
+    {
         att.value.encoded_att_value(dev_attr.EncodedSeq.in());
+    }
 }
 
 void ApiUtil::device_to_attr(const DeviceAttribute &dev_attr, AttributeValue &att, string &d_name)
@@ -1251,29 +1363,53 @@ void ApiUtil::device_to_attr(const DeviceAttribute &dev_attr, AttributeValue &at
     att.dim_y = dev_attr.dim_y;
 
     if (dev_attr.LongSeq.operator->() != NULL)
+    {
         att.value <<= dev_attr.LongSeq.in();
+    }
     else if (dev_attr.ShortSeq.operator->() != NULL)
+    {
         att.value <<= dev_attr.ShortSeq.in();
+    }
     else if (dev_attr.DoubleSeq.operator->() != NULL)
+    {
         att.value <<= dev_attr.DoubleSeq.in();
+    }
     else if (dev_attr.StringSeq.operator->() != NULL)
+    {
         att.value <<= dev_attr.StringSeq.in();
+    }
     else if (dev_attr.FloatSeq.operator->() != NULL)
+    {
         att.value <<= dev_attr.FloatSeq.in();
+    }
     else if (dev_attr.BooleanSeq.operator->() != NULL)
+    {
         att.value <<= dev_attr.BooleanSeq.in();
+    }
     else if (dev_attr.UShortSeq.operator->() != NULL)
+    {
         att.value <<= dev_attr.UShortSeq.in();
+    }
     else if (dev_attr.UCharSeq.operator->() != NULL)
+    {
         att.value <<= dev_attr.UCharSeq.in();
+    }
     else if (dev_attr.Long64Seq.operator->() != NULL)
+    {
         att.value <<= dev_attr.Long64Seq.in();
+    }
     else if (dev_attr.ULongSeq.operator->() != NULL)
+    {
         att.value <<= dev_attr.ULongSeq.in();
+    }
     else if (dev_attr.ULong64Seq.operator->() != NULL)
+    {
         att.value <<= dev_attr.ULong64Seq.in();
+    }
     else if (dev_attr.StateSeq.operator->() != NULL)
+    {
         att.value <<= dev_attr.StateSeq.in();
+    }
     else if (dev_attr.EncodedSeq.operator->() != NULL)
     {
         TangoSys_OMemStream desc;
@@ -1677,9 +1813,13 @@ ostream &operator<<(ostream &o_str, AttributeInfo &p)
     }
 
     if ((p.writable == Tango::WRITE) || (p.writable == Tango::READ_WRITE))
+    {
         o_str << "Attribute is writable" << endl;
+    }
     else
+    {
         o_str << "Attribute is not writable" << endl;
+    }
     o_str << "Attribute label = " << p.label << endl;
     o_str << "Attribute description = " << p.description << endl;
     o_str << "Attribute unit = " << p.unit;
@@ -1846,13 +1986,19 @@ AttributeInfoEx &AttributeInfoEx::operator=(const AttributeConfig_5 *att_5)
     disp_level = att_5->level;
     root_attr_name = att_5->root_attr_name;
     if (att_5->memorized == false)
+    {
         memorized = NONE;
+    }
     else
     {
         if (att_5->mem_init == false)
+        {
             memorized = MEMORIZED;
+        }
         else
+        {
             memorized = MEMORIZED_WRITE_INIT;
+        }
     }
     enum_labels.clear();
     for (unsigned int j = 0; j < att_5->enum_labels.length(); j++)
@@ -1972,7 +2118,9 @@ ostream &operator<<(ostream &o_str, AttributeInfoEx &p)
         case Tango::DEV_ENUM :
             o_str << "Tango::DevEnum" << endl;
             for (size_t loop = 0; loop < p.enum_labels.size(); loop++)
+            {
                 o_str << "\tEnumeration label = " << p.enum_labels[loop] << endl;
+            }
             break;
 
         case Tango::DATA_TYPE_UNKNOWN :
@@ -2069,7 +2217,9 @@ ostream &operator<<(ostream &o_str, AttributeInfoEx &p)
 
     o_str << "Attribute writable_attr_name = " << p.writable_attr_name << endl;
     if (p.root_attr_name.empty() == false)
+    {
         o_str << "Root attribute name = " << p.root_attr_name << endl;
+    }
     o_str << "Attribute label = " << p.label << endl;
     o_str << "Attribute description = " << p.description << endl;
     o_str << "Attribute unit = " << p.unit;
@@ -2081,7 +2231,9 @@ ostream &operator<<(ostream &o_str, AttributeInfoEx &p)
 
     unsigned int i;
     for (i = 0; i < p.extensions.size(); i++)
+    {
         o_str << "Attribute extensions " << i + 1 << " = " << p.extensions[i] << endl;
+    }
 
     o_str << "Attribute alarm : min alarm = ";
     p.alarms.min_alarm.empty() == true ? o_str << "Not specified" : o_str << p.alarms.min_alarm;
@@ -2108,7 +2260,9 @@ ostream &operator<<(ostream &o_str, AttributeInfoEx &p)
     o_str << endl;
 
     for (i = 0; i < p.alarms.extensions.size(); i++)
+    {
         o_str << "Attribute alarm extensions " << i + 1 << " = " << p.alarms.extensions[i] << endl;
+    }
 
     o_str << "Attribute event : change event absolute change = ";
     p.events.ch_event.abs_change.empty() == true ? o_str << "Not specified" : o_str << p.events.ch_event.abs_change;
@@ -2119,16 +2273,20 @@ ostream &operator<<(ostream &o_str, AttributeInfoEx &p)
     o_str << endl;
 
     for (i = 0; i < p.events.ch_event.extensions.size(); i++)
+    {
         o_str << "Attribute alarm : change event extensions " << i + 1 << " = " << p.events.ch_event.extensions[i]
               << endl;
+    }
 
     o_str << "Attribute event : periodic event period = ";
     p.events.per_event.period.empty() == true ? o_str << "Not specified" : o_str << p.events.per_event.period;
     o_str << endl;
 
     for (i = 0; i < p.events.per_event.extensions.size(); i++)
+    {
         o_str << "Attribute alarm : periodic event extensions " << i + 1 << " = " << p.events.per_event.extensions[i]
               << endl;
+    }
 
     o_str << "Attribute event : archive event absolute change = ";
     p.events.arch_event.archive_abs_change.empty() == true ? o_str << "Not specified" : o_str
@@ -2148,10 +2306,14 @@ ostream &operator<<(ostream &o_str, AttributeInfoEx &p)
     for (i = 0; i < p.events.arch_event.extensions.size(); i++)
     {
         if (i == 0)
+        {
             o_str << endl;
+        }
         o_str << "Attribute alarm : archive event extensions " << i + 1 << " = " << p.events.arch_event.extensions[i];
         if (i != p.events.arch_event.extensions.size() - 1)
+        {
             o_str << endl;
+        }
     }
 
     return o_str;
@@ -2180,9 +2342,13 @@ ostream &operator<<(ostream &o_str, PipeInfo &p)
 
     o_str << "Pipe writable type = ";
     if (p.writable == PIPE_READ)
+    {
         o_str << "READ" << endl;
+    }
     else
+    {
         o_str << "READ_WRITE" << endl;
+    }
 
     o_str << "Pipe display level = ";
     switch (p.disp_level)
@@ -2207,7 +2373,9 @@ ostream &operator<<(ostream &o_str, PipeInfo &p)
     for (i = 0; i < p.extensions.size(); i++)
     {
         if (i == 0)
+        {
             o_str << endl;
+        }
         o_str << "Pipe extensions " << i + 1 << " = " << p.extensions[i] << endl;
     }
 

--- a/cppapi/client/api_util.cpp
+++ b/cppapi/client/api_util.cpp
@@ -36,20 +36,20 @@
 #include <api_util.tpp>
 
 #ifndef _TG_WINDOWS_
-	#include <sys/types.h>
-	#include <sys/socket.h>
-	#include <net/if.h>
-	#include <sys/ioctl.h>
-	#include <netdb.h>
-	#include <signal.h>
-	#include <ifaddrs.h>
-	#ifdef HAS_THREAD
-		#include <thread>
-	#endif
-	#include <netinet/in.h> 	// FreeBSD
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <net/if.h>
+#include <sys/ioctl.h>
+#include <netdb.h>
+#include <signal.h>
+#include <ifaddrs.h>
+#ifdef HAS_THREAD
+#include <thread>
+#endif
+#include <netinet/in.h>    // FreeBSD
 #else
-	#include <ws2tcpip.h>
-	#include <process.h>
+#include <ws2tcpip.h>
+#include <process.h>
 #endif
 
 
@@ -57,25 +57,26 @@ namespace Tango
 {
 
 ApiUtil *ApiUtil::_instance = NULL;
+
 omni_mutex ApiUtil::inst_mutex;
 
 #ifdef HAS_THREAD
 void _killproc_()
 {
-	::exit(-1);
+    ::exit(-1);
 }
 #endif // HAS_THREAD
 
-void _t_handler (TANGO_UNUSED(int signum))
+void _t_handler(TANGO_UNUSED(int signum))
 {
 #ifdef HAS_THREAD
-	thread t(_killproc_);
-	t.detach();
+    thread t(_killproc_);
+    t.detach();
 #else
-	_KillProc_ *t = new _KillProc_;
-	t->start();
+    _KillProc_ *t = new _KillProc_;
+    t->start();
 #endif
-	Tango_sleep(3);
+    Tango_sleep(3);
 }
 
 //+-----------------------------------------------------------------------------------------------------------------
@@ -88,76 +89,77 @@ void _t_handler (TANGO_UNUSED(int signum))
 //
 //------------------------------------------------------------------------------------------------------------------
 
-ApiUtil::ApiUtil():exit_lock_installed(false),reset_already_executed_flag(false),ext(new ApiUtilExt),
-notifd_event_consumer(NULL),cl_pid(0),user_connect_timeout(-1),zmq_event_consumer(NULL),user_sub_hwm(-1)
+ApiUtil::ApiUtil()
+    : exit_lock_installed(false), reset_already_executed_flag(false), ext(new ApiUtilExt),
+      notifd_event_consumer(NULL), cl_pid(0), user_connect_timeout(-1), zmq_event_consumer(NULL), user_sub_hwm(-1)
 {
-	_orb = CORBA::ORB::_nil();
+    _orb = CORBA::ORB::_nil();
 
 //
 // Check if it is created from a device server
 //
 
-	if (Util::_constructed == true)
-		in_serv = true;
-	else
-		in_serv = false;
+    if (Util::_constructed == true)
+        in_serv = true;
+    else
+        in_serv = false;
 
 //
 // Create the Asynchronous polling request Id generator
 //
 
-	UniqIdent *ui = new UniqIdent();
+    UniqIdent *ui = new UniqIdent();
 
 //
 // Create the table used to store asynchronous polling requests
 //
 
-	asyn_p_table = new AsynReq(ui);
+    asyn_p_table = new AsynReq(ui);
 
 //
 // Set the asynchronous callback mode to "ON_CALL"
 //
 
-	auto_cb = PULL_CALLBACK;
-	cb_thread_ptr = NULL;
+    auto_cb = PULL_CALLBACK;
+    cb_thread_ptr = NULL;
 
 //
 // Get the process PID
 //
 
 #ifdef _TG_WINDOWS_
-	cl_pid = _getpid();
+    cl_pid = _getpid();
 #else
-	cl_pid = getpid();
+    cl_pid = getpid();
 #endif
 
 //
 // Check if the user has defined his own connection timeout
 //
 
-	string var;
-	if (get_env_var("TANGOconnectTimeout",var) == 0)
-	{
-		int user_to = -1;
-		istringstream iss(var);
-		iss >> user_to;
-		if (iss)
-			user_connect_timeout = user_to;
-	}
+    string var;
+    if (get_env_var("TANGOconnectTimeout", var) == 0)
+    {
+        int user_to = -1;
+        istringstream iss(var);
+        iss >> user_to;
+        if (iss)
+            user_connect_timeout = user_to;
+    }
 
 //
 // Check if the user has defined his own subscriber hwm (fpr zmq event tuning)
 //
 
-	var.clear();
-	if (get_env_var("TANGO_EVENT_BUFFER_HWM",var) == 0)
-	{
-		int sub_hwm = -1;
-		istringstream iss(var);
-		iss >> sub_hwm;
-		if (iss)
-			user_sub_hwm = sub_hwm;
-	}
+    var.clear();
+    if (get_env_var("TANGO_EVENT_BUFFER_HWM", var) == 0)
+    {
+        int sub_hwm = -1;
+        istringstream iss(var);
+        iss >> sub_hwm;
+        if (iss)
+            user_sub_hwm = sub_hwm;
+    }
 }
 
 //+----------------------------------------------------------------------------------------------------------------
@@ -177,69 +179,70 @@ ApiUtil::~ApiUtil()
 // Release Asyn stuff
 //
 
-	delete asyn_p_table;
+    delete asyn_p_table;
 
-	if (cb_thread_ptr != NULL)
-	{
-		cb_thread_cmd.stop_thread();
-		cb_thread_ptr->join(0);
-	}
+    if (cb_thread_ptr != NULL)
+    {
+        cb_thread_cmd.stop_thread();
+        cb_thread_ptr->join(0);
+    }
 
 //
 // Kill any remaining locking threads
 //
 
-	clean_locking_threads();
+    clean_locking_threads();
 
 //
 // Release event stuff (in case it is necessary)
 //
 
-	bool event_was_used = false;
+    bool event_was_used = false;
 
 #ifdef HAS_UNIQUE_PTR
-	if (ext.get() != NULL)
+    if (ext.get() != NULL)
 #else
-	if (ext != NULL)
+        if (ext != NULL)
 #endif
-	{
-		if ((notifd_event_consumer != NULL) || (zmq_event_consumer != NULL))
-		{
-			event_was_used = true;
-			leavefunc();
-			NotifdEventConsumer::cleanup();
-			ZmqEventConsumer::cleanup();
-		}
+    {
+        if ((notifd_event_consumer != NULL) || (zmq_event_consumer != NULL))
+        {
+            event_was_used = true;
+            leavefunc();
+            NotifdEventConsumer::cleanup();
+            ZmqEventConsumer::cleanup();
+        }
 #ifndef HAS_UNIQUE_PTR
-		delete ext;
+        delete ext;
 #endif
-	}
+    }
 
 //
 // Delete the database object
 //
 
-	for (unsigned int i = 0;i < db_vect.size();i++)
-	{
-		delete db_vect[i];
-	}
+    for (unsigned int i = 0; i < db_vect.size(); i++)
+    {
+        delete db_vect[i];
+    }
 
 //
 // Properly shutdown the ORB
 //
 
-	if ((in_serv == false) && (CORBA::is_nil(_orb) == false))
-	{
-		if (event_was_used == false)
-		{
-			try
-			{
-				_orb->destroy();
-			}
-			catch (...) {}
-		}
-		CORBA::release(_orb);
-	}
+    if ((in_serv == false) && (CORBA::is_nil(_orb) == false))
+    {
+        if (event_was_used == false)
+        {
+            try
+            {
+                _orb->destroy();
+            }
+            catch (...)
+            {}
+        }
+        CORBA::release(_orb);
+    }
 
 }
 
@@ -256,26 +259,26 @@ ApiUtil::~ApiUtil()
 void ApiUtil::set_sig_handler()
 {
 #ifndef _TG_WINDOWS_
-	if (in_serv == false)
-	{
-		struct sigaction sa,old_action;
+    if (in_serv == false)
+    {
+        struct sigaction sa, old_action;
 
-		sa.sa_handler = _t_handler;
-		sigemptyset (&sa.sa_mask);
-		sa.sa_flags = SA_RESTART;
+        sa.sa_handler = _t_handler;
+        sigemptyset(&sa.sa_mask);
+        sa.sa_flags = SA_RESTART;
 
-		if (sigaction(SIGTERM,NULL,&old_action) != -1)
-		{
-			if (old_action.sa_handler == NULL)
-				sigaction(SIGTERM,&sa,NULL);
-		}
+        if (sigaction(SIGTERM, NULL, &old_action) != -1)
+        {
+            if (old_action.sa_handler == NULL)
+                sigaction(SIGTERM, &sa, NULL);
+        }
 
-		if (sigaction(SIGINT,NULL,&old_action) != -1)
-		{
-			if (old_action.sa_handler == NULL)
-				sigaction(SIGINT,&sa,NULL);
-		}
-	}
+        if (sigaction(SIGINT, NULL, &old_action) != -1)
+        {
+            if (old_action.sa_handler == NULL)
+                sigaction(SIGINT, &sa, NULL);
+        }
+    }
 #endif
 }
 
@@ -291,16 +294,16 @@ void ApiUtil::set_sig_handler()
 
 void ApiUtil::create_orb()
 {
-	int _argc;
-	char **_argv;
+    int _argc;
+    char **_argv;
 
 //
 // pass dummy arguments to init() because we don't have access to argc and argv
 //
 
-	_argc = 1;
-	_argv = (char**)malloc(sizeof(char*));
-	_argv[0] = (char*)"dummy";
+    _argc = 1;
+    _argv = (char **) malloc(sizeof(char *));
+    _argv[0] = (char *) "dummy";
 
 //
 // Get user signal handler for SIGPIPE (ORB_init call install a SIG_IGN for SIGPIPE. This could be annoying in case
@@ -308,11 +311,11 @@ void ApiUtil::create_orb()
 //
 
 #ifndef _TG_WINDOWS_
-	struct sigaction sa;
-	sa.sa_handler = NULL;
+    struct sigaction sa;
+    sa.sa_handler = NULL;
 
-	if (sigaction(SIGPIPE,NULL,&sa) == -1)
-		sa.sa_handler = NULL;
+    if (sigaction(SIGPIPE, NULL, &sa) == -1)
+        sa.sa_handler = NULL;
 #endif
 
 //
@@ -325,41 +328,41 @@ void ApiUtil::create_orb()
     if (omni_vers_hex > 0x04020000)
         omni_42_compat = true;
 
-	const char *options[][2] = {
-			{"clientCallTimeOutPeriod",CLNT_TIMEOUT_STR},
-			{"verifyObjectExistsAndType","0"},
-			{"maxGIOPConnectionPerServer",MAX_GIOP_PER_SERVER},
-			{"giopMaxMsgSize",MAX_TRANSFER_SIZE},
-            {"throwTransientOnTimeOut","1"},
-			{0,0}};
+    const char *options[][2] = {
+        {"clientCallTimeOutPeriod", CLNT_TIMEOUT_STR},
+        {"verifyObjectExistsAndType", "0"},
+        {"maxGIOPConnectionPerServer", MAX_GIOP_PER_SERVER},
+        {"giopMaxMsgSize", MAX_TRANSFER_SIZE},
+        {"throwTransientOnTimeOut", "1"},
+        {0, 0}};
 
     if (omni_42_compat == false)
     {
-        int nb_opt = sizeof(options) / sizeof (char *[2]);
+        int nb_opt = sizeof(options) / sizeof(char *[2]);
         options[nb_opt - 2][0] = NULL;
         options[nb_opt - 2][1] = NULL;
     }
 
-	_orb = CORBA::ORB_init(_argc,_argv,"omniORB4",options);
+    _orb = CORBA::ORB_init(_argc, _argv, "omniORB4", options);
 
-	free(_argv);
+    free(_argv);
 
 //
 // Restore SIGPIPE handler
 //
 
 #ifndef _TG_WINDOWS_
-	if (sa.sa_handler != NULL)
-	{
-		struct sigaction sb;
+    if (sa.sa_handler != NULL)
+    {
+        struct sigaction sb;
 
-		sb = sa;
+        sb = sa;
 
-		if (sigaction(SIGPIPE,&sb,NULL) == -1)
-		{
-			cerr << "Can re-install user signal handler for SIGPIPE!" << endl;
-		}
-	}
+        if (sigaction(SIGPIPE, &sb, NULL) == -1)
+        {
+            cerr << "Can re-install user signal handler for SIGPIPE!" << endl;
+        }
+    }
 #endif
 }
 
@@ -375,44 +378,44 @@ void ApiUtil::create_orb()
 
 int ApiUtil::get_db_ind()
 {
-	omni_mutex_lock lo(the_mutex);
+    omni_mutex_lock lo(the_mutex);
 
-	for (unsigned int i = 0;i < db_vect.size();i++)
-	{
-		if (db_vect[i]->get_from_env_var() == true)
-			return i;
-	}
+    for (unsigned int i = 0; i < db_vect.size(); i++)
+    {
+        if (db_vect[i]->get_from_env_var() == true)
+            return i;
+    }
 
 //
 // The database object has not been found, create it
 //
 
-	db_vect.push_back(new Database());
+    db_vect.push_back(new Database());
 
-	return (db_vect.size() - 1);
+    return (db_vect.size() - 1);
 
 }
 
-int ApiUtil::get_db_ind(string &host,int port)
+int ApiUtil::get_db_ind(string &host, int port)
 {
-	omni_mutex_lock lo(the_mutex);
+    omni_mutex_lock lo(the_mutex);
 
-	for (unsigned int i = 0;i < db_vect.size();i++)
-	{
-		if (db_vect[i]->get_db_port_num() == port)
-		{
-			if (db_vect[i]->get_db_host() == host)
-				return i;
-		}
-	}
+    for (unsigned int i = 0; i < db_vect.size(); i++)
+    {
+        if (db_vect[i]->get_db_port_num() == port)
+        {
+            if (db_vect[i]->get_db_host() == host)
+                return i;
+        }
+    }
 
 //
 // The database object has not been found, create it
 //
 
-	db_vect.push_back(new Database(host,port));
+    db_vect.push_back(new Database(host, port));
 
-	return (db_vect.size() - 1);
+    return (db_vect.size() - 1);
 
 }
 
@@ -435,83 +438,83 @@ void ApiUtil::get_asynch_replies()
 // First get all replies from ORB buffers
 //
 
-	try
-	{
-		while (_orb->poll_next_response() == true)
-		{
-			CORBA::Request_ptr req;
-			_orb->get_next_response(req);
+    try
+    {
+        while (_orb->poll_next_response() == true)
+        {
+            CORBA::Request_ptr req;
+            _orb->get_next_response(req);
 
 //
 // Retrieve this request in the cb request map and mark it as "arrived" in both maps
 //
 
-			TgRequest &tg_req = asyn_p_table->get_request(req);
+            TgRequest &tg_req = asyn_p_table->get_request(req);
 
-			tg_req.arrived = true;
-			asyn_p_table->mark_as_arrived(req);
+            tg_req.arrived = true;
+            asyn_p_table->mark_as_arrived(req);
 
 //
 // Process request
 //
 
-			switch (tg_req.req_type)
-			{
-			case TgRequest::CMD_INOUT :
-				tg_req.dev->Cb_Cmd_Request(req,tg_req.cb_ptr);
-				break;
+            switch (tg_req.req_type)
+            {
+                case TgRequest::CMD_INOUT :
+                    tg_req.dev->Cb_Cmd_Request(req, tg_req.cb_ptr);
+                    break;
 
-			case TgRequest::READ_ATTR :
-				tg_req.dev->Cb_ReadAttr_Request(req,tg_req.cb_ptr);
-				break;
+                case TgRequest::READ_ATTR :
+                    tg_req.dev->Cb_ReadAttr_Request(req, tg_req.cb_ptr);
+                    break;
 
-			case TgRequest::WRITE_ATTR :
-			case TgRequest::WRITE_ATTR_SINGLE :
-				tg_req.dev->Cb_WriteAttr_Request(req,tg_req.cb_ptr);
-				break;
-			}
+                case TgRequest::WRITE_ATTR :
+                case TgRequest::WRITE_ATTR_SINGLE :
+                    tg_req.dev->Cb_WriteAttr_Request(req, tg_req.cb_ptr);
+                    break;
+            }
 
-			tg_req.dev->dec_asynch_counter(CALL_BACK);
-			asyn_p_table->remove_request(tg_req.dev,req);
-		}
-	}
-	catch (CORBA::BAD_INV_ORDER &e)
-	{
-		if (e.minor() != omni::BAD_INV_ORDER_RequestNotSentYet)
-			throw;
-	}
+            tg_req.dev->dec_asynch_counter(CALL_BACK);
+            asyn_p_table->remove_request(tg_req.dev, req);
+        }
+    }
+    catch (CORBA::BAD_INV_ORDER &e)
+    {
+        if (e.minor() != omni::BAD_INV_ORDER_RequestNotSentYet)
+            throw;
+    }
 
 //
 // For all replies already there
 //
 
-	multimap<Connection *,TgRequest>::iterator pos;
-	multimap<Connection *,TgRequest> &req_table = asyn_p_table->get_cb_dev_table();
+    multimap<Connection *, TgRequest>::iterator pos;
+    multimap<Connection *, TgRequest> &req_table = asyn_p_table->get_cb_dev_table();
 
-	for (pos = req_table.begin();pos != req_table.end();++pos)
-	{
-		if (pos->second.arrived == true)
-		{
-			switch (pos->second.req_type)
-			{
-			case TgRequest::CMD_INOUT :
-				pos->first->Cb_Cmd_Request(pos->second.request,pos->second.cb_ptr);
-				break;
+    for (pos = req_table.begin(); pos != req_table.end(); ++pos)
+    {
+        if (pos->second.arrived == true)
+        {
+            switch (pos->second.req_type)
+            {
+                case TgRequest::CMD_INOUT :
+                    pos->first->Cb_Cmd_Request(pos->second.request, pos->second.cb_ptr);
+                    break;
 
-			case TgRequest::READ_ATTR :
-				pos->first->Cb_ReadAttr_Request(pos->second.request,pos->second.cb_ptr);
-				break;
+                case TgRequest::READ_ATTR :
+                    pos->first->Cb_ReadAttr_Request(pos->second.request, pos->second.cb_ptr);
+                    break;
 
-			case TgRequest::WRITE_ATTR :
-			case TgRequest::WRITE_ATTR_SINGLE :
-				pos->first->Cb_WriteAttr_Request(pos->second.request,pos->second.cb_ptr);
-				break;
-			}
-			pos->first->dec_asynch_counter(CALL_BACK);
-			asyn_p_table->remove_request(pos->first,pos->second.request);
-		}
+                case TgRequest::WRITE_ATTR :
+                case TgRequest::WRITE_ATTR_SINGLE :
+                    pos->first->Cb_WriteAttr_Request(pos->second.request, pos->second.cb_ptr);
+                    break;
+            }
+            pos->first->dec_asynch_counter(CALL_BACK);
+            asyn_p_table->remove_request(pos->first, pos->second.request);
+        }
 
-	}
+    }
 
 }
 
@@ -537,177 +540,177 @@ void ApiUtil::get_asynch_replies(long call_timeout)
 // For all replies already there
 //
 
-	multimap<Connection *,TgRequest>::iterator pos;
-	multimap<Connection *,TgRequest> &req_table = asyn_p_table->get_cb_dev_table();
+    multimap<Connection *, TgRequest>::iterator pos;
+    multimap<Connection *, TgRequest> &req_table = asyn_p_table->get_cb_dev_table();
 
-	for (pos = req_table.begin();pos != req_table.end();++pos)
-	{
-		if (pos->second.arrived == true)
-		{
-			switch (pos->second.req_type)
-			{
-			case TgRequest::CMD_INOUT :
-				pos->first->Cb_Cmd_Request(pos->second.request,pos->second.cb_ptr);
-				break;
+    for (pos = req_table.begin(); pos != req_table.end(); ++pos)
+    {
+        if (pos->second.arrived == true)
+        {
+            switch (pos->second.req_type)
+            {
+                case TgRequest::CMD_INOUT :
+                    pos->first->Cb_Cmd_Request(pos->second.request, pos->second.cb_ptr);
+                    break;
 
-			case TgRequest::READ_ATTR :
-				pos->first->Cb_ReadAttr_Request(pos->second.request,pos->second.cb_ptr);
-				break;
+                case TgRequest::READ_ATTR :
+                    pos->first->Cb_ReadAttr_Request(pos->second.request, pos->second.cb_ptr);
+                    break;
 
-			case TgRequest::WRITE_ATTR :
-			case TgRequest::WRITE_ATTR_SINGLE :
-				pos->first->Cb_WriteAttr_Request(pos->second.request,pos->second.cb_ptr);
-				break;
-			}
-			pos->first->dec_asynch_counter(CALL_BACK);
-			asyn_p_table->remove_request(pos->first,pos->second.request);
-		}
+                case TgRequest::WRITE_ATTR :
+                case TgRequest::WRITE_ATTR_SINGLE :
+                    pos->first->Cb_WriteAttr_Request(pos->second.request, pos->second.cb_ptr);
+                    break;
+            }
+            pos->first->dec_asynch_counter(CALL_BACK);
+            asyn_p_table->remove_request(pos->first, pos->second.request);
+        }
 
-	}
+    }
 
 //
 // If they are requests already sent but without being replied yet
 //
 
-	if (asyn_p_table->get_cb_request_nb() != 0)
-	{
-		CORBA::Request_ptr req;
+    if (asyn_p_table->get_cb_request_nb() != 0)
+    {
+        CORBA::Request_ptr req;
 
-		if (call_timeout != 0)
-		{
+        if (call_timeout != 0)
+        {
 
 //
 // A timeout has been specified. Wait if there are still request without replies but not more than the specified
 // timeout. Leave method if the timeout is not arrived but there is no more request without reply
 //
 
-			long nb = call_timeout / 20;
+            long nb = call_timeout / 20;
 #ifndef _TG_WINDOWS_
-			struct timespec to_wait,inter;
-			to_wait.tv_sec = 0;
-			to_wait.tv_nsec = 20000000;
+            struct timespec to_wait, inter;
+            to_wait.tv_sec = 0;
+            to_wait.tv_nsec = 20000000;
 #endif
 
-			while ((nb > 0) && (asyn_p_table->get_cb_request_nb() != 0))
-			{
+            while ((nb > 0) && (asyn_p_table->get_cb_request_nb() != 0))
+            {
 #ifdef _TG_WINDOWS_
-				Sleep(20);
+                Sleep(20);
 #else
-				nanosleep(&to_wait,&inter);
+                nanosleep(&to_wait, &inter);
 #endif
-				nb--;
+                nb--;
 
-				try
-				{
-					if (_orb->poll_next_response() == true)
-					{
-						_orb->get_next_response(req);
+                try
+                {
+                    if (_orb->poll_next_response() == true)
+                    {
+                        _orb->get_next_response(req);
 
 //
 // Retrieve this request in the cb request map and mark it as "arrived" in both maps
 //
 
-						TgRequest &tg_req = asyn_p_table->get_request(req);
+                        TgRequest &tg_req = asyn_p_table->get_request(req);
 
-						tg_req.arrived = true;
-						asyn_p_table->mark_as_arrived(req);
+                        tg_req.arrived = true;
+                        asyn_p_table->mark_as_arrived(req);
 
 //
 // Is it a request for our device, process it ?
 //
 
-						switch (tg_req.req_type)
-						{
-						case TgRequest::CMD_INOUT :
-							tg_req.dev->Cb_Cmd_Request(req,tg_req.cb_ptr);
-							break;
+                        switch (tg_req.req_type)
+                        {
+                            case TgRequest::CMD_INOUT :
+                                tg_req.dev->Cb_Cmd_Request(req, tg_req.cb_ptr);
+                                break;
 
-						case TgRequest::READ_ATTR :
-							tg_req.dev->Cb_ReadAttr_Request(req,tg_req.cb_ptr);
-							break;
+                            case TgRequest::READ_ATTR :
+                                tg_req.dev->Cb_ReadAttr_Request(req, tg_req.cb_ptr);
+                                break;
 
-						case TgRequest::WRITE_ATTR :
-						case TgRequest::WRITE_ATTR_SINGLE :
-							tg_req.dev->Cb_WriteAttr_Request(req,tg_req.cb_ptr);
-							break;
-						}
+                            case TgRequest::WRITE_ATTR :
+                            case TgRequest::WRITE_ATTR_SINGLE :
+                                tg_req.dev->Cb_WriteAttr_Request(req, tg_req.cb_ptr);
+                                break;
+                        }
 
-						tg_req.dev->dec_asynch_counter(CALL_BACK);
-						asyn_p_table->remove_request(tg_req.dev,req);
-					}
-				}
-				catch (CORBA::BAD_INV_ORDER &e)
-				{
-					if (e.minor() != omni::BAD_INV_ORDER_RequestNotSentYet)
-						throw;
-				}
-			}
+                        tg_req.dev->dec_asynch_counter(CALL_BACK);
+                        asyn_p_table->remove_request(tg_req.dev, req);
+                    }
+                }
+                catch (CORBA::BAD_INV_ORDER &e)
+                {
+                    if (e.minor() != omni::BAD_INV_ORDER_RequestNotSentYet)
+                        throw;
+                }
+            }
 
 //
 // Throw exception if the timeout has expired but there are still request without replies
 //
 
-			if ((nb == 0) && (asyn_p_table->get_cb_request_nb() != 0))
-			{
-				TangoSys_OMemStream desc;
-				desc << "Still some reply(ies) for asynchronous callback call(s) to be received" << ends;
-				ApiAsynNotThereExcept::throw_exception((const char *)API_AsynReplyNotArrived,
-						       	       desc.str(),
-						               (const char *)"ApiUtil::get_asynch_replies");
-			}
-		}
-		else
-		{
+            if ((nb == 0) && (asyn_p_table->get_cb_request_nb() != 0))
+            {
+                TangoSys_OMemStream desc;
+                desc << "Still some reply(ies) for asynchronous callback call(s) to be received" << ends;
+                ApiAsynNotThereExcept::throw_exception((const char *) API_AsynReplyNotArrived,
+                                                       desc.str(),
+                                                       (const char *) "ApiUtil::get_asynch_replies");
+            }
+        }
+        else
+        {
 //
 // If timeout is set to 0, this means wait until all the requests sent to this device has sent their replies
 //
 
-			while (asyn_p_table->get_cb_request_nb() != 0)
-			{
-				try
-				{
-					_orb->get_next_response(req);
+            while (asyn_p_table->get_cb_request_nb() != 0)
+            {
+                try
+                {
+                    _orb->get_next_response(req);
 
 //
 // Retrieve this request in the cb request map and mark it as "arrived" in both maps
 //
 
-					TgRequest &tg_req = asyn_p_table->get_request(req);
+                    TgRequest &tg_req = asyn_p_table->get_request(req);
 
-					tg_req.arrived = true;
-					asyn_p_table->mark_as_arrived(req);
+                    tg_req.arrived = true;
+                    asyn_p_table->mark_as_arrived(req);
 
 //
 // Process the reply
 //
 
-					switch (tg_req.req_type)
-					{
-					case TgRequest::CMD_INOUT :
-						tg_req.dev->Cb_Cmd_Request(req,tg_req.cb_ptr);
-						break;
+                    switch (tg_req.req_type)
+                    {
+                        case TgRequest::CMD_INOUT :
+                            tg_req.dev->Cb_Cmd_Request(req, tg_req.cb_ptr);
+                            break;
 
-					case TgRequest::READ_ATTR :
-						tg_req.dev->Cb_ReadAttr_Request(req,tg_req.cb_ptr);
-						break;
+                        case TgRequest::READ_ATTR :
+                            tg_req.dev->Cb_ReadAttr_Request(req, tg_req.cb_ptr);
+                            break;
 
-					case TgRequest::WRITE_ATTR :
-					case TgRequest::WRITE_ATTR_SINGLE :
-						tg_req.dev->Cb_WriteAttr_Request(req,tg_req.cb_ptr);
-						break;
-					}
+                        case TgRequest::WRITE_ATTR :
+                        case TgRequest::WRITE_ATTR_SINGLE :
+                            tg_req.dev->Cb_WriteAttr_Request(req, tg_req.cb_ptr);
+                            break;
+                    }
 
-					tg_req.dev->dec_asynch_counter(CALL_BACK);
-					asyn_p_table->remove_request(tg_req.dev,req);
-				}
-				catch (CORBA::BAD_INV_ORDER &e)
-				{
-					if (e.minor() != omni::BAD_INV_ORDER_RequestNotSentYet)
-						throw;
-				}
-			}
-		}
-	}
+                    tg_req.dev->dec_asynch_counter(CALL_BACK);
+                    asyn_p_table->remove_request(tg_req.dev, req);
+                }
+                catch (CORBA::BAD_INV_ORDER &e)
+                {
+                    if (e.minor() != omni::BAD_INV_ORDER_RequestNotSentYet)
+                        throw;
+                }
+            }
+        }
+    }
 
 }
 
@@ -728,10 +731,10 @@ void ApiUtil::get_asynch_replies(long call_timeout)
 void ApiUtil::set_asynch_cb_sub_model(cb_sub_model mode)
 {
 
-	if (auto_cb == PULL_CALLBACK)
-	{
-		if (mode == PUSH_CALLBACK)
-		{
+    if (auto_cb == PULL_CALLBACK)
+    {
+        if (mode == PUSH_CALLBACK)
+        {
 
 //
 // In this case, delete the old object in case it is needed, create a new thread and start it
@@ -740,27 +743,27 @@ void ApiUtil::set_asynch_cb_sub_model(cb_sub_model mode)
             delete cb_thread_ptr;
             cb_thread_ptr = NULL;
 
-			cb_thread_cmd.start_thread();
+            cb_thread_cmd.start_thread();
 
-			cb_thread_ptr = new CallBackThread(cb_thread_cmd,asyn_p_table);
-			cb_thread_ptr->start();
-			auto_cb = PUSH_CALLBACK;
-		}
-	}
-	else
-	{
-		if (mode == PULL_CALLBACK)
-		{
+            cb_thread_ptr = new CallBackThread(cb_thread_cmd, asyn_p_table);
+            cb_thread_ptr->start();
+            auto_cb = PUSH_CALLBACK;
+        }
+    }
+    else
+    {
+        if (mode == PULL_CALLBACK)
+        {
 
 //
 // Ask the thread to stop and to exit
 //
 
-			cb_thread_cmd.stop_thread();
-			auto_cb = PULL_CALLBACK;
-			asyn_p_table->signal();
-		}
-	}
+            cb_thread_cmd.stop_thread();
+            auto_cb = PULL_CALLBACK;
+            asyn_p_table->signal();
+        }
+    }
 
 }
 
@@ -787,12 +790,12 @@ void ApiUtil::create_zmq_event_consumer()
 
 NotifdEventConsumer *ApiUtil::get_notifd_event_consumer()
 {
-	return notifd_event_consumer;
+    return notifd_event_consumer;
 }
 
 ZmqEventConsumer *ApiUtil::get_zmq_event_consumer()
 {
-	return zmq_event_consumer;
+    return zmq_event_consumer;
 }
 
 //+-----------------------------------------------------------------------------------------------------------------
@@ -811,44 +814,44 @@ ZmqEventConsumer *ApiUtil::get_zmq_event_consumer()
 
 void ApiUtil::clean_locking_threads(bool clean)
 {
-	omni_mutex_lock oml(lock_th_map);
+    omni_mutex_lock oml(lock_th_map);
 
-	if (lock_threads.empty() == false)
-	{
-		map<string,LockingThread>::iterator pos;
-		for (pos = lock_threads.begin();pos != lock_threads.end();++pos)
-		{
-			if (pos->second.shared->suicide == true)
-			{
-				delete pos->second.shared;
-				delete pos->second.mon;
-			}
-			else
-			{
-				{
-					omni_mutex_lock sync(*(pos->second.mon));
+    if (lock_threads.empty() == false)
+    {
+        map<string, LockingThread>::iterator pos;
+        for (pos = lock_threads.begin(); pos != lock_threads.end(); ++pos)
+        {
+            if (pos->second.shared->suicide == true)
+            {
+                delete pos->second.shared;
+                delete pos->second.mon;
+            }
+            else
+            {
+                {
+                    omni_mutex_lock sync(*(pos->second.mon));
 
-					pos->second.shared->cmd_pending = true;
-					if (clean == true)
-						pos->second.shared->cmd_code = LOCK_UNLOCK_ALL_EXIT;
-					else
-						pos->second.shared->cmd_code = LOCK_EXIT;
+                    pos->second.shared->cmd_pending = true;
+                    if (clean == true)
+                        pos->second.shared->cmd_code = LOCK_UNLOCK_ALL_EXIT;
+                    else
+                        pos->second.shared->cmd_code = LOCK_EXIT;
 
-					pos->second.mon->signal();
+                    pos->second.mon->signal();
 
-					cout4 << "Cmd sent to locking thread" << endl;
+                    cout4 << "Cmd sent to locking thread" << endl;
 
-					if (pos->second.shared->cmd_pending == true)
-						pos->second.mon->wait(DEFAULT_TIMEOUT);
-				}
-				delete pos->second.shared;
-				delete pos->second.mon;
-			}
-		}
+                    if (pos->second.shared->cmd_pending == true)
+                        pos->second.mon->wait(DEFAULT_TIMEOUT);
+                }
+                delete pos->second.shared;
+                delete pos->second.mon;
+            }
+        }
 
-		if (clean == false)
-			lock_threads.clear();
-	}
+        if (clean == false)
+            lock_threads.clear();
+    }
 }
 
 //-----------------------------------------------------------------------------------------------------------------
@@ -861,314 +864,314 @@ void ApiUtil::clean_locking_threads(bool clean)
 //
 //-------------------------------------------------------------------------------------------------------------------
 
-void ApiUtil::attr_to_device(const AttributeValue *attr_value,const AttributeValue_3 *attr_value_3,
-			     long vers,DeviceAttribute *dev_attr)
+void ApiUtil::attr_to_device(const AttributeValue *attr_value, const AttributeValue_3 *attr_value_3,
+                             long vers, DeviceAttribute *dev_attr)
 {
 
-	const DevVarLongArray *tmp_seq_lo;
-	CORBA::Long *tmp_lo;
-	const DevVarShortArray *tmp_seq_sh;
-	CORBA::Short *tmp_sh;
-	const DevVarDoubleArray *tmp_seq_db;
-	CORBA::Double *tmp_db;
-	const DevVarStringArray *tmp_seq_str;
-	char **tmp_str;
-	const DevVarFloatArray *tmp_seq_fl;
-	CORBA::Float *tmp_fl;
-	const DevVarBooleanArray *tmp_seq_boo;
-	CORBA::Boolean *tmp_boo;
-	const DevVarUShortArray *tmp_seq_ush;
-	CORBA::UShort *tmp_ush;
-	const DevVarCharArray *tmp_seq_uch;
-	CORBA::Octet *tmp_uch;
-	const DevVarLong64Array *tmp_seq_64;
-	CORBA::LongLong *tmp_lolo;
-	const DevVarULongArray *tmp_seq_ulo;
-	CORBA::ULong *tmp_ulo;
-	const DevVarULong64Array *tmp_seq_u64;
-	CORBA::ULongLong *tmp_ulolo;
-	const DevVarStateArray *tmp_seq_state;
-	Tango::DevState *tmp_state;
+    const DevVarLongArray *tmp_seq_lo;
+    CORBA::Long *tmp_lo;
+    const DevVarShortArray *tmp_seq_sh;
+    CORBA::Short *tmp_sh;
+    const DevVarDoubleArray *tmp_seq_db;
+    CORBA::Double *tmp_db;
+    const DevVarStringArray *tmp_seq_str;
+    char **tmp_str;
+    const DevVarFloatArray *tmp_seq_fl;
+    CORBA::Float *tmp_fl;
+    const DevVarBooleanArray *tmp_seq_boo;
+    CORBA::Boolean *tmp_boo;
+    const DevVarUShortArray *tmp_seq_ush;
+    CORBA::UShort *tmp_ush;
+    const DevVarCharArray *tmp_seq_uch;
+    CORBA::Octet *tmp_uch;
+    const DevVarLong64Array *tmp_seq_64;
+    CORBA::LongLong *tmp_lolo;
+    const DevVarULongArray *tmp_seq_ulo;
+    CORBA::ULong *tmp_ulo;
+    const DevVarULong64Array *tmp_seq_u64;
+    CORBA::ULongLong *tmp_ulolo;
+    const DevVarStateArray *tmp_seq_state;
+    Tango::DevState *tmp_state;
 
-	CORBA::ULong max,len;
+    CORBA::ULong max, len;
 
-	if (vers == 3)
-	{
-		dev_attr->name = attr_value_3->name;
-		dev_attr->quality = attr_value_3->quality;
-		dev_attr->time = attr_value_3->time;
-		dev_attr->dim_x = attr_value_3->r_dim.dim_x;
-		dev_attr->dim_y = attr_value_3->r_dim.dim_y;
-		dev_attr->set_w_dim_x(attr_value_3->w_dim.dim_x);
-		dev_attr->set_w_dim_y(attr_value_3->w_dim.dim_y);
-		dev_attr->err_list = new DevErrorList(attr_value_3->err_list);
-	}
-	else
-	{
-		dev_attr->name = attr_value->name;
-		dev_attr->quality = attr_value->quality;
-		dev_attr->time = attr_value->time;
-		dev_attr->dim_x = attr_value->dim_x;
-		dev_attr->dim_y = attr_value->dim_y;
-	}
+    if (vers == 3)
+    {
+        dev_attr->name = attr_value_3->name;
+        dev_attr->quality = attr_value_3->quality;
+        dev_attr->time = attr_value_3->time;
+        dev_attr->dim_x = attr_value_3->r_dim.dim_x;
+        dev_attr->dim_y = attr_value_3->r_dim.dim_y;
+        dev_attr->set_w_dim_x(attr_value_3->w_dim.dim_x);
+        dev_attr->set_w_dim_y(attr_value_3->w_dim.dim_y);
+        dev_attr->err_list = new DevErrorList(attr_value_3->err_list);
+    }
+    else
+    {
+        dev_attr->name = attr_value->name;
+        dev_attr->quality = attr_value->quality;
+        dev_attr->time = attr_value->time;
+        dev_attr->dim_x = attr_value->dim_x;
+        dev_attr->dim_y = attr_value->dim_y;
+    }
 
-	if (dev_attr->quality != Tango::ATTR_INVALID)
-	{
-		CORBA::TypeCode_var ty;
-		if (vers == 3)
-			ty = attr_value_3->value.type();
-		else
-			ty = attr_value->value.type();
+    if (dev_attr->quality != Tango::ATTR_INVALID)
+    {
+        CORBA::TypeCode_var ty;
+        if (vers == 3)
+            ty = attr_value_3->value.type();
+        else
+            ty = attr_value->value.type();
 
-		if (ty->kind() == CORBA::tk_enum)
-		{
-			attr_value_3->value >>= dev_attr->d_state;
-			dev_attr->d_state_filled = true;
-			return;
-		}
+        if (ty->kind() == CORBA::tk_enum)
+        {
+            attr_value_3->value >>= dev_attr->d_state;
+            dev_attr->d_state_filled = true;
+            return;
+        }
 
-		CORBA::TypeCode_var ty_alias = ty->content_type();
-		CORBA::TypeCode_var ty_seq = ty_alias->content_type();
-		switch (ty_seq->kind())
-		{
-			case CORBA::tk_long:
-				if (vers == 3)
-					attr_value_3->value >>= tmp_seq_lo;
-				else
-					attr_value->value >>= tmp_seq_lo;
-				max = tmp_seq_lo->maximum();
-				len = tmp_seq_lo->length();
-				if (tmp_seq_lo->release() == true)
-				{
-					tmp_lo = (const_cast<DevVarLongArray *>(tmp_seq_lo))->get_buffer((CORBA::Boolean)true);
-					dev_attr->LongSeq = new DevVarLongArray(max,len,tmp_lo,true);
-				}
-				else
-				{
-					tmp_lo = const_cast<CORBA::Long *>(tmp_seq_lo->get_buffer());
-					dev_attr->LongSeq = new DevVarLongArray(max,len,tmp_lo,false);
-				}
-				break;
+        CORBA::TypeCode_var ty_alias = ty->content_type();
+        CORBA::TypeCode_var ty_seq = ty_alias->content_type();
+        switch (ty_seq->kind())
+        {
+            case CORBA::tk_long:
+                if (vers == 3)
+                    attr_value_3->value >>= tmp_seq_lo;
+                else
+                    attr_value->value >>= tmp_seq_lo;
+                max = tmp_seq_lo->maximum();
+                len = tmp_seq_lo->length();
+                if (tmp_seq_lo->release() == true)
+                {
+                    tmp_lo = (const_cast<DevVarLongArray *>(tmp_seq_lo))->get_buffer((CORBA::Boolean) true);
+                    dev_attr->LongSeq = new DevVarLongArray(max, len, tmp_lo, true);
+                }
+                else
+                {
+                    tmp_lo = const_cast<CORBA::Long *>(tmp_seq_lo->get_buffer());
+                    dev_attr->LongSeq = new DevVarLongArray(max, len, tmp_lo, false);
+                }
+                break;
 
-			case CORBA::tk_longlong:
-				if (vers == 3)
-					attr_value_3->value >>= tmp_seq_64;
-				else
-					attr_value->value >>= tmp_seq_64;
-				max = tmp_seq_64->maximum();
-				len = tmp_seq_64->length();
-				if (tmp_seq_64->release() == true)
-				{
-					tmp_lolo = (const_cast<DevVarLong64Array *>(tmp_seq_64))->get_buffer((CORBA::Boolean)true);
-					dev_attr->Long64Seq = new DevVarLong64Array(max,len,tmp_lolo,true);
-				}
-				else
-				{
-					tmp_lolo = const_cast<CORBA::LongLong *>(tmp_seq_64->get_buffer());
-					dev_attr->Long64Seq = new DevVarLong64Array(max,len,tmp_lolo,false);
-				}
-				break;
+            case CORBA::tk_longlong:
+                if (vers == 3)
+                    attr_value_3->value >>= tmp_seq_64;
+                else
+                    attr_value->value >>= tmp_seq_64;
+                max = tmp_seq_64->maximum();
+                len = tmp_seq_64->length();
+                if (tmp_seq_64->release() == true)
+                {
+                    tmp_lolo = (const_cast<DevVarLong64Array *>(tmp_seq_64))->get_buffer((CORBA::Boolean) true);
+                    dev_attr->Long64Seq = new DevVarLong64Array(max, len, tmp_lolo, true);
+                }
+                else
+                {
+                    tmp_lolo = const_cast<CORBA::LongLong *>(tmp_seq_64->get_buffer());
+                    dev_attr->Long64Seq = new DevVarLong64Array(max, len, tmp_lolo, false);
+                }
+                break;
 
-			case CORBA::tk_short:
-				if (vers == 3)
-					attr_value_3->value >>= tmp_seq_sh;
-				else
-					attr_value->value >>= tmp_seq_sh;
-				max = tmp_seq_sh->maximum();
-				len = tmp_seq_sh->length();
-				if (tmp_seq_sh->release() == true)
-				{
-					tmp_sh = (const_cast<DevVarShortArray *>(tmp_seq_sh))->get_buffer((CORBA::Boolean)true);
-					dev_attr->ShortSeq = new DevVarShortArray(max,len,tmp_sh,true);
-				}
-				else
-				{
-					tmp_sh = const_cast<CORBA::Short *>(tmp_seq_sh->get_buffer());
-					dev_attr->ShortSeq = new DevVarShortArray(max,len,tmp_sh,false);
-				}
-				break;
+            case CORBA::tk_short:
+                if (vers == 3)
+                    attr_value_3->value >>= tmp_seq_sh;
+                else
+                    attr_value->value >>= tmp_seq_sh;
+                max = tmp_seq_sh->maximum();
+                len = tmp_seq_sh->length();
+                if (tmp_seq_sh->release() == true)
+                {
+                    tmp_sh = (const_cast<DevVarShortArray *>(tmp_seq_sh))->get_buffer((CORBA::Boolean) true);
+                    dev_attr->ShortSeq = new DevVarShortArray(max, len, tmp_sh, true);
+                }
+                else
+                {
+                    tmp_sh = const_cast<CORBA::Short *>(tmp_seq_sh->get_buffer());
+                    dev_attr->ShortSeq = new DevVarShortArray(max, len, tmp_sh, false);
+                }
+                break;
 
-			case CORBA::tk_double:
-				if (vers == 3)
-					attr_value_3->value >>= tmp_seq_db;
-				else
-					attr_value->value >>= tmp_seq_db;
-				max = tmp_seq_db->maximum();
-				len = tmp_seq_db->length();
-				if (tmp_seq_db->release() == true)
-				{
-					tmp_db = (const_cast<DevVarDoubleArray *>(tmp_seq_db))->get_buffer((CORBA::Boolean)true);
-					dev_attr->DoubleSeq = new DevVarDoubleArray(max,len,tmp_db,true);
-				}
-				else
-				{
-					tmp_db = const_cast<CORBA::Double *>(tmp_seq_db->get_buffer());
-					dev_attr->DoubleSeq = new DevVarDoubleArray(max,len,tmp_db,false);
-				}
-				break;
+            case CORBA::tk_double:
+                if (vers == 3)
+                    attr_value_3->value >>= tmp_seq_db;
+                else
+                    attr_value->value >>= tmp_seq_db;
+                max = tmp_seq_db->maximum();
+                len = tmp_seq_db->length();
+                if (tmp_seq_db->release() == true)
+                {
+                    tmp_db = (const_cast<DevVarDoubleArray *>(tmp_seq_db))->get_buffer((CORBA::Boolean) true);
+                    dev_attr->DoubleSeq = new DevVarDoubleArray(max, len, tmp_db, true);
+                }
+                else
+                {
+                    tmp_db = const_cast<CORBA::Double *>(tmp_seq_db->get_buffer());
+                    dev_attr->DoubleSeq = new DevVarDoubleArray(max, len, tmp_db, false);
+                }
+                break;
 
-			case CORBA::tk_string:
-				if (vers == 3)
-					attr_value_3->value >>= tmp_seq_str;
-				else
-					attr_value->value >>= tmp_seq_str;
-				max = tmp_seq_str->maximum();
-				len = tmp_seq_str->length();
-				if (tmp_seq_str->release() == true)
-				{
-					tmp_str = (const_cast<DevVarStringArray *>(tmp_seq_str))->get_buffer((CORBA::Boolean)true);
-					dev_attr->StringSeq = new DevVarStringArray(max,len,tmp_str,true);
-				}
-				else
-				{
-					tmp_str = const_cast<char **>(tmp_seq_str->get_buffer());
-					dev_attr->StringSeq = new DevVarStringArray(max,len,tmp_str,false);
-				}
-				break;
+            case CORBA::tk_string:
+                if (vers == 3)
+                    attr_value_3->value >>= tmp_seq_str;
+                else
+                    attr_value->value >>= tmp_seq_str;
+                max = tmp_seq_str->maximum();
+                len = tmp_seq_str->length();
+                if (tmp_seq_str->release() == true)
+                {
+                    tmp_str = (const_cast<DevVarStringArray *>(tmp_seq_str))->get_buffer((CORBA::Boolean) true);
+                    dev_attr->StringSeq = new DevVarStringArray(max, len, tmp_str, true);
+                }
+                else
+                {
+                    tmp_str = const_cast<char **>(tmp_seq_str->get_buffer());
+                    dev_attr->StringSeq = new DevVarStringArray(max, len, tmp_str, false);
+                }
+                break;
 
-			case CORBA::tk_float:
-				if (vers == 3)
-					attr_value_3->value >>= tmp_seq_fl;
-				else
-					attr_value->value >>= tmp_seq_fl;
-				max = tmp_seq_fl->maximum();
-				len = tmp_seq_fl->length();
-				if (tmp_seq_fl->release() == true)
-				{
-					tmp_fl = (const_cast<DevVarFloatArray *>(tmp_seq_fl))->get_buffer((CORBA::Boolean)true);
-					dev_attr->FloatSeq = new DevVarFloatArray(max,len,tmp_fl,true);
-				}
-				else
-				{
-					tmp_fl = const_cast<CORBA::Float *>(tmp_seq_fl->get_buffer());
-					dev_attr->FloatSeq = new DevVarFloatArray(max,len,tmp_fl,false);
-				}
-				break;
+            case CORBA::tk_float:
+                if (vers == 3)
+                    attr_value_3->value >>= tmp_seq_fl;
+                else
+                    attr_value->value >>= tmp_seq_fl;
+                max = tmp_seq_fl->maximum();
+                len = tmp_seq_fl->length();
+                if (tmp_seq_fl->release() == true)
+                {
+                    tmp_fl = (const_cast<DevVarFloatArray *>(tmp_seq_fl))->get_buffer((CORBA::Boolean) true);
+                    dev_attr->FloatSeq = new DevVarFloatArray(max, len, tmp_fl, true);
+                }
+                else
+                {
+                    tmp_fl = const_cast<CORBA::Float *>(tmp_seq_fl->get_buffer());
+                    dev_attr->FloatSeq = new DevVarFloatArray(max, len, tmp_fl, false);
+                }
+                break;
 
-			case CORBA::tk_boolean:
-				if (vers == 3)
-					attr_value_3->value >>= tmp_seq_boo;
-				else
-					attr_value->value >>= tmp_seq_boo;
-				max = tmp_seq_boo->maximum();
-				len = tmp_seq_boo->length();
-				if (tmp_seq_boo->release() == true)
-				{
-					tmp_boo = (const_cast<DevVarBooleanArray *>(tmp_seq_boo))->get_buffer((CORBA::Boolean)true);
-					dev_attr->BooleanSeq = new DevVarBooleanArray(max,len,tmp_boo,true);
-				}
-				else
-				{
-					tmp_boo = const_cast<CORBA::Boolean *>(tmp_seq_boo->get_buffer());
-					dev_attr->BooleanSeq = new DevVarBooleanArray(max,len,tmp_boo,false);
-				}
-				break;
+            case CORBA::tk_boolean:
+                if (vers == 3)
+                    attr_value_3->value >>= tmp_seq_boo;
+                else
+                    attr_value->value >>= tmp_seq_boo;
+                max = tmp_seq_boo->maximum();
+                len = tmp_seq_boo->length();
+                if (tmp_seq_boo->release() == true)
+                {
+                    tmp_boo = (const_cast<DevVarBooleanArray *>(tmp_seq_boo))->get_buffer((CORBA::Boolean) true);
+                    dev_attr->BooleanSeq = new DevVarBooleanArray(max, len, tmp_boo, true);
+                }
+                else
+                {
+                    tmp_boo = const_cast<CORBA::Boolean *>(tmp_seq_boo->get_buffer());
+                    dev_attr->BooleanSeq = new DevVarBooleanArray(max, len, tmp_boo, false);
+                }
+                break;
 
-			case CORBA::tk_ushort:
-				if (vers == 3)
-					attr_value_3->value >>= tmp_seq_ush;
-				else
-					attr_value->value >>= tmp_seq_ush;
-				max = tmp_seq_ush->maximum();
-				len = tmp_seq_ush->length();
-				if (tmp_seq_ush->release() == true)
-				{
-					tmp_ush = (const_cast<DevVarUShortArray *>(tmp_seq_ush))->get_buffer((CORBA::Boolean)true);
-					dev_attr->UShortSeq = new DevVarUShortArray(max,len,tmp_ush,true);
-				}
-				else
-				{
-					tmp_ush = const_cast<CORBA::UShort *>(tmp_seq_ush->get_buffer());
-					dev_attr->UShortSeq = new DevVarUShortArray(max,len,tmp_ush,false);
-				}
-				break;
+            case CORBA::tk_ushort:
+                if (vers == 3)
+                    attr_value_3->value >>= tmp_seq_ush;
+                else
+                    attr_value->value >>= tmp_seq_ush;
+                max = tmp_seq_ush->maximum();
+                len = tmp_seq_ush->length();
+                if (tmp_seq_ush->release() == true)
+                {
+                    tmp_ush = (const_cast<DevVarUShortArray *>(tmp_seq_ush))->get_buffer((CORBA::Boolean) true);
+                    dev_attr->UShortSeq = new DevVarUShortArray(max, len, tmp_ush, true);
+                }
+                else
+                {
+                    tmp_ush = const_cast<CORBA::UShort *>(tmp_seq_ush->get_buffer());
+                    dev_attr->UShortSeq = new DevVarUShortArray(max, len, tmp_ush, false);
+                }
+                break;
 
-			case CORBA::tk_octet:
-				if (vers == 3)
-					attr_value_3->value >>= tmp_seq_uch;
-				else
-					attr_value->value >>= tmp_seq_uch;
-				max = tmp_seq_uch->maximum();
-				len = tmp_seq_uch->length();
-				if (tmp_seq_uch->release() == true)
-				{
-					tmp_uch = (const_cast<DevVarCharArray *>(tmp_seq_uch))->get_buffer((CORBA::Boolean)true);
-					dev_attr->UCharSeq = new DevVarCharArray(max,len,tmp_uch,true);
-				}
-				else
-				{
-					tmp_uch = const_cast<CORBA::Octet *>(tmp_seq_uch->get_buffer());
-					dev_attr->UCharSeq = new DevVarCharArray(max,len,tmp_uch,false);
-				}
-				break;
+            case CORBA::tk_octet:
+                if (vers == 3)
+                    attr_value_3->value >>= tmp_seq_uch;
+                else
+                    attr_value->value >>= tmp_seq_uch;
+                max = tmp_seq_uch->maximum();
+                len = tmp_seq_uch->length();
+                if (tmp_seq_uch->release() == true)
+                {
+                    tmp_uch = (const_cast<DevVarCharArray *>(tmp_seq_uch))->get_buffer((CORBA::Boolean) true);
+                    dev_attr->UCharSeq = new DevVarCharArray(max, len, tmp_uch, true);
+                }
+                else
+                {
+                    tmp_uch = const_cast<CORBA::Octet *>(tmp_seq_uch->get_buffer());
+                    dev_attr->UCharSeq = new DevVarCharArray(max, len, tmp_uch, false);
+                }
+                break;
 
-			case CORBA::tk_ulong:
-				if (vers == 3)
-					attr_value_3->value >>= tmp_seq_ulo;
-				else
-					attr_value->value >>= tmp_seq_ulo;
-				max = tmp_seq_ulo->maximum();
-				len = tmp_seq_ulo->length();
-				if (tmp_seq_ulo->release() == true)
-				{
-					tmp_ulo = (const_cast<DevVarULongArray *>(tmp_seq_ulo))->get_buffer((CORBA::Boolean)true);
-					dev_attr->ULongSeq = new DevVarULongArray(max,len,tmp_ulo,true);
-				}
-				else
-				{
-					tmp_ulo = const_cast<CORBA::ULong *>(tmp_seq_ulo->get_buffer());
-					dev_attr->ULongSeq = new DevVarULongArray(max,len,tmp_ulo,false);
-				}
-				break;
+            case CORBA::tk_ulong:
+                if (vers == 3)
+                    attr_value_3->value >>= tmp_seq_ulo;
+                else
+                    attr_value->value >>= tmp_seq_ulo;
+                max = tmp_seq_ulo->maximum();
+                len = tmp_seq_ulo->length();
+                if (tmp_seq_ulo->release() == true)
+                {
+                    tmp_ulo = (const_cast<DevVarULongArray *>(tmp_seq_ulo))->get_buffer((CORBA::Boolean) true);
+                    dev_attr->ULongSeq = new DevVarULongArray(max, len, tmp_ulo, true);
+                }
+                else
+                {
+                    tmp_ulo = const_cast<CORBA::ULong *>(tmp_seq_ulo->get_buffer());
+                    dev_attr->ULongSeq = new DevVarULongArray(max, len, tmp_ulo, false);
+                }
+                break;
 
-			case CORBA::tk_ulonglong:
-				if (vers == 3)
-					attr_value_3->value >>= tmp_seq_u64;
-				else
-					attr_value->value >>= tmp_seq_u64;
-				max = tmp_seq_u64->maximum();
-				len = tmp_seq_u64->length();
-				if (tmp_seq_u64->release() == true)
-				{
-					tmp_ulolo = (const_cast<DevVarULong64Array *>(tmp_seq_u64))->get_buffer((CORBA::Boolean)true);
-					dev_attr->ULong64Seq = new DevVarULong64Array(max,len,tmp_ulolo,true);
-				}
-				else
-				{
-					tmp_ulolo = const_cast<CORBA::ULongLong *>(tmp_seq_u64->get_buffer());
-					dev_attr->ULong64Seq = new DevVarULong64Array(max,len,tmp_ulolo,false);
-				}
-				break;
+            case CORBA::tk_ulonglong:
+                if (vers == 3)
+                    attr_value_3->value >>= tmp_seq_u64;
+                else
+                    attr_value->value >>= tmp_seq_u64;
+                max = tmp_seq_u64->maximum();
+                len = tmp_seq_u64->length();
+                if (tmp_seq_u64->release() == true)
+                {
+                    tmp_ulolo = (const_cast<DevVarULong64Array *>(tmp_seq_u64))->get_buffer((CORBA::Boolean) true);
+                    dev_attr->ULong64Seq = new DevVarULong64Array(max, len, tmp_ulolo, true);
+                }
+                else
+                {
+                    tmp_ulolo = const_cast<CORBA::ULongLong *>(tmp_seq_u64->get_buffer());
+                    dev_attr->ULong64Seq = new DevVarULong64Array(max, len, tmp_ulolo, false);
+                }
+                break;
 
-			case CORBA::tk_enum:
-				if (vers == 3)
-					attr_value_3->value >>= tmp_seq_state;
-				else
-					attr_value->value >>= tmp_seq_state;
-				max = tmp_seq_state->maximum();
-				len = tmp_seq_state->length();
-				if (tmp_seq_state->release() == true)
-				{
-					tmp_state = (const_cast<DevVarStateArray *>(tmp_seq_state))->get_buffer((CORBA::Boolean)true);
-					dev_attr->StateSeq = new DevVarStateArray(max,len,tmp_state,true);
-				}
-				else
-				{
-					tmp_state = const_cast<Tango::DevState *>(tmp_seq_state->get_buffer());
-					dev_attr->StateSeq = new DevVarStateArray(max,len,tmp_state,false);
-				}
-				break;
+            case CORBA::tk_enum:
+                if (vers == 3)
+                    attr_value_3->value >>= tmp_seq_state;
+                else
+                    attr_value->value >>= tmp_seq_state;
+                max = tmp_seq_state->maximum();
+                len = tmp_seq_state->length();
+                if (tmp_seq_state->release() == true)
+                {
+                    tmp_state = (const_cast<DevVarStateArray *>(tmp_seq_state))->get_buffer((CORBA::Boolean) true);
+                    dev_attr->StateSeq = new DevVarStateArray(max, len, tmp_state, true);
+                }
+                else
+                {
+                    tmp_state = const_cast<Tango::DevState *>(tmp_seq_state->get_buffer());
+                    dev_attr->StateSeq = new DevVarStateArray(max, len, tmp_state, false);
+                }
+                break;
 
-			default:
-				break;
-		}
+            default:
+                break;
+        }
         dev_attr->data_type = Tango::DEV_SHORT;
-	}
+    }
 }
 
-void ApiUtil::attr_to_device(const AttributeValue_4 *attr_value_4,TANGO_UNUSED(long vers),DeviceAttribute *dev_attr)
+void ApiUtil::attr_to_device(const AttributeValue_4 *attr_value_4, TANGO_UNUSED(long vers), DeviceAttribute *dev_attr)
 {
-	attr_to_device_base(attr_value_4,dev_attr);
+    attr_to_device_base(attr_value_4, dev_attr);
 
 //
 // Warning: Since Tango 9, data type SHORT is used for both short attribute and enumeration attribute!
@@ -1179,10 +1182,10 @@ void ApiUtil::attr_to_device(const AttributeValue_4 *attr_value_4,TANGO_UNUSED(l
     dev_attr->data_type = Tango::DEV_SHORT;
 }
 
-void ApiUtil::attr_to_device(const AttributeValue_5 *attr_value_5,TANGO_UNUSED(long vers),DeviceAttribute *dev_attr)
+void ApiUtil::attr_to_device(const AttributeValue_5 *attr_value_5, TANGO_UNUSED(long vers), DeviceAttribute *dev_attr)
 {
-	attr_to_device_base(attr_value_5,dev_attr);
-	dev_attr->data_type = attr_value_5->data_type;
+    attr_to_device_base(attr_value_5, dev_attr);
+    dev_attr->data_type = attr_value_5->data_type;
 }
 
 //------------------------------------------------------------------------------------------------------------------
@@ -1201,85 +1204,85 @@ void ApiUtil::attr_to_device(const AttributeValue_5 *attr_value_5,TANGO_UNUSED(l
 //
 //---------------------------------------------------------------------------------------------------------------
 
-void ApiUtil::device_to_attr(const DeviceAttribute &dev_attr,AttributeValue_4 &att)
+void ApiUtil::device_to_attr(const DeviceAttribute &dev_attr, AttributeValue_4 &att)
 {
-	att.name = dev_attr.name.c_str();
-	att.quality = dev_attr.quality;
-	att.time = dev_attr.time;
-	att.w_dim.dim_x = dev_attr.dim_x;
-	att.w_dim.dim_y = dev_attr.dim_y;
-	att.data_format = Tango::FMT_UNKNOWN;
+    att.name = dev_attr.name.c_str();
+    att.quality = dev_attr.quality;
+    att.time = dev_attr.time;
+    att.w_dim.dim_x = dev_attr.dim_x;
+    att.w_dim.dim_y = dev_attr.dim_y;
+    att.data_format = Tango::FMT_UNKNOWN;
 
-	if (dev_attr.LongSeq.operator->() != NULL)
-		att.value.long_att_value(dev_attr.LongSeq.in());
-	else if (dev_attr.ShortSeq.operator->() != NULL)
-		att.value.short_att_value(dev_attr.ShortSeq.in());
-	else if (dev_attr.DoubleSeq.operator->() != NULL)
-		att.value.double_att_value(dev_attr.DoubleSeq.in());
-	else if (dev_attr.StringSeq.operator->() != NULL)
-		att.value.string_att_value(dev_attr.StringSeq.in());
-	else if (dev_attr.FloatSeq.operator->() != NULL)
-		att.value.float_att_value(dev_attr.FloatSeq.in());
-	else if (dev_attr.BooleanSeq.operator->() != NULL)
-		att.value.bool_att_value(dev_attr.BooleanSeq.in());
-	else if (dev_attr.UShortSeq.operator->() != NULL)
-		att.value.ushort_att_value(dev_attr.UShortSeq.in());
-	else if (dev_attr.UCharSeq.operator->() != NULL)
-		att.value.uchar_att_value(dev_attr.UCharSeq.in());
-	else if (dev_attr.Long64Seq.operator->() != NULL)
-		att.value.long64_att_value(dev_attr.Long64Seq.in());
-	else if (dev_attr.ULongSeq.operator->() != NULL)
-		att.value.ulong_att_value(dev_attr.ULongSeq.in());
-	else if (dev_attr.ULong64Seq.operator->() != NULL)
-		att.value.ulong64_att_value(dev_attr.ULong64Seq.in());
-	else if (dev_attr.StateSeq.operator->() != NULL)
-		att.value.state_att_value(dev_attr.StateSeq.in());
-	else if (dev_attr.EncodedSeq.operator->() != NULL)
-		att.value.encoded_att_value(dev_attr.EncodedSeq.in());
+    if (dev_attr.LongSeq.operator->() != NULL)
+        att.value.long_att_value(dev_attr.LongSeq.in());
+    else if (dev_attr.ShortSeq.operator->() != NULL)
+        att.value.short_att_value(dev_attr.ShortSeq.in());
+    else if (dev_attr.DoubleSeq.operator->() != NULL)
+        att.value.double_att_value(dev_attr.DoubleSeq.in());
+    else if (dev_attr.StringSeq.operator->() != NULL)
+        att.value.string_att_value(dev_attr.StringSeq.in());
+    else if (dev_attr.FloatSeq.operator->() != NULL)
+        att.value.float_att_value(dev_attr.FloatSeq.in());
+    else if (dev_attr.BooleanSeq.operator->() != NULL)
+        att.value.bool_att_value(dev_attr.BooleanSeq.in());
+    else if (dev_attr.UShortSeq.operator->() != NULL)
+        att.value.ushort_att_value(dev_attr.UShortSeq.in());
+    else if (dev_attr.UCharSeq.operator->() != NULL)
+        att.value.uchar_att_value(dev_attr.UCharSeq.in());
+    else if (dev_attr.Long64Seq.operator->() != NULL)
+        att.value.long64_att_value(dev_attr.Long64Seq.in());
+    else if (dev_attr.ULongSeq.operator->() != NULL)
+        att.value.ulong_att_value(dev_attr.ULongSeq.in());
+    else if (dev_attr.ULong64Seq.operator->() != NULL)
+        att.value.ulong64_att_value(dev_attr.ULong64Seq.in());
+    else if (dev_attr.StateSeq.operator->() != NULL)
+        att.value.state_att_value(dev_attr.StateSeq.in());
+    else if (dev_attr.EncodedSeq.operator->() != NULL)
+        att.value.encoded_att_value(dev_attr.EncodedSeq.in());
 }
 
-void ApiUtil::device_to_attr(const DeviceAttribute &dev_attr,AttributeValue &att,string &d_name)
+void ApiUtil::device_to_attr(const DeviceAttribute &dev_attr, AttributeValue &att, string &d_name)
 {
 
-	att.name = dev_attr.name.c_str();
-	att.quality = dev_attr.quality;
-	att.time = dev_attr.time;
-	att.dim_x = dev_attr.dim_x;
-	att.dim_y = dev_attr.dim_y;
+    att.name = dev_attr.name.c_str();
+    att.quality = dev_attr.quality;
+    att.time = dev_attr.time;
+    att.dim_x = dev_attr.dim_x;
+    att.dim_y = dev_attr.dim_y;
 
-	if (dev_attr.LongSeq.operator->() != NULL)
-		att.value <<= dev_attr.LongSeq.in();
-	else if (dev_attr.ShortSeq.operator->() != NULL)
-		att.value <<= dev_attr.ShortSeq.in();
-	else if (dev_attr.DoubleSeq.operator->() != NULL)
-		att.value <<= dev_attr.DoubleSeq.in();
-	else if (dev_attr.StringSeq.operator->() != NULL)
-		att.value  <<= dev_attr.StringSeq.in();
-	else if (dev_attr.FloatSeq.operator->() != NULL)
-		att.value <<= dev_attr.FloatSeq.in();
-	else if (dev_attr.BooleanSeq.operator->() != NULL)
-		att.value <<= dev_attr.BooleanSeq.in();
-	else if (dev_attr.UShortSeq.operator->() != NULL)
-		att.value <<= dev_attr.UShortSeq.in();
-	else if (dev_attr.UCharSeq.operator->() != NULL)
-		att.value  <<= dev_attr.UCharSeq.in();
-	else if (dev_attr.Long64Seq.operator->() != NULL)
-		att.value  <<= dev_attr.Long64Seq.in();
-	else if (dev_attr.ULongSeq.operator->() != NULL)
-		att.value  <<= dev_attr.ULongSeq.in();
-	else if (dev_attr.ULong64Seq.operator->() != NULL)
-		att.value  <<= dev_attr.ULong64Seq.in();
-	else if (dev_attr.StateSeq.operator->() != NULL)
-		att.value  <<= dev_attr.StateSeq.in();
-	else if (dev_attr.EncodedSeq.operator->() != NULL)
-	{
-		TangoSys_OMemStream desc;
-		desc << "Device " << d_name;
-		desc << " does not support DevEncoded data type" << ends;
-		ApiNonSuppExcept::throw_exception((const char *)API_UnsupportedFeature,
-						  	desc.str(),
-						  	(const char *)"DeviceProxy::device_to_attr");
-	}
+    if (dev_attr.LongSeq.operator->() != NULL)
+        att.value <<= dev_attr.LongSeq.in();
+    else if (dev_attr.ShortSeq.operator->() != NULL)
+        att.value <<= dev_attr.ShortSeq.in();
+    else if (dev_attr.DoubleSeq.operator->() != NULL)
+        att.value <<= dev_attr.DoubleSeq.in();
+    else if (dev_attr.StringSeq.operator->() != NULL)
+        att.value <<= dev_attr.StringSeq.in();
+    else if (dev_attr.FloatSeq.operator->() != NULL)
+        att.value <<= dev_attr.FloatSeq.in();
+    else if (dev_attr.BooleanSeq.operator->() != NULL)
+        att.value <<= dev_attr.BooleanSeq.in();
+    else if (dev_attr.UShortSeq.operator->() != NULL)
+        att.value <<= dev_attr.UShortSeq.in();
+    else if (dev_attr.UCharSeq.operator->() != NULL)
+        att.value <<= dev_attr.UCharSeq.in();
+    else if (dev_attr.Long64Seq.operator->() != NULL)
+        att.value <<= dev_attr.Long64Seq.in();
+    else if (dev_attr.ULongSeq.operator->() != NULL)
+        att.value <<= dev_attr.ULongSeq.in();
+    else if (dev_attr.ULong64Seq.operator->() != NULL)
+        att.value <<= dev_attr.ULong64Seq.in();
+    else if (dev_attr.StateSeq.operator->() != NULL)
+        att.value <<= dev_attr.StateSeq.in();
+    else if (dev_attr.EncodedSeq.operator->() != NULL)
+    {
+        TangoSys_OMemStream desc;
+        desc << "Device " << d_name;
+        desc << " does not support DevEncoded data type" << ends;
+        ApiNonSuppExcept::throw_exception((const char *) API_UnsupportedFeature,
+                                          desc.str(),
+                                          (const char *) "DeviceProxy::device_to_attr");
+    }
 }
 
 //------------------------------------------------------------------------------------------------------------------
@@ -1298,92 +1301,92 @@ void ApiUtil::device_to_attr(const DeviceAttribute &dev_attr,AttributeValue &att
 //
 //------------------------------------------------------------------------------------------------------------------
 
-void ApiUtil::AttributeInfoEx_to_AttributeConfig(const AttributeInfoEx *aie,AttributeConfig_5 *att_conf_5)
+void ApiUtil::AttributeInfoEx_to_AttributeConfig(const AttributeInfoEx *aie, AttributeConfig_5 *att_conf_5)
 {
-	att_conf_5->name = aie->name.c_str();
-	att_conf_5->writable = aie->writable;
-	att_conf_5->data_format = aie->data_format;
-	att_conf_5->data_type = aie->data_type;
-	att_conf_5->max_dim_x = aie->max_dim_x;
-	att_conf_5->max_dim_y = aie->max_dim_y;
-	att_conf_5->description = aie->description.c_str();
-	att_conf_5->label = aie->label.c_str();
-	att_conf_5->unit = aie->unit.c_str();
-	att_conf_5->standard_unit = aie->standard_unit.c_str();
-	att_conf_5->display_unit = aie->display_unit.c_str();
-	att_conf_5->format = aie->format.c_str();
-	att_conf_5->min_value = aie->min_value.c_str();
-	att_conf_5->max_value = aie->max_value.c_str();
-	att_conf_5->writable_attr_name = aie->writable_attr_name.c_str();
-	att_conf_5->level = aie->disp_level;
-	att_conf_5->root_attr_name = aie->root_attr_name.c_str();
-	switch(aie->memorized)
-	{
-	case NOT_KNOWN:
-	case NONE:
-		att_conf_5->memorized = false;
-		att_conf_5->mem_init = false;
-		break;
+    att_conf_5->name = aie->name.c_str();
+    att_conf_5->writable = aie->writable;
+    att_conf_5->data_format = aie->data_format;
+    att_conf_5->data_type = aie->data_type;
+    att_conf_5->max_dim_x = aie->max_dim_x;
+    att_conf_5->max_dim_y = aie->max_dim_y;
+    att_conf_5->description = aie->description.c_str();
+    att_conf_5->label = aie->label.c_str();
+    att_conf_5->unit = aie->unit.c_str();
+    att_conf_5->standard_unit = aie->standard_unit.c_str();
+    att_conf_5->display_unit = aie->display_unit.c_str();
+    att_conf_5->format = aie->format.c_str();
+    att_conf_5->min_value = aie->min_value.c_str();
+    att_conf_5->max_value = aie->max_value.c_str();
+    att_conf_5->writable_attr_name = aie->writable_attr_name.c_str();
+    att_conf_5->level = aie->disp_level;
+    att_conf_5->root_attr_name = aie->root_attr_name.c_str();
+    switch (aie->memorized)
+    {
+        case NOT_KNOWN:
+        case NONE:
+            att_conf_5->memorized = false;
+            att_conf_5->mem_init = false;
+            break;
 
-	case MEMORIZED:
-		att_conf_5->memorized = true;
-		att_conf_5->mem_init = false;
-		break;
+        case MEMORIZED:
+            att_conf_5->memorized = true;
+            att_conf_5->mem_init = false;
+            break;
 
-	case MEMORIZED_WRITE_INIT:
-		att_conf_5->memorized = true;
-		att_conf_5->mem_init = true;
-		break;
+        case MEMORIZED_WRITE_INIT:
+            att_conf_5->memorized = true;
+            att_conf_5->mem_init = true;
+            break;
 
-	default:
-		break;
-	}
-	att_conf_5->enum_labels.length(aie->enum_labels.size());
-	for (size_t j=0; j<aie->enum_labels.size(); j++)
-	{
-		att_conf_5->enum_labels[j] = string_dup(aie->enum_labels[j].c_str());
-	}
-	att_conf_5->extensions.length(aie->extensions.size());
-	for (size_t j=0; j<aie->extensions.size(); j++)
-	{
-		att_conf_5->extensions[j] = string_dup(aie->extensions[j].c_str());
-	}
-	for (size_t j=0; j<aie->sys_extensions.size(); j++)
-	{
-		att_conf_5->sys_extensions[j] = string_dup(aie->sys_extensions[j].c_str());
-	}
+        default:
+            break;
+    }
+    att_conf_5->enum_labels.length(aie->enum_labels.size());
+    for (size_t j = 0; j < aie->enum_labels.size(); j++)
+    {
+        att_conf_5->enum_labels[j] = string_dup(aie->enum_labels[j].c_str());
+    }
+    att_conf_5->extensions.length(aie->extensions.size());
+    for (size_t j = 0; j < aie->extensions.size(); j++)
+    {
+        att_conf_5->extensions[j] = string_dup(aie->extensions[j].c_str());
+    }
+    for (size_t j = 0; j < aie->sys_extensions.size(); j++)
+    {
+        att_conf_5->sys_extensions[j] = string_dup(aie->sys_extensions[j].c_str());
+    }
 
-	att_conf_5->att_alarm.min_alarm = aie->alarms.min_alarm.c_str();
-	att_conf_5->att_alarm.max_alarm = aie->alarms.max_alarm.c_str();
-	att_conf_5->att_alarm.min_warning = aie->alarms.min_warning.c_str();
-	att_conf_5->att_alarm.max_warning = aie->alarms.max_warning.c_str();
-	att_conf_5->att_alarm.delta_t = aie->alarms.delta_t.c_str();
-	att_conf_5->att_alarm.delta_val = aie->alarms.delta_val.c_str();
-	for (size_t j=0; j<aie->alarms.extensions.size(); j++)
-	{
-		att_conf_5->att_alarm.extensions[j] = string_dup(aie->alarms.extensions[j].c_str());
-	}
+    att_conf_5->att_alarm.min_alarm = aie->alarms.min_alarm.c_str();
+    att_conf_5->att_alarm.max_alarm = aie->alarms.max_alarm.c_str();
+    att_conf_5->att_alarm.min_warning = aie->alarms.min_warning.c_str();
+    att_conf_5->att_alarm.max_warning = aie->alarms.max_warning.c_str();
+    att_conf_5->att_alarm.delta_t = aie->alarms.delta_t.c_str();
+    att_conf_5->att_alarm.delta_val = aie->alarms.delta_val.c_str();
+    for (size_t j = 0; j < aie->alarms.extensions.size(); j++)
+    {
+        att_conf_5->att_alarm.extensions[j] = string_dup(aie->alarms.extensions[j].c_str());
+    }
 
-	att_conf_5->event_prop.ch_event.rel_change = aie->events.ch_event.rel_change.c_str();
-	att_conf_5->event_prop.ch_event.abs_change = aie->events.ch_event.abs_change.c_str();
-	for (size_t j=0; j<aie->events.ch_event.extensions.size(); j++)
-	{
-		att_conf_5->event_prop.ch_event.extensions[j] = string_dup(aie->events.ch_event.extensions[j].c_str());
-	}
+    att_conf_5->event_prop.ch_event.rel_change = aie->events.ch_event.rel_change.c_str();
+    att_conf_5->event_prop.ch_event.abs_change = aie->events.ch_event.abs_change.c_str();
+    for (size_t j = 0; j < aie->events.ch_event.extensions.size(); j++)
+    {
+        att_conf_5->event_prop.ch_event.extensions[j] = string_dup(aie->events.ch_event.extensions[j].c_str());
+    }
 
-	att_conf_5->event_prop.per_event.period = aie->events.per_event.period.c_str();
-	for (size_t j=0; j<aie->events.per_event.extensions.size(); j++)
-	{
-		att_conf_5->event_prop.per_event.extensions[j] = string_dup(aie->events.per_event.extensions[j].c_str());
-	}
+    att_conf_5->event_prop.per_event.period = aie->events.per_event.period.c_str();
+    for (size_t j = 0; j < aie->events.per_event.extensions.size(); j++)
+    {
+        att_conf_5->event_prop.per_event.extensions[j] = string_dup(aie->events.per_event.extensions[j].c_str());
+    }
 
-	att_conf_5->event_prop.arch_event.rel_change = aie->events.arch_event.archive_rel_change.c_str();
-	att_conf_5->event_prop.arch_event.abs_change = aie->events.arch_event.archive_abs_change.c_str();
-	att_conf_5->event_prop.arch_event.period = aie->events.arch_event.archive_period.c_str();
-	for (size_t j=0; j<aie->events.ch_event.extensions.size(); j++)
-	{
-		att_conf_5->event_prop.arch_event.extensions[j] = string_dup(aie->events.arch_event.extensions[j].c_str());
-	}
+    att_conf_5->event_prop.arch_event.rel_change = aie->events.arch_event.archive_rel_change.c_str();
+    att_conf_5->event_prop.arch_event.abs_change = aie->events.arch_event.archive_abs_change.c_str();
+    att_conf_5->event_prop.arch_event.period = aie->events.arch_event.archive_period.c_str();
+    for (size_t j = 0; j < aie->events.ch_event.extensions.size(); j++)
+    {
+        att_conf_5->event_prop.arch_event.extensions[j] = string_dup(aie->events.arch_event.extensions[j].c_str());
+    }
 }
 
 
@@ -1406,10 +1409,10 @@ void ApiUtil::AttributeInfoEx_to_AttributeConfig(const AttributeInfoEx *aie,Attr
 //
 //----------------------------------------------------------------------------------------------------------------
 
-int ApiUtil::get_env_var(const char *env_var_name,string &env_var)
+int ApiUtil::get_env_var(const char *env_var_name, string &env_var)
 {
-	DummyDeviceProxy d;
-	return d.get_env_var(env_var_name,env_var);
+    DummyDeviceProxy d;
+    return d.get_env_var(env_var_name, env_var);
 }
 
 //---------------------------------------------------------------------------------------------------------------
@@ -1428,7 +1431,7 @@ int ApiUtil::get_env_var(const char *env_var_name,string &env_var)
 
 void ApiUtil::get_ip_from_if(vector<string> &ip_adr_list)
 {
-	omni_mutex_lock oml(lock_th_map);
+    omni_mutex_lock oml(lock_th_map);
 
     if (host_ip_adrs.empty() == true)
     {
@@ -1439,11 +1442,11 @@ void ApiUtil::get_ip_from_if(vector<string> &ip_adr_list)
 
         if (getifaddrs(&ifaddr) == -1)
         {
-            cerr << "ApiUtil::get_ip_from_if: getifaddrs() failed: "  << strerror(errno) << endl;
+            cerr << "ApiUtil::get_ip_from_if: getifaddrs() failed: " << strerror(errno) << endl;
 
-            Tango::Except::throw_exception((const char *)API_SystemCallFailed,
-                                            (const char *) strerror(errno),
-                                            (const char *)"ApiUtil::get_ip_from_if()");
+            Tango::Except::throw_exception((const char *) API_SystemCallFailed,
+                                           (const char *) strerror(errno),
+                                           (const char *) "ApiUtil::get_ip_from_if()");
         }
 
 //
@@ -1452,7 +1455,7 @@ void ApiUtil::get_ip_from_if(vector<string> &ip_adr_list)
 // of the address structure.)
 //
 
-        for (ifa = ifaddr;ifa != NULL;ifa = ifa->ifa_next)
+        for (ifa = ifaddr; ifa != NULL; ifa = ifa->ifa_next)
         {
             if (ifa->ifa_addr != NULL)
             {
@@ -1469,7 +1472,13 @@ void ApiUtil::get_ip_from_if(vector<string> &ip_adr_list)
 
                 if (family == AF_INET)
                 {
-                    s = getnameinfo(ifa->ifa_addr,sizeof(struct sockaddr_in),host,NI_MAXHOST,NULL,0,NI_NUMERICHOST);
+                    s = getnameinfo(ifa->ifa_addr,
+                                    sizeof(struct sockaddr_in),
+                                    host,
+                                    NI_MAXHOST,
+                                    NULL,
+                                    0,
+                                    NI_NUMERICHOST);
 
                     if (s != 0)
                     {
@@ -1478,9 +1487,9 @@ void ApiUtil::get_ip_from_if(vector<string> &ip_adr_list)
 
                         freeifaddrs(ifaddr);
 
-                        Tango::Except::throw_exception((const char *)API_SystemCallFailed,
-                                                        (const char *) gai_strerror(s),
-                                                        (const char *)"ApiUtil::get_ip_from_if()");
+                        Tango::Except::throw_exception((const char *) API_SystemCallFailed,
+                                                       (const char *) gai_strerror(s),
+                                                       (const char *) "ApiUtil::get_ip_from_if()");
                     }
                     else
                     {
@@ -1493,63 +1502,63 @@ void ApiUtil::get_ip_from_if(vector<string> &ip_adr_list)
         freeifaddrs(ifaddr);
 #else
 
-//
-// Get address from interfaces
-//
+        //
+        // Get address from interfaces
+        //
 
-		int sock = socket(AF_INET,SOCK_STREAM,0);
+                int sock = socket(AF_INET,SOCK_STREAM,0);
 
-		INTERFACE_INFO info[64];  // Assume max 64 interfaces
-		DWORD retlen;
+                INTERFACE_INFO info[64];  // Assume max 64 interfaces
+                DWORD retlen;
 
-		if ( WSAIoctl(sock, SIO_GET_INTERFACE_LIST, NULL,0,(LPVOID)&info, sizeof(info), (LPDWORD)&retlen,NULL,NULL) == SOCKET_ERROR )
-		{
-			closesocket(sock);
+                if ( WSAIoctl(sock, SIO_GET_INTERFACE_LIST, NULL,0,(LPVOID)&info, sizeof(info), (LPDWORD)&retlen,NULL,NULL) == SOCKET_ERROR )
+                {
+                    closesocket(sock);
 
-			int err = WSAGetLastError();
-			cerr << "Warning: WSAIoctl failed" << endl;
-			cerr << "Unable to obtain the list of all interface addresses. Error = " << err << endl;
+                    int err = WSAGetLastError();
+                    cerr << "Warning: WSAIoctl failed" << endl;
+                    cerr << "Unable to obtain the list of all interface addresses. Error = " << err << endl;
 
-			TangoSys_OMemStream desc;
-			desc << "Can't retrieve list of all interfaces addresses (WSAIoctl)! Error = " << err << ends;
+                    TangoSys_OMemStream desc;
+                    desc << "Can't retrieve list of all interfaces addresses (WSAIoctl)! Error = " << err << ends;
 
-			Tango::Except::throw_exception((const char*)API_SystemCallFailed,
-										   (const char *)desc.str().c_str(),
-										   (const char *)"ApiUtil::get_ip_from_if()");
-		}
-		closesocket(sock);
+                    Tango::Except::throw_exception((const char*)API_SystemCallFailed,
+                                                   (const char *)desc.str().c_str(),
+                                                   (const char *)"ApiUtil::get_ip_from_if()");
+                }
+                closesocket(sock);
 
-//
-// Converts addresses to string. Only for running interfaces
-//
+        //
+        // Converts addresses to string. Only for running interfaces
+        //
 
-		int numAddresses = retlen / sizeof(INTERFACE_INFO);
-		for (int i = 0; i < numAddresses; i++)
-		{
-			if (info[i].iiFlags & IFF_UP)
-			{
-				if (info[i].iiAddress.Address.sa_family == AF_INET || info[i].iiAddress.Address.sa_family == AF_INET6)
-				{
-					struct sockaddr* addr = (struct sockaddr*)&info[i].iiAddress.AddressIn;
-					char dest[NI_MAXHOST];
-					socklen_t addrlen = sizeof(sockaddr);
+                int numAddresses = retlen / sizeof(INTERFACE_INFO);
+                for (int i = 0; i < numAddresses; i++)
+                {
+                    if (info[i].iiFlags & IFF_UP)
+                    {
+                        if (info[i].iiAddress.Address.sa_family == AF_INET || info[i].iiAddress.Address.sa_family == AF_INET6)
+                        {
+                            struct sockaddr* addr = (struct sockaddr*)&info[i].iiAddress.AddressIn;
+                            char dest[NI_MAXHOST];
+                            socklen_t addrlen = sizeof(sockaddr);
 
-					int result = getnameinfo(addr, addrlen, dest, sizeof(dest),0,0,NI_NUMERICHOST);
-					if (result != 0)
-					{
-						cerr << "Warning: getnameinfo failed" << endl;
-						cerr << "Unable to convert IP address to string (getnameinfo)." << endl;
+                            int result = getnameinfo(addr, addrlen, dest, sizeof(dest),0,0,NI_NUMERICHOST);
+                            if (result != 0)
+                            {
+                                cerr << "Warning: getnameinfo failed" << endl;
+                                cerr << "Unable to convert IP address to string (getnameinfo)." << endl;
 
-						Tango::Except::throw_exception((const char *)API_SystemCallFailed,
-												   (const char *)"Can't convert IP address to string (getnameinfo)!",
-												   (const char *)"ApiUtil::get_ip_from_if()");
-					}
-					string tmp_str(dest);
-					if (tmp_str != "0.0.0.0" && tmp_str != "0:0:0:0:0:0:0:0" &&tmp_str != "::")
-						host_ip_adrs.push_back(tmp_str);
-				}
-			}
-		}
+                                Tango::Except::throw_exception((const char *)API_SystemCallFailed,
+                                                           (const char *)"Can't convert IP address to string (getnameinfo)!",
+                                                           (const char *)"ApiUtil::get_ip_from_if()");
+                            }
+                            string tmp_str(dest);
+                            if (tmp_str != "0.0.0.0" && tmp_str != "0:0:0:0:0:0:0:0" &&tmp_str != "::")
+                                host_ip_adrs.push_back(tmp_str);
+                        }
+                    }
+                }
 #endif
     }
 
@@ -1558,7 +1567,7 @@ void ApiUtil::get_ip_from_if(vector<string> &ip_adr_list)
 //
 
     ip_adr_list.clear();
-    copy(host_ip_adrs.begin(),host_ip_adrs.end(),back_inserter(ip_adr_list));
+    copy(host_ip_adrs.begin(), host_ip_adrs.end(), back_inserter(ip_adr_list));
 }
 
 //--------------------------------------------------------------------------------------------------------------------
@@ -1577,16 +1586,16 @@ void ApiUtil::get_ip_from_if(vector<string> &ip_adr_list)
 
 void ApiUtil::print_error_message(const char *mess)
 {
-	time_t tmp_val = time(NULL);
+    time_t tmp_val = time(NULL);
 
-	char tmp_date[128];
+    char tmp_date[128];
 #ifdef _TG_WINDOWS_
-	ctime_s(tmp_date,128,&tmp_val);
+    ctime_s(tmp_date,128,&tmp_val);
 #else
-	ctime_r(&tmp_val,tmp_date);
+    ctime_r(&tmp_val, tmp_date);
 #endif
-	tmp_date[strlen(tmp_date) - 1] = '\0';
-	cerr << tmp_date << ": " << mess << endl;
+    tmp_date[strlen(tmp_date) - 1] = '\0';
+    cerr << tmp_date << ": " << mess << endl;
 }
 
 //+-----------------------------------------------------------------------------------------------------------------
@@ -1599,7 +1608,7 @@ void ApiUtil::print_error_message(const char *mess)
 //
 //-----------------------------------------------------------------------------------------------------------------
 
-ostream &operator<<(ostream &o_str,AttributeInfo &p)
+ostream &operator<<(ostream &o_str, AttributeInfo &p)
 {
 
 
@@ -1607,83 +1616,83 @@ ostream &operator<<(ostream &o_str,AttributeInfo &p)
 // Print all these properties
 //
 
-	o_str << "Attribute name = " << p.name << endl;
-	o_str << "Attribute data_type = ";
-	switch (p.data_type)
-	{
-	case Tango::DEV_SHORT :
-		o_str << "Tango::DevShort" << endl;
-		break;
+    o_str << "Attribute name = " << p.name << endl;
+    o_str << "Attribute data_type = ";
+    switch (p.data_type)
+    {
+        case Tango::DEV_SHORT :
+            o_str << "Tango::DevShort" << endl;
+            break;
 
-	case Tango::DEV_LONG :
-		o_str << "Tango::DevLong" << endl;
-		break;
+        case Tango::DEV_LONG :
+            o_str << "Tango::DevLong" << endl;
+            break;
 
-	case Tango::DEV_DOUBLE :
-		o_str << "Tango::DevDouble" << endl;
-		break;
+        case Tango::DEV_DOUBLE :
+            o_str << "Tango::DevDouble" << endl;
+            break;
 
-	case Tango::DEV_STRING :
-		o_str << "Tango::DevString" << endl;
-		break;
+        case Tango::DEV_STRING :
+            o_str << "Tango::DevString" << endl;
+            break;
 
-	case Tango::DEV_FLOAT :
-		o_str << "Tango::DevFloat" << endl;
-		break;
+        case Tango::DEV_FLOAT :
+            o_str << "Tango::DevFloat" << endl;
+            break;
 
-	case Tango::DEV_USHORT :
-		o_str << "Tango::DevUShort" << endl;
-		break;
+        case Tango::DEV_USHORT :
+            o_str << "Tango::DevUShort" << endl;
+            break;
 
-	case Tango::DEV_UCHAR :
-		o_str << "Tango::DevUChar" << endl;
-		break;
+        case Tango::DEV_UCHAR :
+            o_str << "Tango::DevUChar" << endl;
+            break;
 
-	case Tango::DEV_BOOLEAN :
-		o_str << "Tango::DevBoolean" << endl;
-		break;
+        case Tango::DEV_BOOLEAN :
+            o_str << "Tango::DevBoolean" << endl;
+            break;
 
-	case Tango::DEV_STATE :
-		o_str << "Tango::DevState" << endl;
-		break;
-	}
+        case Tango::DEV_STATE :
+            o_str << "Tango::DevState" << endl;
+            break;
+    }
 
-	o_str << "Attribute data_format = ";
-	switch (p.data_format)
-	{
-	case Tango::FMT_UNKNOWN:
-		break;
+    o_str << "Attribute data_format = ";
+    switch (p.data_format)
+    {
+        case Tango::FMT_UNKNOWN:
+            break;
 
-	case Tango::SCALAR :
-		o_str << "scalar" << endl;
-		break;
+        case Tango::SCALAR :
+            o_str << "scalar" << endl;
+            break;
 
-	case Tango::SPECTRUM :
-		o_str << "spectrum, max_dim_x = " << p.max_dim_x << endl;
-		break;
+        case Tango::SPECTRUM :
+            o_str << "spectrum, max_dim_x = " << p.max_dim_x << endl;
+            break;
 
-	case Tango::IMAGE :
-		o_str << "image, max_dim_x = " << p.max_dim_x << ", max_dim_y = " << p.max_dim_y << endl;
-		break;
-	}
+        case Tango::IMAGE :
+            o_str << "image, max_dim_x = " << p.max_dim_x << ", max_dim_y = " << p.max_dim_y << endl;
+            break;
+    }
 
-	if ((p.writable == Tango::WRITE) || (p.writable == Tango::READ_WRITE))
-		o_str << "Attribute is writable" << endl;
-	else
-		o_str << "Attribute is not writable" << endl;
-	o_str << "Attribute label = " << p.label << endl;
-	o_str << "Attribute description = " << p.description << endl;
-	o_str << "Attribute unit = " << p.unit;
-	o_str << ", standard unit = " << p.standard_unit;
-	o_str << ", display unit = " << p.display_unit << endl;
-	o_str << "Attribute format = " << p.format << endl;
-	o_str << "Attribute min alarm = " << p.min_alarm << endl;
-	o_str << "Attribute max alarm = " << p.max_alarm << endl;
-	o_str << "Attribute min value = " << p.min_value << endl;
-	o_str << "Attribute max value = " << p.max_value << endl;
-	o_str << "Attribute writable_attr_name = " << p.writable_attr_name;
+    if ((p.writable == Tango::WRITE) || (p.writable == Tango::READ_WRITE))
+        o_str << "Attribute is writable" << endl;
+    else
+        o_str << "Attribute is not writable" << endl;
+    o_str << "Attribute label = " << p.label << endl;
+    o_str << "Attribute description = " << p.description << endl;
+    o_str << "Attribute unit = " << p.unit;
+    o_str << ", standard unit = " << p.standard_unit;
+    o_str << ", display unit = " << p.display_unit << endl;
+    o_str << "Attribute format = " << p.format << endl;
+    o_str << "Attribute min alarm = " << p.min_alarm << endl;
+    o_str << "Attribute max alarm = " << p.max_alarm << endl;
+    o_str << "Attribute min value = " << p.min_value << endl;
+    o_str << "Attribute max value = " << p.max_value << endl;
+    o_str << "Attribute writable_attr_name = " << p.writable_attr_name;
 
-	return o_str;
+    return o_str;
 }
 
 //+----------------------------------------------------------------------------------------------------------------
@@ -1698,31 +1707,31 @@ ostream &operator<<(ostream &o_str,AttributeInfo &p)
 
 AttributeInfoEx &AttributeInfoEx::operator=(const AttributeConfig_2 *att_2)
 {
-	name = att_2->name;
-	writable = att_2->writable;
-	data_format = att_2->data_format;
-	data_type = att_2->data_type;
-	max_dim_x = att_2->max_dim_x;
-	max_dim_y = att_2->max_dim_y;
-	description = att_2->description;
-	label = att_2->label;
-	unit = att_2->unit;
-	standard_unit = att_2->standard_unit;
-	display_unit = att_2->display_unit;
-	format = att_2->format;
-	min_value = att_2->min_value;
-	max_value = att_2->max_value;
-	min_alarm = att_2->min_alarm;
-	max_alarm = att_2->max_alarm;
-	writable_attr_name = att_2->writable_attr_name;
-	extensions.resize(att_2->extensions.length());
-	for (unsigned int j=0; j<att_2->extensions.length(); j++)
-	{
-		extensions[j] = att_2->extensions[j];
-	}
-	disp_level = att_2->level;
+    name = att_2->name;
+    writable = att_2->writable;
+    data_format = att_2->data_format;
+    data_type = att_2->data_type;
+    max_dim_x = att_2->max_dim_x;
+    max_dim_y = att_2->max_dim_y;
+    description = att_2->description;
+    label = att_2->label;
+    unit = att_2->unit;
+    standard_unit = att_2->standard_unit;
+    display_unit = att_2->display_unit;
+    format = att_2->format;
+    min_value = att_2->min_value;
+    max_value = att_2->max_value;
+    min_alarm = att_2->min_alarm;
+    max_alarm = att_2->max_alarm;
+    writable_attr_name = att_2->writable_attr_name;
+    extensions.resize(att_2->extensions.length());
+    for (unsigned int j = 0; j < att_2->extensions.length(); j++)
+    {
+        extensions[j] = att_2->extensions[j];
+    }
+    disp_level = att_2->level;
 
-	return *this;
+    return *this;
 }
 
 //+---------------------------------------------------------------------------------------------------------------
@@ -1737,67 +1746,67 @@ AttributeInfoEx &AttributeInfoEx::operator=(const AttributeConfig_2 *att_2)
 
 AttributeInfoEx &AttributeInfoEx::operator=(const AttributeConfig_3 *att_3)
 {
-	name = att_3->name;
-	writable = att_3->writable;
-	data_format = att_3->data_format;
-	data_type = att_3->data_type;
-	max_dim_x = att_3->max_dim_x;
-	max_dim_y = att_3->max_dim_y;
-	description = att_3->description;
-	label = att_3->label;
-	unit = att_3->unit;
-	standard_unit = att_3->standard_unit;
-	display_unit = att_3->display_unit;
-	format = att_3->format;
-	min_value = att_3->min_value;
-	max_value = att_3->max_value;
-	min_alarm = att_3->att_alarm.min_alarm;
-	max_alarm = att_3->att_alarm.max_alarm;
-	writable_attr_name = att_3->writable_attr_name;
-	extensions.resize(att_3->sys_extensions.length());
-	for (unsigned int j=0; j<att_3->sys_extensions.length(); j++)
-	{
-		extensions[j] = att_3->sys_extensions[j];
-	}
-	disp_level = att_3->level;
+    name = att_3->name;
+    writable = att_3->writable;
+    data_format = att_3->data_format;
+    data_type = att_3->data_type;
+    max_dim_x = att_3->max_dim_x;
+    max_dim_y = att_3->max_dim_y;
+    description = att_3->description;
+    label = att_3->label;
+    unit = att_3->unit;
+    standard_unit = att_3->standard_unit;
+    display_unit = att_3->display_unit;
+    format = att_3->format;
+    min_value = att_3->min_value;
+    max_value = att_3->max_value;
+    min_alarm = att_3->att_alarm.min_alarm;
+    max_alarm = att_3->att_alarm.max_alarm;
+    writable_attr_name = att_3->writable_attr_name;
+    extensions.resize(att_3->sys_extensions.length());
+    for (unsigned int j = 0; j < att_3->sys_extensions.length(); j++)
+    {
+        extensions[j] = att_3->sys_extensions[j];
+    }
+    disp_level = att_3->level;
 
-	alarms.min_alarm = att_3->att_alarm.min_alarm;
-	alarms.max_alarm = att_3->att_alarm.max_alarm;
-	alarms.min_warning = att_3->att_alarm.min_warning;
-	alarms.max_warning = att_3->att_alarm.max_warning;
-	alarms.delta_t = att_3->att_alarm.delta_t;
-	alarms.delta_val = att_3->att_alarm.delta_val;
-	alarms.extensions.resize(att_3->att_alarm.extensions.length());
-	for (unsigned int j=0; j<att_3->att_alarm.extensions.length(); j++)
-	{
-		alarms.extensions[j] = att_3->att_alarm.extensions[j];
-	}
+    alarms.min_alarm = att_3->att_alarm.min_alarm;
+    alarms.max_alarm = att_3->att_alarm.max_alarm;
+    alarms.min_warning = att_3->att_alarm.min_warning;
+    alarms.max_warning = att_3->att_alarm.max_warning;
+    alarms.delta_t = att_3->att_alarm.delta_t;
+    alarms.delta_val = att_3->att_alarm.delta_val;
+    alarms.extensions.resize(att_3->att_alarm.extensions.length());
+    for (unsigned int j = 0; j < att_3->att_alarm.extensions.length(); j++)
+    {
+        alarms.extensions[j] = att_3->att_alarm.extensions[j];
+    }
 
-	events.ch_event.abs_change = att_3->event_prop.ch_event.abs_change;
-	events.ch_event.rel_change = att_3->event_prop.ch_event.rel_change;
-	events.ch_event.extensions.resize(att_3->event_prop.ch_event.extensions.length());
-	for (unsigned int j=0; j<att_3->event_prop.ch_event.extensions.length(); j++)
-	{
-		events.ch_event.extensions[j] = att_3->event_prop.ch_event.extensions[j];
-	}
+    events.ch_event.abs_change = att_3->event_prop.ch_event.abs_change;
+    events.ch_event.rel_change = att_3->event_prop.ch_event.rel_change;
+    events.ch_event.extensions.resize(att_3->event_prop.ch_event.extensions.length());
+    for (unsigned int j = 0; j < att_3->event_prop.ch_event.extensions.length(); j++)
+    {
+        events.ch_event.extensions[j] = att_3->event_prop.ch_event.extensions[j];
+    }
 
-	events.per_event.period = att_3->event_prop.per_event.period;
-	events.per_event.extensions.resize(att_3->event_prop.per_event.extensions.length());
-	for (unsigned int j=0; j<att_3->event_prop.per_event.extensions.length(); j++)
-	{
-		events.per_event.extensions[j] = att_3->event_prop.per_event.extensions[j];
-	}
+    events.per_event.period = att_3->event_prop.per_event.period;
+    events.per_event.extensions.resize(att_3->event_prop.per_event.extensions.length());
+    for (unsigned int j = 0; j < att_3->event_prop.per_event.extensions.length(); j++)
+    {
+        events.per_event.extensions[j] = att_3->event_prop.per_event.extensions[j];
+    }
 
-	events.arch_event.archive_abs_change = att_3->event_prop.arch_event.abs_change;
-	events.arch_event.archive_rel_change = att_3->event_prop.arch_event.rel_change;
-	events.arch_event.archive_period = att_3->event_prop.arch_event.period;
-	events.arch_event.extensions.resize(att_3->event_prop.arch_event.extensions.length());
-	for (unsigned int j=0; j<att_3->event_prop.arch_event.extensions.length(); j++)
-	{
-		events.arch_event.extensions[j] = att_3->event_prop.arch_event.extensions[j];
-	}
+    events.arch_event.archive_abs_change = att_3->event_prop.arch_event.abs_change;
+    events.arch_event.archive_rel_change = att_3->event_prop.arch_event.rel_change;
+    events.arch_event.archive_period = att_3->event_prop.arch_event.period;
+    events.arch_event.extensions.resize(att_3->event_prop.arch_event.extensions.length());
+    for (unsigned int j = 0; j < att_3->event_prop.arch_event.extensions.length(); j++)
+    {
+        events.arch_event.extensions[j] = att_3->event_prop.arch_event.extensions[j];
+    }
 
-	return *this;
+    return *this;
 }
 
 //+---------------------------------------------------------------------------------------------------------------
@@ -1812,82 +1821,82 @@ AttributeInfoEx &AttributeInfoEx::operator=(const AttributeConfig_3 *att_3)
 
 AttributeInfoEx &AttributeInfoEx::operator=(const AttributeConfig_5 *att_5)
 {
-	name = att_5->name;
-	writable = att_5->writable;
-	data_format = att_5->data_format;
-	data_type = att_5->data_type;
-	max_dim_x = att_5->max_dim_x;
-	max_dim_y = att_5->max_dim_y;
-	description = att_5->description;
-	label = att_5->label;
-	unit = att_5->unit;
-	standard_unit = att_5->standard_unit;
-	display_unit = att_5->display_unit;
-	format = att_5->format;
-	min_value = att_5->min_value;
-	max_value = att_5->max_value;
-	min_alarm = att_5->att_alarm.min_alarm;
-	max_alarm = att_5->att_alarm.max_alarm;
-	writable_attr_name = att_5->writable_attr_name;
-	extensions.resize(att_5->sys_extensions.length());
-	for (unsigned int j=0; j<att_5->sys_extensions.length(); j++)
-	{
-		extensions[j] = att_5->sys_extensions[j];
-	}
-	disp_level = att_5->level;
-	root_attr_name = att_5->root_attr_name;
-	if (att_5->memorized == false)
-		memorized = NONE;
-	else
-	{
-		if (att_5->mem_init == false)
-			memorized = MEMORIZED;
-		else
-			memorized = MEMORIZED_WRITE_INIT;
-	}
-	enum_labels.clear();
-	for (unsigned int j=0; j<att_5->enum_labels.length(); j++)
-	{
-		enum_labels.push_back(att_5->enum_labels[j].in());
-	}
+    name = att_5->name;
+    writable = att_5->writable;
+    data_format = att_5->data_format;
+    data_type = att_5->data_type;
+    max_dim_x = att_5->max_dim_x;
+    max_dim_y = att_5->max_dim_y;
+    description = att_5->description;
+    label = att_5->label;
+    unit = att_5->unit;
+    standard_unit = att_5->standard_unit;
+    display_unit = att_5->display_unit;
+    format = att_5->format;
+    min_value = att_5->min_value;
+    max_value = att_5->max_value;
+    min_alarm = att_5->att_alarm.min_alarm;
+    max_alarm = att_5->att_alarm.max_alarm;
+    writable_attr_name = att_5->writable_attr_name;
+    extensions.resize(att_5->sys_extensions.length());
+    for (unsigned int j = 0; j < att_5->sys_extensions.length(); j++)
+    {
+        extensions[j] = att_5->sys_extensions[j];
+    }
+    disp_level = att_5->level;
+    root_attr_name = att_5->root_attr_name;
+    if (att_5->memorized == false)
+        memorized = NONE;
+    else
+    {
+        if (att_5->mem_init == false)
+            memorized = MEMORIZED;
+        else
+            memorized = MEMORIZED_WRITE_INIT;
+    }
+    enum_labels.clear();
+    for (unsigned int j = 0; j < att_5->enum_labels.length(); j++)
+    {
+        enum_labels.push_back(att_5->enum_labels[j].in());
+    }
 
-	alarms.min_alarm = att_5->att_alarm.min_alarm;
-	alarms.max_alarm = att_5->att_alarm.max_alarm;
-	alarms.min_warning = att_5->att_alarm.min_warning;
-	alarms.max_warning = att_5->att_alarm.max_warning;
-	alarms.delta_t = att_5->att_alarm.delta_t;
-	alarms.delta_val = att_5->att_alarm.delta_val;
-	alarms.extensions.resize(att_5->att_alarm.extensions.length());
-	for (unsigned int j=0; j<att_5->att_alarm.extensions.length(); j++)
-	{
-		alarms.extensions[j] = att_5->att_alarm.extensions[j];
-	}
+    alarms.min_alarm = att_5->att_alarm.min_alarm;
+    alarms.max_alarm = att_5->att_alarm.max_alarm;
+    alarms.min_warning = att_5->att_alarm.min_warning;
+    alarms.max_warning = att_5->att_alarm.max_warning;
+    alarms.delta_t = att_5->att_alarm.delta_t;
+    alarms.delta_val = att_5->att_alarm.delta_val;
+    alarms.extensions.resize(att_5->att_alarm.extensions.length());
+    for (unsigned int j = 0; j < att_5->att_alarm.extensions.length(); j++)
+    {
+        alarms.extensions[j] = att_5->att_alarm.extensions[j];
+    }
 
-	events.ch_event.abs_change = att_5->event_prop.ch_event.abs_change;
-	events.ch_event.rel_change = att_5->event_prop.ch_event.rel_change;
-	events.ch_event.extensions.resize(att_5->event_prop.ch_event.extensions.length());
-	for (unsigned int j=0; j<att_5->event_prop.ch_event.extensions.length(); j++)
-	{
-		events.ch_event.extensions[j] = att_5->event_prop.ch_event.extensions[j];
-	}
+    events.ch_event.abs_change = att_5->event_prop.ch_event.abs_change;
+    events.ch_event.rel_change = att_5->event_prop.ch_event.rel_change;
+    events.ch_event.extensions.resize(att_5->event_prop.ch_event.extensions.length());
+    for (unsigned int j = 0; j < att_5->event_prop.ch_event.extensions.length(); j++)
+    {
+        events.ch_event.extensions[j] = att_5->event_prop.ch_event.extensions[j];
+    }
 
-	events.per_event.period = att_5->event_prop.per_event.period;
-	events.per_event.extensions.resize(att_5->event_prop.per_event.extensions.length());
-	for (unsigned int j=0; j<att_5->event_prop.per_event.extensions.length(); j++)
-	{
-		events.per_event.extensions[j] = att_5->event_prop.per_event.extensions[j];
-	}
+    events.per_event.period = att_5->event_prop.per_event.period;
+    events.per_event.extensions.resize(att_5->event_prop.per_event.extensions.length());
+    for (unsigned int j = 0; j < att_5->event_prop.per_event.extensions.length(); j++)
+    {
+        events.per_event.extensions[j] = att_5->event_prop.per_event.extensions[j];
+    }
 
-	events.arch_event.archive_abs_change = att_5->event_prop.arch_event.abs_change;
-	events.arch_event.archive_rel_change = att_5->event_prop.arch_event.rel_change;
-	events.arch_event.archive_period = att_5->event_prop.arch_event.period;
-	events.arch_event.extensions.resize(att_5->event_prop.arch_event.extensions.length());
-	for (unsigned int j=0; j<att_5->event_prop.arch_event.extensions.length(); j++)
-	{
-		events.arch_event.extensions[j] = att_5->event_prop.arch_event.extensions[j];
-	}
+    events.arch_event.archive_abs_change = att_5->event_prop.arch_event.abs_change;
+    events.arch_event.archive_rel_change = att_5->event_prop.arch_event.rel_change;
+    events.arch_event.archive_period = att_5->event_prop.arch_event.period;
+    events.arch_event.extensions.resize(att_5->event_prop.arch_event.extensions.length());
+    for (unsigned int j = 0; j < att_5->event_prop.arch_event.extensions.length(); j++)
+    {
+        events.arch_event.extensions[j] = att_5->event_prop.arch_event.extensions[j];
+    }
 
-	return *this;
+    return *this;
 }
 
 //+----------------------------------------------------------------------------------------------------------------
@@ -1900,7 +1909,7 @@ AttributeInfoEx &AttributeInfoEx::operator=(const AttributeConfig_5 *att_5)
 //
 //-----------------------------------------------------------------------------------------------------------------
 
-ostream &operator<<(ostream &o_str,AttributeInfoEx &p)
+ostream &operator<<(ostream &o_str, AttributeInfoEx &p)
 {
 
 
@@ -1908,239 +1917,244 @@ ostream &operator<<(ostream &o_str,AttributeInfoEx &p)
 // Print all these properties
 //
 
-	o_str << "Attribute name = " << p.name << endl;
-	o_str << "Attribute data_type = ";
-	switch (p.data_type)
-	{
-	case Tango::DEV_SHORT :
-		o_str << "Tango::DevShort" << endl;
-		break;
+    o_str << "Attribute name = " << p.name << endl;
+    o_str << "Attribute data_type = ";
+    switch (p.data_type)
+    {
+        case Tango::DEV_SHORT :
+            o_str << "Tango::DevShort" << endl;
+            break;
 
-	case Tango::DEV_LONG :
-		o_str << "Tango::DevLong" << endl;
-		break;
+        case Tango::DEV_LONG :
+            o_str << "Tango::DevLong" << endl;
+            break;
 
-	case Tango::DEV_DOUBLE :
-		o_str << "Tango::DevDouble" << endl;
-		break;
+        case Tango::DEV_DOUBLE :
+            o_str << "Tango::DevDouble" << endl;
+            break;
 
-	case Tango::DEV_STRING :
-		o_str << "Tango::DevString" << endl;
-		break;
+        case Tango::DEV_STRING :
+            o_str << "Tango::DevString" << endl;
+            break;
 
-	case Tango::DEV_FLOAT :
-		o_str << "Tango::DevFloat" << endl;
-		break;
+        case Tango::DEV_FLOAT :
+            o_str << "Tango::DevFloat" << endl;
+            break;
 
-	case Tango::DEV_USHORT :
-		o_str << "Tango::DevUShort" << endl;
-		break;
+        case Tango::DEV_USHORT :
+            o_str << "Tango::DevUShort" << endl;
+            break;
 
-	case Tango::DEV_UCHAR :
-		o_str << "Tango::DevUChar" << endl;
-		break;
+        case Tango::DEV_UCHAR :
+            o_str << "Tango::DevUChar" << endl;
+            break;
 
-	case Tango::DEV_BOOLEAN :
-		o_str << "Tango::DevBoolean" << endl;
-		break;
+        case Tango::DEV_BOOLEAN :
+            o_str << "Tango::DevBoolean" << endl;
+            break;
 
-	case Tango::DEV_STATE :
-		o_str << "Tango::DevState" << endl;
-		break;
+        case Tango::DEV_STATE :
+            o_str << "Tango::DevState" << endl;
+            break;
 
-	case Tango::DEV_ULONG :
-		o_str << "Tango::DevULong" << endl;
-		break;
+        case Tango::DEV_ULONG :
+            o_str << "Tango::DevULong" << endl;
+            break;
 
-	case Tango::DEV_ULONG64 :
-		o_str << "Tango::DevULong64" << endl;
-		break;
+        case Tango::DEV_ULONG64 :
+            o_str << "Tango::DevULong64" << endl;
+            break;
 
-	case Tango::DEV_ENCODED :
-		o_str << "Tango::DevEncoded" << endl;
-		break;
+        case Tango::DEV_ENCODED :
+            o_str << "Tango::DevEncoded" << endl;
+            break;
 
-	case Tango::DEV_ENUM :
-		o_str << "Tango::DevEnum" << endl;
-		for (size_t loop = 0;loop < p.enum_labels.size();loop++)
-			o_str << "\tEnumeration label = " << p.enum_labels[loop] << endl;
-		break;
+        case Tango::DEV_ENUM :
+            o_str << "Tango::DevEnum" << endl;
+            for (size_t loop = 0; loop < p.enum_labels.size(); loop++)
+                o_str << "\tEnumeration label = " << p.enum_labels[loop] << endl;
+            break;
 
-	case Tango::DATA_TYPE_UNKNOWN :
-		o_str << "Unknown" << endl;
-		break;
-	}
+        case Tango::DATA_TYPE_UNKNOWN :
+            o_str << "Unknown" << endl;
+            break;
+    }
 
-	o_str << "Attribute data_format = ";
-	switch (p.data_format)
-	{
-	case Tango::FMT_UNKNOWN:
-		o_str << " Unknown" << endl;
-		break;
+    o_str << "Attribute data_format = ";
+    switch (p.data_format)
+    {
+        case Tango::FMT_UNKNOWN:
+            o_str << " Unknown" << endl;
+            break;
 
-	case Tango::SCALAR :
-		o_str << "scalar" << endl;
-		break;
+        case Tango::SCALAR :
+            o_str << "scalar" << endl;
+            break;
 
-	case Tango::SPECTRUM :
-		o_str << "spectrum, max_dim_x = " << p.max_dim_x << endl;
-		break;
+        case Tango::SPECTRUM :
+            o_str << "spectrum, max_dim_x = " << p.max_dim_x << endl;
+            break;
 
-	case Tango::IMAGE :
-		o_str << "image, max_dim_x = " << p.max_dim_x << ", max_dim_y = " << p.max_dim_y << endl;
-		break;
-	}
+        case Tango::IMAGE :
+            o_str << "image, max_dim_x = " << p.max_dim_x << ", max_dim_y = " << p.max_dim_y << endl;
+            break;
+    }
 
-	o_str << "Attribute writable type = ";
-	switch (p.writable)
-	{
-	case Tango::WRITE:
-		o_str << "Write" << endl;
-		break;
+    o_str << "Attribute writable type = ";
+    switch (p.writable)
+    {
+        case Tango::WRITE:
+            o_str << "Write" << endl;
+            break;
 
-	case Tango::READ:
-		o_str << "Read" << endl;
-		break;
+        case Tango::READ:
+            o_str << "Read" << endl;
+            break;
 
-	case Tango::READ_WRITE:
-		o_str << "Read/Write" << endl;
-		break;
+        case Tango::READ_WRITE:
+            o_str << "Read/Write" << endl;
+            break;
 
-	case Tango::READ_WITH_WRITE:
-		o_str << "Read with write" << endl;
-		break;
+        case Tango::READ_WITH_WRITE:
+            o_str << "Read with write" << endl;
+            break;
 
-	default:
-		break;
-	}
+        default:
+            break;
+    }
 
-	if ((p.writable == Tango::WRITE) || (p.writable == Tango::READ_WRITE))
-	{
-		switch(p.memorized)
-		{
-		case NOT_KNOWN:
-			o_str << "Device/Appli too old to send/receive attribute memorisation data" << endl;
-			break;
+    if ((p.writable == Tango::WRITE) || (p.writable == Tango::READ_WRITE))
+    {
+        switch (p.memorized)
+        {
+            case NOT_KNOWN:
+                o_str << "Device/Appli too old to send/receive attribute memorisation data" << endl;
+                break;
 
-		case NONE:
-			o_str << "Attribute is not memorized" << endl;
-			break;
+            case NONE:
+                o_str << "Attribute is not memorized" << endl;
+                break;
 
-		case MEMORIZED:
-			o_str << "Attribute is memorized" << endl;
-			break;
+            case MEMORIZED:
+                o_str << "Attribute is memorized" << endl;
+                break;
 
-		case MEMORIZED_WRITE_INIT:
-			o_str << "Attribute is memorized and the memorized value is written at initialisation" << endl;
-			break;
+            case MEMORIZED_WRITE_INIT:
+                o_str << "Attribute is memorized and the memorized value is written at initialisation" << endl;
+                break;
 
-		default:
-			break;
-		}
-	}
+            default:
+                break;
+        }
+    }
 
-	o_str << "Attribute display level = ";
-	switch(p.disp_level)
-	{
-	case DL_UNKNOWN :
-		o_str << "Unknown" << endl;
-		break;
+    o_str << "Attribute display level = ";
+    switch (p.disp_level)
+    {
+        case DL_UNKNOWN :
+            o_str << "Unknown" << endl;
+            break;
 
-	case OPERATOR:
-		o_str << "Operator" << endl;
-		break;
+        case OPERATOR:
+            o_str << "Operator" << endl;
+            break;
 
-	case EXPERT:
-		o_str << "Expert" << endl;
-		break;
+        case EXPERT:
+            o_str << "Expert" << endl;
+            break;
 
-	default:
-		break;
-	}
+        default:
+            break;
+    }
 
-	o_str << "Attribute writable_attr_name = " << p.writable_attr_name << endl;
-	if (p.root_attr_name.empty() == false)
-		o_str << "Root attribute name = " << p.root_attr_name << endl;
-	o_str << "Attribute label = " << p.label << endl;
-	o_str << "Attribute description = " << p.description << endl;
-	o_str << "Attribute unit = " << p.unit;
-	o_str << ", standard unit = " << p.standard_unit;
-	o_str << ", display unit = " << p.display_unit << endl;
-	o_str << "Attribute format = " << p.format << endl;
-	o_str << "Attribute min value = " << p.min_value << endl;
-	o_str << "Attribute max value = " << p.max_value << endl;
+    o_str << "Attribute writable_attr_name = " << p.writable_attr_name << endl;
+    if (p.root_attr_name.empty() == false)
+        o_str << "Root attribute name = " << p.root_attr_name << endl;
+    o_str << "Attribute label = " << p.label << endl;
+    o_str << "Attribute description = " << p.description << endl;
+    o_str << "Attribute unit = " << p.unit;
+    o_str << ", standard unit = " << p.standard_unit;
+    o_str << ", display unit = " << p.display_unit << endl;
+    o_str << "Attribute format = " << p.format << endl;
+    o_str << "Attribute min value = " << p.min_value << endl;
+    o_str << "Attribute max value = " << p.max_value << endl;
 
-	unsigned int i;
-	for (i = 0;i < p.extensions.size();i++)
-		o_str << "Attribute extensions " << i + 1 << " = " << p.extensions[i] << endl;
+    unsigned int i;
+    for (i = 0; i < p.extensions.size(); i++)
+        o_str << "Attribute extensions " << i + 1 << " = " << p.extensions[i] << endl;
 
-	o_str << "Attribute alarm : min alarm = ";
-	p.alarms.min_alarm.empty() == true ? o_str << "Not specified" : o_str << p.alarms.min_alarm;
-	o_str << endl;
+    o_str << "Attribute alarm : min alarm = ";
+    p.alarms.min_alarm.empty() == true ? o_str << "Not specified" : o_str << p.alarms.min_alarm;
+    o_str << endl;
 
-	o_str << "Attribute alarm : max alarm = ";
-	p.alarms.max_alarm.empty() == true ? o_str << "Not specified" : o_str << p.alarms.max_alarm;
-	o_str << endl;
+    o_str << "Attribute alarm : max alarm = ";
+    p.alarms.max_alarm.empty() == true ? o_str << "Not specified" : o_str << p.alarms.max_alarm;
+    o_str << endl;
 
-	o_str << "Attribute warning alarm : min warning = ";
-	p.alarms.min_warning.empty() == true ? o_str << "Not specified" : o_str << p.alarms.min_warning;
-	o_str << endl;
+    o_str << "Attribute warning alarm : min warning = ";
+    p.alarms.min_warning.empty() == true ? o_str << "Not specified" : o_str << p.alarms.min_warning;
+    o_str << endl;
 
-	o_str << "Attribute warning alarm : max warning = ";
-	p.alarms.max_warning.empty() == true ? o_str << "Not specified" : o_str << p.alarms.max_warning;
-	o_str << endl;
+    o_str << "Attribute warning alarm : max warning = ";
+    p.alarms.max_warning.empty() == true ? o_str << "Not specified" : o_str << p.alarms.max_warning;
+    o_str << endl;
 
-	o_str << "Attribute rds alarm : delta time = ";
-	p.alarms.delta_t.empty() == true ? o_str << "Not specified" : o_str << p.alarms.delta_t;
-	o_str << endl;
+    o_str << "Attribute rds alarm : delta time = ";
+    p.alarms.delta_t.empty() == true ? o_str << "Not specified" : o_str << p.alarms.delta_t;
+    o_str << endl;
 
-	o_str << "Attribute rds alarm : delta value = ";
-	p.alarms.delta_val.empty() == true ? o_str << "Not specified" : o_str << p.alarms.delta_val;
-	o_str << endl;
+    o_str << "Attribute rds alarm : delta value = ";
+    p.alarms.delta_val.empty() == true ? o_str << "Not specified" : o_str << p.alarms.delta_val;
+    o_str << endl;
 
-	for (i = 0;i < p.alarms.extensions.size();i++)
-		o_str << "Attribute alarm extensions " << i + 1 << " = " << p.alarms.extensions[i] << endl;
+    for (i = 0; i < p.alarms.extensions.size(); i++)
+        o_str << "Attribute alarm extensions " << i + 1 << " = " << p.alarms.extensions[i] << endl;
 
-	o_str << "Attribute event : change event absolute change = ";
-	p.events.ch_event.abs_change.empty() == true ? o_str << "Not specified" : o_str << p.events.ch_event.abs_change;
-	o_str << endl;
+    o_str << "Attribute event : change event absolute change = ";
+    p.events.ch_event.abs_change.empty() == true ? o_str << "Not specified" : o_str << p.events.ch_event.abs_change;
+    o_str << endl;
 
-	o_str << "Attribute event : change event relative change = ";
-	p.events.ch_event.rel_change.empty() == true ? o_str << "Not specified" : o_str << p.events.ch_event.rel_change;
-	o_str << endl;
+    o_str << "Attribute event : change event relative change = ";
+    p.events.ch_event.rel_change.empty() == true ? o_str << "Not specified" : o_str << p.events.ch_event.rel_change;
+    o_str << endl;
 
-	for (i = 0;i < p.events.ch_event.extensions.size();i++)
-		o_str << "Attribute alarm : change event extensions " << i + 1 << " = " << p.events.ch_event.extensions[i] << endl;
+    for (i = 0; i < p.events.ch_event.extensions.size(); i++)
+        o_str << "Attribute alarm : change event extensions " << i + 1 << " = " << p.events.ch_event.extensions[i]
+              << endl;
 
-	o_str << "Attribute event : periodic event period = ";
-	p.events.per_event.period.empty() == true ? o_str << "Not specified" : o_str << p.events.per_event.period;
-	o_str << endl;
+    o_str << "Attribute event : periodic event period = ";
+    p.events.per_event.period.empty() == true ? o_str << "Not specified" : o_str << p.events.per_event.period;
+    o_str << endl;
 
-	for (i = 0;i < p.events.per_event.extensions.size();i++)
-		o_str << "Attribute alarm : periodic event extensions " << i + 1 << " = " << p.events.per_event.extensions[i] << endl;
+    for (i = 0; i < p.events.per_event.extensions.size(); i++)
+        o_str << "Attribute alarm : periodic event extensions " << i + 1 << " = " << p.events.per_event.extensions[i]
+              << endl;
 
-	o_str << "Attribute event : archive event absolute change = ";
-	p.events.arch_event.archive_abs_change.empty() == true ? o_str << "Not specified" : o_str << p.events.arch_event.archive_abs_change;
-	o_str << endl;
+    o_str << "Attribute event : archive event absolute change = ";
+    p.events.arch_event.archive_abs_change.empty() == true ? o_str << "Not specified" : o_str
+        << p.events.arch_event.archive_abs_change;
+    o_str << endl;
 
-	o_str << "Attribute event : archive event relative change = ";
-	p.events.arch_event.archive_rel_change.empty() == true ? o_str << "Not specified" : o_str << p.events.arch_event.archive_rel_change;
-	o_str << endl;
+    o_str << "Attribute event : archive event relative change = ";
+    p.events.arch_event.archive_rel_change.empty() == true ? o_str << "Not specified" : o_str
+        << p.events.arch_event.archive_rel_change;
+    o_str << endl;
 
-	o_str << "Attribute event : archive event period = ";
-	p.events.arch_event.archive_period.empty() == true ? o_str << "Not specified" : o_str << p.events.arch_event.archive_period;
-	o_str << endl;
+    o_str << "Attribute event : archive event period = ";
+    p.events.arch_event.archive_period.empty() == true ? o_str << "Not specified" : o_str
+        << p.events.arch_event.archive_period;
+    o_str << endl;
 
-	for (i = 0;i < p.events.arch_event.extensions.size();i++)
-	{
-		if (i == 0)
-			o_str << endl;
-		o_str << "Attribute alarm : archive event extensions " << i + 1 << " = " << p.events.arch_event.extensions[i];
-		if (i != p.events.arch_event.extensions.size() - 1)
-			o_str << endl;
-	}
+    for (i = 0; i < p.events.arch_event.extensions.size(); i++)
+    {
+        if (i == 0)
+            o_str << endl;
+        o_str << "Attribute alarm : archive event extensions " << i + 1 << " = " << p.events.arch_event.extensions[i];
+        if (i != p.events.arch_event.extensions.size() - 1)
+            o_str << endl;
+    }
 
-	return o_str;
+    return o_str;
 }
 
 //+----------------------------------------------------------------------------------------------------------------
@@ -2153,51 +2167,51 @@ ostream &operator<<(ostream &o_str,AttributeInfoEx &p)
 //
 //-----------------------------------------------------------------------------------------------------------------
 
-ostream &operator<<(ostream &o_str,PipeInfo &p)
+ostream &operator<<(ostream &o_str, PipeInfo &p)
 {
 
 //
 // Print all these properties
 //
 
-	o_str << "Pipe name = " << p.name << endl;
-	o_str << "Pipe label = " << p.label << endl;
-	o_str << "Pipe description = " << p.description << endl;
+    o_str << "Pipe name = " << p.name << endl;
+    o_str << "Pipe label = " << p.label << endl;
+    o_str << "Pipe description = " << p.description << endl;
 
-	o_str << "Pipe writable type = ";
-	if (p.writable == PIPE_READ)
-		o_str << "READ" << endl;
-	else
-		o_str << "READ_WRITE" << endl;
+    o_str << "Pipe writable type = ";
+    if (p.writable == PIPE_READ)
+        o_str << "READ" << endl;
+    else
+        o_str << "READ_WRITE" << endl;
 
-	o_str << "Pipe display level = ";
-	switch(p.disp_level)
-	{
-	case DL_UNKNOWN :
-		o_str << "Unknown";
-		break;
+    o_str << "Pipe display level = ";
+    switch (p.disp_level)
+    {
+        case DL_UNKNOWN :
+            o_str << "Unknown";
+            break;
 
-	case OPERATOR:
-		o_str << "Operator";
-		break;
+        case OPERATOR:
+            o_str << "Operator";
+            break;
 
-	case EXPERT:
-		o_str << "Expert";
-		break;
+        case EXPERT:
+            o_str << "Expert";
+            break;
 
-	default:
-		break;
-	}
+        default:
+            break;
+    }
 
-	unsigned int i;
-	for (i = 0;i < p.extensions.size();i++)
-	{
-		if (i == 0)
-			o_str << endl;
-		o_str << "Pipe extensions " << i + 1 << " = " << p.extensions[i] << endl;
-	}
+    unsigned int i;
+    for (i = 0; i < p.extensions.size(); i++)
+    {
+        if (i == 0)
+            o_str << endl;
+        o_str << "Pipe extensions " << i + 1 << " = " << p.extensions[i] << endl;
+    }
 
-	return o_str;
+    return o_str;
 }
 
 } // End of tango namespace

--- a/cppapi/client/dbapi_base.cpp
+++ b/cppapi/client/dbapi_base.cpp
@@ -365,12 +365,12 @@ Database::Database(const Database &sou):Connection(sou),ext(Tango_nullptr)
         filedb = Tango_nullptr;
     else
         filedb = new FileDatabase(file_name);
-	serv_version = sou.serv_version;
+    serv_version = sou.serv_version;
 
     if (sou.access_proxy == Tango_nullptr)
-        access_proxy = Tango_nullptr;
+		access_proxy = Tango_nullptr;
     else
-        access_proxy = new AccessProxy(sou.access_proxy->name().c_str());
+		access_proxy = new AccessProxy(sou.access_proxy->name().c_str());
 	access_checked = sou.access_checked;
 	access_except_errors = sou.access_except_errors;
 

--- a/cppapi/client/dbapi_cache.cpp
+++ b/cppapi/client/dbapi_cache.cpp
@@ -897,7 +897,7 @@ int DbServerCache::find_obj(DevString obj_name,int &obj_ind)
 {
 
     if (ctrl_serv_prop.first_idx == -1)
-        return -1;
+		return -1;
 
 	if (TG_strcasecmp((*data_list)[ctrl_serv_prop.first_idx],obj_name) == 0)
 	{

--- a/cppapi/client/devapi_attr.cpp
+++ b/cppapi/client/devapi_attr.cpp
@@ -536,7 +536,7 @@ DeviceAttribute & DeviceAttribute::operator=(DeviceAttribute &&rval)
         ext = move(rval.ext);
     }
     else
-        ext.reset();
+		ext.reset();
 
 	return *this;
 }

--- a/cppapi/client/devapi_base.cpp
+++ b/cppapi/client/devapi_base.cpp
@@ -100,14 +100,20 @@ Connection::Connection(ORB *orb_in)
     if ((orb_in == NULL) && (CORBA::is_nil(au->get_orb()) == true))
     {
         if (au->in_server() == true)
+        {
             ApiUtil::instance()->set_orb(Util::instance()->get_orb());
+        }
         else
+        {
             ApiUtil::instance()->create_orb();
+        }
     }
     else
     {
         if (orb_in != NULL)
+        {
             au->set_orb(orb_in);
+        }
     }
 
 //
@@ -116,7 +122,9 @@ Connection::Connection(ORB *orb_in)
 
     int ucto = au->get_user_connect_timeout();
     if (ucto != -1)
+    {
         user_connect_timeout = ucto;
+    }
 }
 
 Connection::Connection(bool dummy)
@@ -171,7 +179,9 @@ Connection::Connection(const Connection &sou)
 
     device = sou.device;
     if (sou.version >= 2)
+    {
         device_2 = sou.device_2;
+    }
 
     timeout = sou.timeout;
     connection_state = sou.connection_state;
@@ -235,7 +245,9 @@ Connection &Connection::operator=(const Connection &rval)
 
     device = rval.device;
     if (rval.version >= 2)
+    {
         device_2 = rval.device_2;
+    }
 
     timeout = rval.timeout;
     connection_state = rval.connection_state;
@@ -265,7 +277,9 @@ Connection &Connection::operator=(const Connection &rval)
         *(ext.get()) = *(rval.ext.get());
     }
     else
+    {
         ext.reset(Tango_nullptr);
+    }
 #else
                                                                                                                             if (rval.ext != NULL)
 	{
@@ -301,7 +315,9 @@ void Connection::check_and_reconnect()
     {
         WriterLock guard(con_to_mon);
         if (connection_state != CONNECTION_OK)
+        {
             reconnect(dbase_used);
+        }
     }
 }
 
@@ -317,7 +333,9 @@ void Connection::check_and_reconnect(Tango::DevSource &sou)
     {
         WriterLock guard(con_to_mon);
         if (connection_state != CONNECTION_OK)
+        {
             reconnect(dbase_used);
+        }
     }
 }
 
@@ -415,14 +433,20 @@ void Connection::connect(string &corba_name)
 //
 
             if (corba_name.find(DbObjName) != string::npos)
+            {
                 connect_to_db = true;
+            }
 
             if (connect_to_db == false)
             {
                 if (user_connect_timeout != -1)
+                {
                     omniORB::setClientConnectTimeout(user_connect_timeout);
+                }
                 else
+                {
                     omniORB::setClientConnectTimeout(NARROW_CLNT_TIMEOUT);
+                }
             }
 
             device_5 = Device_5::_narrow(obj);
@@ -517,7 +541,9 @@ void Connection::connect(string &corba_name)
                         break;
                     }
                     else
+                    {
                         ext->has_alt_adr = false;
+                    }
                 }
             }
 
@@ -532,7 +558,9 @@ void Connection::connect(string &corba_name)
 
             connection_state = CONNECTION_OK;
             if (timeout != CLNT_TIMEOUT)
+            {
                 set_timeout_millis(timeout);
+            }
         }
         catch (CORBA::SystemException &ce)
         {
@@ -568,17 +596,25 @@ void Connection::connect(string &corba_name)
                             reason << "API_CantConnectToDatabase" << ends;
                             db_retries--;
                             if (db_retries != 0)
+                            {
                                 db_connect = true;
+                            }
                         }
                         else
                         {
                             desc << "device " << dev_name() << ends;
                             if (CORBA::OBJECT_NOT_EXIST::_downcast(&ce) != 0)
+                            {
                                 reason << "API_DeviceNotDefined" << ends;
+                            }
                             else if (CORBA::TRANSIENT::_downcast(&ce) != 0)
+                            {
                                 reason << "API_ServerNotRunning" << ends;
+                            }
                             else
+                            {
                                 reason << API_CantConnectToDevice << ends;
+                            }
                         }
                     }
                     else
@@ -616,13 +652,17 @@ void Connection::toIOR(const char *iorstr, IOP::IOR &ior)
 {
     size_t s = (iorstr ? strlen(iorstr) : 0);
     if (s < 4)
+    {
         throw CORBA::MARSHAL(0, CORBA::COMPLETED_NO);
+    }
     const char *p = iorstr;
     if (p[0] != 'I' ||
         p[1] != 'O' ||
         p[2] != 'R' ||
         p[3] != ':')
+    {
         throw CORBA::MARSHAL(0, CORBA::COMPLETED_NO);
+    }
 
     s = (s - 4) / 2;  // how many octets are there in the string
     p += 4;
@@ -647,7 +687,9 @@ void Connection::toIOR(const char *iorstr, IOP::IOR &ior)
             v = ((p[j] - 'A' + 10) << 4);
         }
         else
+        {
             throw CORBA::MARSHAL(0, CORBA::COMPLETED_NO);
+        }
 
         if (p[j + 1] >= '0' && p[j + 1] <= '9')
         {
@@ -662,7 +704,9 @@ void Connection::toIOR(const char *iorstr, IOP::IOR &ior)
             v += (p[j + 1] - 'A' + 10);
         }
         else
+        {
             throw CORBA::MARSHAL(0, CORBA::COMPLETED_NO);
+        }
 
         buf.marshalOctet(v);
     }
@@ -726,14 +770,20 @@ void Connection::reconnect(bool db_used)
                     ApiUtil *au = ApiUtil::instance();
                     int db_num;
                     if (get_from_env_var() == true)
+                    {
                         db_num = au->get_db_ind();
+                    }
                     else
+                    {
                         db_num = au->get_db_ind(get_db_host(), get_db_port_num());
+                    }
                     (au->get_db_vect())[db_num]->clear_access_except_errors();
                 }
             }
             else
+            {
                 corba_name = build_corba_name();
+            }
 
             connect(corba_name);
         }
@@ -805,7 +855,9 @@ bool Connection::is_connected()
     bool connected = true;
     ReaderLock guard(con_to_mon);
     if (connection_state != CONNECTION_OK)
+    {
         connected = false;
+    }
     return connected;
 }
 
@@ -959,7 +1011,9 @@ int Connection::get_env_var_from_file(string &f_name, const char *env_var, strin
         {
             pos_comment = file_line.find('#');
             if ((pos_comment != string::npos) && (pos_comment < pos_env))
+            {
                 continue;
+            }
 
             string::size_type pos;
             if ((pos = file_line.find('=')) != string::npos)
@@ -1007,7 +1061,9 @@ void Connection::get_fqdn(string &the_host)
     if (gethostname(buffer, 80) == 0)
     {
         if (::strcmp(buffer, the_host.c_str()) == 0)
+        {
             local_host = true;
+        }
     }
 
     struct addrinfo hints;
@@ -1035,7 +1091,9 @@ void Connection::get_fqdn(string &the_host)
         hints.ai_flags |= AI_NUMERICHOST;
     }
     else
+    {
         ip_list.push_back(the_host);
+    }
 
 //
 // Try to get FQDN
@@ -1111,7 +1169,9 @@ void Connection::set_timeout_millis(int millisecs)
     try
     {
         if (connection_state != CONNECTION_OK)
+        {
             reconnect(dbase_used);
+        }
 
         omniORB::setClientCallTimeout(device, millisecs);
 
@@ -1203,15 +1263,21 @@ DeviceData Connection::command_inout(string &command, DeviceData &data_in)
                 vector<Database *> &v_d = au->get_db_vect();
                 Database *db;
                 if (v_d.empty() == true)
+                {
                     db = static_cast<Database *>(this);
+                }
                 else
                 {
                     int db_num;
 
                     if (get_from_env_var() == true)
+                    {
                         db_num = au->get_db_ind();
+                    }
                     else
+                    {
                         db_num = au->get_db_ind(get_db_host(), get_db_port_num());
+                    }
                     db = v_d[db_num];
 /*					if (db->is_control_access_checked() == false)
 						db = static_cast<Database *>(this);*/
@@ -1250,7 +1316,9 @@ DeviceData Connection::command_inout(string &command, DeviceData &data_in)
 
                     TangoSys_OMemStream desc;
                     if (e.length() == 0)
+                    {
                         desc << "Command " << command << " on device " << dev_name() << " is not authorized" << ends;
+                    }
                     else
                     {
                         desc << "Command " << command << " on device " << dev_name()
@@ -1258,7 +1326,9 @@ DeviceData Connection::command_inout(string &command, DeviceData &data_in)
                              << ends;
                         string ex(e[0].desc);
                         if (ex.find("defined") != string::npos)
+                        {
                             desc << "\n" << ex;
+                        }
                         desc << ends;
                     }
 
@@ -1310,11 +1380,15 @@ DeviceData Connection::command_inout(string &command, DeviceData &data_in)
             desc << ", command " << command << ends;
 
             if (::strcmp(e.errors[0].reason, DEVICE_UNLOCKED_REASON) == 0)
+            {
                 DeviceUnlockedExcept::re_throw_exception(e, (const char *) DEVICE_UNLOCKED_REASON,
                                                          desc.str(), (const char *) "Connection::command_inout()");
+            }
             else
+            {
                 Except::re_throw_exception(e, (const char *) API_CommandFailed,
                                            desc.str(), (const char *) "Connection::command_inout()");
+            }
         }
         catch (CORBA::TRANSIENT &trans)
         {
@@ -1406,15 +1480,21 @@ CORBA::Any_var Connection::command_inout(string &command, CORBA::Any &any)
                 vector<Database *> &v_d = au->get_db_vect();
                 Database *db;
                 if (v_d.empty() == true)
+                {
                     db = static_cast<Database *>(this);
+                }
                 else
                 {
                     int db_num;
 
                     if (get_from_env_var() == true)
+                    {
                         db_num = au->get_db_ind();
+                    }
                     else
+                    {
                         db_num = au->get_db_ind(get_db_host(), get_db_port_num());
+                    }
                     db = v_d[db_num];
 /*					if (db->is_control_access_checked() == false)
 						db = static_cast<Database *>(this);*/
@@ -1452,7 +1532,9 @@ CORBA::Any_var Connection::command_inout(string &command, CORBA::Any &any)
 
                     TangoSys_OMemStream desc;
                     if (e.length() == 0)
+                    {
                         desc << "Command " << command << " on device " << dev_name() << " is not authorized" << ends;
+                    }
                     else
                     {
                         desc << "Command " << command << " on device " << dev_name()
@@ -1460,7 +1542,9 @@ CORBA::Any_var Connection::command_inout(string &command, CORBA::Any &any)
                              << ends;
                         string ex(e[0].desc);
                         if (ex.find("defined") != string::npos)
+                        {
                             desc << "\n" << ex;
+                        }
                         desc << ends;
                     }
 
@@ -1505,11 +1589,15 @@ CORBA::Any_var Connection::command_inout(string &command, CORBA::Any &any)
             desc << ", command " << command << ends;
 
             if (::strcmp(e.errors[0].reason, DEVICE_UNLOCKED_REASON) == 0)
+            {
                 DeviceUnlockedExcept::re_throw_exception(e, (const char *) DEVICE_UNLOCKED_REASON,
                                                          desc.str(), (const char *) "Connection::command_inout()");
+            }
             else
+            {
                 Except::re_throw_exception(e, (const char *) API_CommandFailed,
                                            desc.str(), (const char *) "Connection::command_inout()");
+            }
         }
         catch (CORBA::TRANSIENT &trans)
         {
@@ -1694,7 +1782,9 @@ void DeviceProxy::real_constructor(string &name, bool need_check_acc)
                                                   (const char *) "DeviceProxy::DeviceProxy");
             }
             else if (strcmp(dfe.errors[0].reason, API_DeviceNotExported) == 0)
+            {
                 exported = false;
+            }
         }
     }
     else
@@ -1735,14 +1825,18 @@ void DeviceProxy::real_constructor(string &name, bool need_check_acc)
         if (dbase_used == false)
         {
             if (strcmp(dfe.errors[1].reason, "API_DeviceNotDefined") == 0)
+            {
                 throw;
+            }
         }
     }
     catch (CORBA::SystemException &)
     {
         set_connection_state(CONNECTION_NOTOK);
         if (dbase_used == false)
+        {
             throw;
+        }
     }
 
 //
@@ -1759,7 +1853,9 @@ void DeviceProxy::real_constructor(string &name, bool need_check_acc)
         catch (Tango::ConnectionFailed &dfe)
         {
             if (strcmp(dfe.errors[1].reason, "API_DeviceNotDefined") == 0)
+            {
                 throw;
+            }
         }
     }
 
@@ -1780,7 +1876,9 @@ void DeviceProxy::real_constructor(string &name, bool need_check_acc)
     catch (Tango::DevFailed &e)
     {
         if (::strcmp(e.errors[0].reason.in(), "API_UtilSingletonNotCreated") != 0)
+        {
             throw;
+        }
     }
 
     return;
@@ -1812,9 +1910,13 @@ DeviceProxy::DeviceProxy(const DeviceProxy &sou)
         {
             ApiUtil *ui = ApiUtil::instance();
             if (ui->in_server() == true)
+            {
                 db_dev = new DbDevice(device_name, Tango::Util::instance()->get_database());
+            }
             else
+            {
                 db_dev = new DbDevice(device_name);
+            }
         }
         else
         {
@@ -1827,7 +1929,9 @@ DeviceProxy::DeviceProxy(const DeviceProxy &sou)
 //
 
     if (sou.adm_device == NULL)
+    {
         adm_device = NULL;
+    }
     else
     {
         adm_device = new DeviceProxy(sou.adm_device->dev_name().c_str());
@@ -1886,9 +1990,13 @@ DeviceProxy &DeviceProxy::operator=(const DeviceProxy &rval)
             {
                 ApiUtil *ui = ApiUtil::instance();
                 if (ui->in_server() == true)
+                {
                     db_dev = new DbDevice(device_name, Tango::Util::instance()->get_database());
+                }
                 else
+                {
                     db_dev = new DbDevice(device_name);
+                }
             }
             else
             {
@@ -1903,7 +2011,9 @@ DeviceProxy &DeviceProxy::operator=(const DeviceProxy &rval)
             adm_device = new DeviceProxy(rval.adm_device->dev_name().c_str());
         }
         else
+        {
             adm_device = NULL;
+        }
 
 #ifdef HAS_UNIQUE_PTR
         if (rval.ext_proxy.get() != NULL)
@@ -1912,9 +2022,11 @@ DeviceProxy &DeviceProxy::operator=(const DeviceProxy &rval)
             *(ext_proxy.get()) = *(rval.ext_proxy.get());
         }
         else
+        {
             ext_proxy.reset();
+        }
 #else
-                                                                                                                                delete ext_proxy;
+        delete ext_proxy;
         if (rval.ext_proxy != NULL)
         {
             ext_proxy = new DeviceProxyExt;
@@ -1975,12 +2087,18 @@ void DeviceProxy::parse_name(string &full_name)
         if (full_name_low.size() > 2)
         {
             if ((full_name_low[0] == '/') && (full_name_low[1] == '/'))
+            {
                 name_wo_prot = full_name_low.substr(2);
+            }
             else
+            {
                 name_wo_prot = full_name_low;
+            }
         }
         else
+        {
             name_wo_prot = full_name_low;
+        }
     }
     else
     {
@@ -2235,7 +2353,9 @@ void DeviceProxy::parse_name(string &full_name)
                 string safe_tmp_host(tmp_host);
 
                 if (tmp_host.find('.') == string::npos)
+                {
                     get_fqdn(tmp_host);
+                }
 
                 string::size_type pos2 = tmp_host.find('.');
                 bool alias_used = false;
@@ -2245,7 +2365,9 @@ void DeviceProxy::parse_name(string &full_name)
                     string h_name = tmp_host.substr(0, pos2);
                     fq = tmp_host.substr(pos2);
                     if (h_name != tmp_host)
+                    {
                         alias_used = true;
+                    }
                 }
 
                 if (alias_used == true)
@@ -2253,10 +2375,14 @@ void DeviceProxy::parse_name(string &full_name)
                     ext_proxy->nethost_alias = true;
                     ext_proxy->orig_tango_host = safe_tmp_host;
                     if (safe_tmp_host.find('.') == string::npos)
+                    {
                         ext_proxy->orig_tango_host = ext_proxy->orig_tango_host + fq;
+                    }
                 }
                 else
+                {
                     ext_proxy->nethost_alias = false;
+                }
 
                 db_host = tmp_host;
                 db_port = bef_sep.substr(tmp + 1);
@@ -2368,7 +2494,9 @@ string DeviceProxy::get_corba_name(bool need_check_acc)
 
     string local_ior;
     if (ApiUtil::instance()->in_server() == true)
+    {
         local_import(local_ior);
+    }
 
 //
 // If we are not in a server or if the device is not in the same process,
@@ -2397,14 +2525,22 @@ string DeviceProxy::get_corba_name(bool need_check_acc)
 //
 
     if (need_check_acc == true)
+    {
         access = db_dev->check_access_control();
+    }
     else
+    {
         check_acc = false;
+    }
 
     if (local_ior.size() != 0)
+    {
         return local_ior;
+    }
     else
+    {
         return import_info.ior;
+    }
 }
 
 //-----------------------------------------------------------------------------
@@ -2488,7 +2624,9 @@ DbDevImportInfo DeviceProxy::import_info()
 DeviceProxy::~DeviceProxy()
 {
     if (dbase_used == true)
+    {
         delete db_dev;
+    }
 
 //
 // If the device has some subscribed event, unsubscribe them
@@ -2726,7 +2864,9 @@ string DeviceProxy::alias()
     {
         Database *db = this->get_device_db();
         if (db != NULL)
+        {
             db->get_alias(device_name, alias_name);
+        }
         else
         {
             Tango::Except::throw_exception((const char *) "DB_AliasNotDefined",
@@ -2915,7 +3055,9 @@ string DeviceProxy::adm_name()
             {
                 string prot("tango://");
                 if (host.find('.') == string::npos)
+                {
                     Connection::get_fqdn(host);
+                }
                 prot = prot + host + ':' + port + '/';
                 adm_name_str.insert(0, prot);
                 adm_name_str.append(MODIFIER_DBASE_NO);
@@ -3356,7 +3498,9 @@ CommandInfoList *DeviceProxy::get_command_config(vector<string> &cmd_names)
 //
 
     if (cmd_names.size() == 1 && cmd_names[0] == AllCmd)
+    {
         return all_cmds;
+    }
 
 //
 // Return only the required commands config
@@ -3789,19 +3933,29 @@ AttributeInfoList *DeviceProxy::get_attribute_config(vector<string> &attr_string
         if (attr_string_list[i] == AllAttr)
         {
             if (version >= 3)
+            {
                 attr_list[i] = string_dup(AllAttr_3);
+            }
             else
+            {
                 attr_list[i] = string_dup(AllAttr);
+            }
         }
         else if (attr_string_list[i] == AllAttr_3)
         {
             if (version < 3)
+            {
                 attr_list[i] = string_dup(AllAttr);
+            }
             else
+            {
                 attr_list[i] = string_dup(AllAttr_3);
+            }
         }
         else
+        {
             attr_list[i] = string_dup(attr_string_list[i].c_str());
+        }
     }
 
     while (ctr < 2)
@@ -3961,19 +4115,29 @@ AttributeInfoListEx *DeviceProxy::get_attribute_config_ex(vector<string> &attr_s
         if (attr_string_list[i] == AllAttr)
         {
             if (version >= 3)
+            {
                 attr_list[i] = string_dup(AllAttr_3);
+            }
             else
+            {
                 attr_list[i] = string_dup(AllAttr);
+            }
         }
         else if (attr_string_list[i] == AllAttr_3)
         {
             if (version < 3)
+            {
                 attr_list[i] = string_dup(AllAttr);
+            }
             else
+            {
                 attr_list[i] = string_dup(AllAttr_3);
+            }
         }
         else
+        {
             attr_list[i] = string_dup(attr_string_list[i].c_str());
+        }
     }
 
     while (ctr < 2)
@@ -4065,19 +4229,27 @@ AttributeInfoListEx *DeviceProxy::get_attribute_config_ex(vector<string> &attr_s
                         (*dev_attr_config)[i].max_alarm = attr_config_list_5[i].att_alarm.max_alarm;
                         (*dev_attr_config)[i].root_attr_name = attr_config_list_5[i].root_attr_name;
                         if (attr_config_list_5[i].memorized == false)
+                        {
                             (*dev_attr_config)[i].memorized = NONE;
+                        }
                         else
                         {
                             if (attr_config_list_5[i].mem_init == false)
+                            {
                                 (*dev_attr_config)[i].memorized = MEMORIZED;
+                            }
                             else
+                            {
                                 (*dev_attr_config)[i].memorized = MEMORIZED_WRITE_INIT;
+                            }
                         }
                         if (attr_config_list_5[i].data_type == DEV_ENUM)
                         {
                             for (size_t loop = 0; loop < attr_config_list_5[i].enum_labels.length(); loop++)
+                            {
                                 (*dev_attr_config)[i].enum_labels
                                     .push_back(attr_config_list_5[i].enum_labels[loop].in());
+                            }
                         }
                         COPY_ALARM_CONFIG((*dev_attr_config), attr_config_list_5)
 
@@ -4256,7 +4428,9 @@ void DeviceProxy::get_remaining_param(AttributeInfoListEx *dev_attr_config)
                     prop_value = tmp[0] + ", " + tmp[1];
                 }
                 else
+                {
                     db_data_class[i] >> prop_value;
+                }
                 i++;
 
 //
@@ -4268,25 +4442,45 @@ void DeviceProxy::get_remaining_param(AttributeInfoListEx *dev_attr_config)
                     if ((*dev_attr_config)[k].name == att_name)
                     {
                         if (prop_name == "min_warning")
+                        {
                             (*dev_attr_config)[k].alarms.min_warning = prop_value;
+                        }
                         else if (prop_name == "max_warning")
+                        {
                             (*dev_attr_config)[k].alarms.max_warning = prop_value;
+                        }
                         else if (prop_name == "delta_t")
+                        {
                             (*dev_attr_config)[k].alarms.delta_t = prop_value;
+                        }
                         else if (prop_name == "delta_val")
+                        {
                             (*dev_attr_config)[k].alarms.delta_val = prop_value;
+                        }
                         else if (prop_name == "abs_change")
+                        {
                             (*dev_attr_config)[k].events.ch_event.abs_change = prop_value;
+                        }
                         else if (prop_name == "rel_change")
+                        {
                             (*dev_attr_config)[k].events.ch_event.rel_change = prop_value;
+                        }
                         else if (prop_name == "period")
+                        {
                             (*dev_attr_config)[k].events.per_event.period = prop_value;
+                        }
                         else if (prop_name == "archive_abs_change")
+                        {
                             (*dev_attr_config)[k].events.arch_event.archive_abs_change = prop_value;
+                        }
                         else if (prop_name == "archive_rel_change")
+                        {
                             (*dev_attr_config)[k].events.arch_event.archive_rel_change = prop_value;
+                        }
                         else if (prop_name == "archive_period")
+                        {
                             (*dev_attr_config)[k].events.arch_event.archive_period = prop_value;
+                        }
                     }
                 }
             }
@@ -4320,7 +4514,9 @@ void DeviceProxy::get_remaining_param(AttributeInfoListEx *dev_attr_config)
                     prop_value = tmp[0] + ", " + tmp[1];
                 }
                 else
+                {
                     db_data_device[i] >> prop_value;
+                }
                 i++;
 
 //
@@ -4332,25 +4528,45 @@ void DeviceProxy::get_remaining_param(AttributeInfoListEx *dev_attr_config)
                     if ((*dev_attr_config)[k].name == att_name)
                     {
                         if (prop_name == "min_warning")
+                        {
                             (*dev_attr_config)[k].alarms.min_warning = prop_value;
+                        }
                         else if (prop_name == "max_warning")
+                        {
                             (*dev_attr_config)[k].alarms.max_warning = prop_value;
+                        }
                         else if (prop_name == "delta_t")
+                        {
                             (*dev_attr_config)[k].alarms.delta_t = prop_value;
+                        }
                         else if (prop_name == "delta_val")
+                        {
                             (*dev_attr_config)[k].alarms.delta_val = prop_value;
+                        }
                         else if (prop_name == "abs_change")
+                        {
                             (*dev_attr_config)[k].events.ch_event.abs_change = prop_value;
+                        }
                         else if (prop_name == "rel_change")
+                        {
                             (*dev_attr_config)[k].events.ch_event.rel_change = prop_value;
+                        }
                         else if (prop_name == "period")
+                        {
                             (*dev_attr_config)[k].events.per_event.period = prop_value;
+                        }
                         else if (prop_name == "archive_abs_change")
+                        {
                             (*dev_attr_config)[k].events.arch_event.archive_abs_change = prop_value;
+                        }
                         else if (prop_name == "archive_rel_change")
+                        {
                             (*dev_attr_config)[k].events.arch_event.archive_rel_change = prop_value;
+                        }
                         else if (prop_name == "archive_period")
+                        {
                             (*dev_attr_config)[k].events.arch_event.archive_period = prop_value;
+                        }
                     }
                 }
             }
@@ -4446,7 +4662,9 @@ void DeviceProxy::set_attribute_config(AttributeInfoList &dev_attr_list)
                                                          (const char *) "DeviceProxy::set_attribute_config()");
             }
             else
+            {
                 throw;
+            }
         }
         catch (CORBA::TRANSIENT &trans)
         {
@@ -4674,7 +4892,9 @@ void DeviceProxy::set_attribute_config(AttributeInfoListEx &dev_attr_list)
                                                          (const char *) "DeviceProxy::set_attribute_config()");
             }
             else
+            {
                 throw;
+            }
         }
         catch (CORBA::TRANSIENT &trans)
         {
@@ -4765,9 +4985,13 @@ PipeInfoList *DeviceProxy::get_pipe_config(vector<string> &pipe_string_list)
     for (unsigned int i = 0; i < pipe_string_list.size(); i++)
     {
         if (pipe_string_list[i] == AllPipe)
+        {
             pipe_list[i] = string_dup(AllPipe);
+        }
         else
+        {
             pipe_list[i] = string_dup(pipe_string_list[i].c_str());
+        }
     }
 
 //
@@ -4938,7 +5162,9 @@ void DeviceProxy::set_pipe_config(PipeInfoList &dev_pipe_list)
                                                          desc.str(), "DeviceProxy::set_pipe_config()");
             }
             else
+            {
                 throw;
+            }
         }
         catch (CORBA::TRANSIENT &trans)
         {
@@ -5174,7 +5400,9 @@ void DeviceProxy::write_pipe(DevicePipe &dev_pipe)
     pipe_value_5.name = dev_pipe.get_name().c_str();
     const string &bl_name = dev_pipe.get_root_blob().get_name();
     if (bl_name.size() != 0)
+    {
         pipe_value_5.data_blob.name = bl_name.c_str();
+    }
 
     DevVarPipeDataEltArray *tmp_ptr = dev_pipe.get_root_blob().get_insert_data();
     if (tmp_ptr == Tango_nullptr)
@@ -5311,7 +5539,9 @@ DevicePipe DeviceProxy::write_read_pipe(DevicePipe &pipe_data)
     pipe_value_5.name = pipe_data.get_name().c_str();
     const string &bl_name = pipe_data.get_root_blob().get_name();
     if (bl_name.size() != 0)
+    {
         pipe_value_5.data_blob.name = bl_name.c_str();
+    }
 
     DevVarPipeDataEltArray *tmp_ptr = pipe_data.get_root_blob().get_insert_data();
     CORBA::ULong max, len;
@@ -5500,7 +5730,9 @@ vector<DeviceAttribute> *DeviceProxy::read_attributes(vector<string> &attr_strin
             {
                 desc << attr_string_list[i];
                 if (i != nb_attr - 1)
+                {
                     desc << ", ";
+                }
             }
             desc << ends;
             ApiConnExcept::re_throw_exception(e, (const char *) API_AttributeFailed,
@@ -5516,7 +5748,9 @@ vector<DeviceAttribute> *DeviceProxy::read_attributes(vector<string> &attr_strin
             {
                 desc << attr_string_list[i];
                 if (i != nb_attr - 1)
+                {
                     desc << ", ";
+                }
             }
             desc << ends;
             Except::re_throw_exception(e, (const char *) API_AttributeFailed,
@@ -5574,13 +5808,21 @@ vector<DeviceAttribute> *DeviceProxy::read_attributes(vector<string> &attr_strin
 
     unsigned long nb_received;
     if (version >= 5)
+    {
         nb_received = attr_value_list_5->length();
+    }
     else if (version == 4)
+    {
         nb_received = attr_value_list_4->length();
+    }
     else if (version == 3)
+    {
         nb_received = attr_value_list_3->length();
+    }
     else
+    {
         nb_received = attr_value_list->length();
+    }
 
     vector<DeviceAttribute> *dev_attr = new(vector<DeviceAttribute>);
     dev_attr->resize(nb_received);
@@ -5590,11 +5832,17 @@ vector<DeviceAttribute> *DeviceProxy::read_attributes(vector<string> &attr_strin
         if (version >= 3)
         {
             if (version == 5)
+            {
                 ApiUtil::attr_to_device(&(attr_value_list_5[i]), version, &(*dev_attr)[i]);
+            }
             else if (version == 4)
+            {
                 ApiUtil::attr_to_device(&(attr_value_list_4[i]), version, &(*dev_attr)[i]);
+            }
             else
+            {
                 ApiUtil::attr_to_device(NULL, &(attr_value_list_3[i]), version, &(*dev_attr)[i]);
+            }
 
 //
 // Add an error in the error stack in case there is one
@@ -5692,11 +5940,17 @@ DeviceAttribute DeviceProxy::read_attribute(string &attr_string)
     if (version >= 3)
     {
         if (version >= 5)
+        {
             ApiUtil::attr_to_device(&(attr_value_list_5[0]), version, &dev_attr);
+        }
         else if (version == 4)
+        {
             ApiUtil::attr_to_device(&(attr_value_list_4[0]), version, &dev_attr);
+        }
         else
+        {
             ApiUtil::attr_to_device(NULL, &(attr_value_list_3[0]), version, &dev_attr);
+        }
 
 //
 // Add an error in the error stack in case there is one
@@ -5958,12 +6212,18 @@ void DeviceProxy::write_attributes(vector<DeviceAttribute> &attr_list)
     Tango::AccessControlType local_act;
 
     if (version == 0)
+    {
         check_and_reconnect(local_act);
+    }
 
     if (version >= 4)
+    {
         attr_value_list_4.length(attr_list.size());
+    }
     else
+    {
         attr_value_list.length(attr_list.size());
+    }
 
     for (unsigned int i = 0; i < attr_list.size(); i++)
     {
@@ -5988,97 +6248,145 @@ void DeviceProxy::write_attributes(vector<DeviceAttribute> &attr_list)
         if (attr_list[i].LongSeq.operator->() != NULL)
         {
             if (version >= 4)
+            {
                 attr_value_list_4[i].value.long_att_value(attr_list[i].LongSeq.in());
+            }
             else
+            {
                 attr_value_list[i].value <<= attr_list[i].LongSeq.in();
+            }
             continue;
         }
         if (attr_list[i].Long64Seq.operator->() != NULL)
         {
             if (version >= 4)
+            {
                 attr_value_list_4[i].value.long64_att_value(attr_list[i].Long64Seq.in());
+            }
             else
+            {
                 attr_value_list[i].value <<= attr_list[i].Long64Seq.in();
+            }
             continue;
         }
         if (attr_list[i].ShortSeq.operator->() != NULL)
         {
             if (version >= 4)
+            {
                 attr_value_list_4[i].value.short_att_value(attr_list[i].ShortSeq.in());
+            }
             else
+            {
                 attr_value_list[i].value <<= attr_list[i].ShortSeq.in();
+            }
             continue;
         }
         if (attr_list[i].DoubleSeq.operator->() != NULL)
         {
             if (version >= 4)
+            {
                 attr_value_list_4[i].value.double_att_value(attr_list[i].DoubleSeq.in());
+            }
             else
+            {
                 attr_value_list[i].value <<= attr_list[i].DoubleSeq.in();
+            }
             continue;
         }
         if (attr_list[i].StringSeq.operator->() != NULL)
         {
             if (version >= 4)
+            {
                 attr_value_list_4[i].value.string_att_value(attr_list[i].StringSeq.in());
+            }
             else
+            {
                 attr_value_list[i].value <<= attr_list[i].StringSeq.in();
+            }
             continue;
         }
         if (attr_list[i].FloatSeq.operator->() != NULL)
         {
             if (version >= 4)
+            {
                 attr_value_list_4[i].value.float_att_value(attr_list[i].FloatSeq.in());
+            }
             else
+            {
                 attr_value_list[i].value <<= attr_list[i].FloatSeq.in();
+            }
             continue;
         }
         if (attr_list[i].BooleanSeq.operator->() != NULL)
         {
             if (version >= 4)
+            {
                 attr_value_list_4[i].value.bool_att_value(attr_list[i].BooleanSeq.in());
+            }
             else
+            {
                 attr_value_list[i].value <<= attr_list[i].BooleanSeq.in();
+            }
             continue;
         }
         if (attr_list[i].UShortSeq.operator->() != NULL)
         {
             if (version >= 4)
+            {
                 attr_value_list_4[i].value.ushort_att_value(attr_list[i].UShortSeq.in());
+            }
             else
+            {
                 attr_value_list[i].value <<= attr_list[i].UShortSeq.in();
+            }
             continue;
         }
         if (attr_list[i].UCharSeq.operator->() != NULL)
         {
             if (version >= 4)
+            {
                 attr_value_list_4[i].value.uchar_att_value(attr_list[i].UCharSeq.in());
+            }
             else
+            {
                 attr_value_list[i].value <<= attr_list[i].UCharSeq.in();
+            }
             continue;
         }
         if (attr_list[i].ULongSeq.operator->() != NULL)
         {
             if (version >= 4)
+            {
                 attr_value_list_4[i].value.ulong_att_value(attr_list[i].ULongSeq.in());
+            }
             else
+            {
                 attr_value_list[i].value <<= attr_list[i].ULongSeq.in();
+            }
             continue;
         }
         if (attr_list[i].ULong64Seq.operator->() != NULL)
         {
             if (version >= 4)
+            {
                 attr_value_list_4[i].value.ulong64_att_value(attr_list[i].ULong64Seq.in());
+            }
             else
+            {
                 attr_value_list[i].value <<= attr_list[i].ULong64Seq.in();
+            }
             continue;
         }
         if (attr_list[i].StateSeq.operator->() != NULL)
         {
             if (version >= 4)
+            {
                 attr_value_list_4[i].value.state_att_value(attr_list[i].StateSeq.in());
+            }
             else
+            {
                 attr_value_list[i].value <<= attr_list[i].StateSeq.in();
+            }
             continue;
         }
     }
@@ -6157,16 +6465,22 @@ void DeviceProxy::write_attributes(vector<DeviceAttribute> &attr_list)
             {
                 desc << attr_value_list[i].name.in();
                 if (i != nb_attr - 1)
+                {
                     desc << ", ";
+                }
             }
             desc << ends;
 
             if (::strcmp(e.errors[0].reason, DEVICE_UNLOCKED_REASON) == 0)
+            {
                 DeviceUnlockedExcept::re_throw_exception(e, (const char *) DEVICE_UNLOCKED_REASON,
                                                          desc.str(), (const char *) "DeviceProxy::write_attribute()");
+            }
             else
+            {
                 Except::re_throw_exception(e, (const char *) API_AttributeFailed,
                                            desc.str(), (const char *) "DeviceProxy::write_attribute()");
+            }
         }
         catch (CORBA::TRANSIENT &trans)
         {
@@ -6235,7 +6549,9 @@ void DeviceProxy::write_attribute(DeviceAttribute &dev_attr)
     Tango::AccessControlType local_act;
 
     if (version == 0)
+    {
         check_and_reconnect(local_act);
+    }
 
     if (version >= 4)
     {
@@ -6249,31 +6565,57 @@ void DeviceProxy::write_attribute(DeviceAttribute &dev_attr)
         attr_value_list_4[0].w_dim.dim_y = dev_attr.dim_y;
 
         if (dev_attr.LongSeq.operator->() != NULL)
+        {
             attr_value_list_4[0].value.long_att_value(dev_attr.LongSeq.in());
+        }
         else if (dev_attr.Long64Seq.operator->() != NULL)
+        {
             attr_value_list_4[0].value.long64_att_value(dev_attr.Long64Seq.in());
+        }
         else if (dev_attr.ShortSeq.operator->() != NULL)
+        {
             attr_value_list_4[0].value.short_att_value(dev_attr.ShortSeq.in());
+        }
         else if (dev_attr.DoubleSeq.operator->() != NULL)
+        {
             attr_value_list_4[0].value.double_att_value(dev_attr.DoubleSeq.in());
+        }
         else if (dev_attr.StringSeq.operator->() != NULL)
+        {
             attr_value_list_4[0].value.string_att_value(dev_attr.StringSeq.in());
+        }
         else if (dev_attr.FloatSeq.operator->() != NULL)
+        {
             attr_value_list_4[0].value.float_att_value(dev_attr.FloatSeq.in());
+        }
         else if (dev_attr.BooleanSeq.operator->() != NULL)
+        {
             attr_value_list_4[0].value.bool_att_value(dev_attr.BooleanSeq.in());
+        }
         else if (dev_attr.UShortSeq.operator->() != NULL)
+        {
             attr_value_list_4[0].value.ushort_att_value(dev_attr.UShortSeq.in());
+        }
         else if (dev_attr.UCharSeq.operator->() != NULL)
+        {
             attr_value_list_4[0].value.uchar_att_value(dev_attr.UCharSeq.in());
+        }
         else if (dev_attr.ULongSeq.operator->() != NULL)
+        {
             attr_value_list_4[0].value.ulong_att_value(dev_attr.ULongSeq.in());
+        }
         else if (dev_attr.ULong64Seq.operator->() != NULL)
+        {
             attr_value_list_4[0].value.ulong64_att_value(dev_attr.ULong64Seq.in());
+        }
         else if (dev_attr.StateSeq.operator->() != NULL)
+        {
             attr_value_list_4[0].value.state_att_value(dev_attr.StateSeq.in());
+        }
         else if (dev_attr.EncodedSeq.operator->() != NULL)
+        {
             attr_value_list_4[0].value.encoded_att_value(dev_attr.EncodedSeq.in());
+        }
     }
     else
     {
@@ -6286,29 +6628,53 @@ void DeviceProxy::write_attribute(DeviceAttribute &dev_attr)
         attr_value_list[0].dim_y = dev_attr.dim_y;
 
         if (dev_attr.LongSeq.operator->() != NULL)
+        {
             attr_value_list[0].value <<= dev_attr.LongSeq.in();
+        }
         else if (dev_attr.Long64Seq.operator->() != NULL)
+        {
             attr_value_list[0].value <<= dev_attr.Long64Seq.in();
+        }
         else if (dev_attr.ShortSeq.operator->() != NULL)
+        {
             attr_value_list[0].value <<= dev_attr.ShortSeq.in();
+        }
         else if (dev_attr.DoubleSeq.operator->() != NULL)
+        {
             attr_value_list[0].value <<= dev_attr.DoubleSeq.in();
+        }
         else if (dev_attr.StringSeq.operator->() != NULL)
+        {
             attr_value_list[0].value <<= dev_attr.StringSeq.in();
+        }
         else if (dev_attr.FloatSeq.operator->() != NULL)
+        {
             attr_value_list[0].value <<= dev_attr.FloatSeq.in();
+        }
         else if (dev_attr.BooleanSeq.operator->() != NULL)
+        {
             attr_value_list[0].value <<= dev_attr.BooleanSeq.in();
+        }
         else if (dev_attr.UShortSeq.operator->() != NULL)
+        {
             attr_value_list[0].value <<= dev_attr.UShortSeq.in();
+        }
         else if (dev_attr.UCharSeq.operator->() != NULL)
+        {
             attr_value_list[0].value <<= dev_attr.UCharSeq.in();
+        }
         else if (dev_attr.ULongSeq.operator->() != NULL)
+        {
             attr_value_list[0].value <<= dev_attr.ULongSeq.in();
+        }
         else if (dev_attr.ULong64Seq.operator->() != NULL)
+        {
             attr_value_list[0].value <<= dev_attr.ULong64Seq.in();
+        }
         else if (dev_attr.StateSeq.operator->() != NULL)
+        {
             attr_value_list[0].value <<= dev_attr.StateSeq.in();
+        }
     }
 
     int ctr = 0;
@@ -6395,11 +6761,15 @@ void DeviceProxy::write_attribute(DeviceAttribute &dev_attr)
             desc << ends;
 
             if (::strcmp(e.errors[0].reason, DEVICE_UNLOCKED_REASON) == 0)
+            {
                 DeviceUnlockedExcept::re_throw_exception(e, (const char *) DEVICE_UNLOCKED_REASON,
                                                          desc.str(), (const char *) "DeviceProxy::write_attribute()");
+            }
             else
+            {
                 Except::re_throw_exception(e, (const char *) API_AttributeFailed,
                                            desc.str(), (const char *) "DeviceProxy::write_attribute()");
+            }
         }
         catch (CORBA::TRANSIENT &trans)
         {
@@ -6541,11 +6911,15 @@ void DeviceProxy::write_attribute(const AttributeValueList &attr_val)
             desc << ends;
 
             if (::strcmp(e.errors[0].reason, DEVICE_UNLOCKED_REASON) == 0)
+            {
                 DeviceUnlockedExcept::re_throw_exception(e, (const char *) DEVICE_UNLOCKED_REASON,
                                                          desc.str(), (const char *) "DeviceProxy::write_attribute()");
+            }
             else
+            {
                 Except::re_throw_exception(e, (const char *) API_AttributeFailed,
                                            desc.str(), (const char *) "DeviceProxy::write_attribute()");
+            }
         }
         catch (CORBA::TRANSIENT &trans)
         {
@@ -6607,7 +6981,9 @@ void DeviceProxy::write_attribute(const AttributeValueList_4 &attr_val)
     Tango::AccessControlType local_act;
 
     if (version == 0)
+    {
         check_and_reconnect(local_act);
+    }
 
 //
 // Check that the device supports IDL V4
@@ -6696,11 +7072,15 @@ void DeviceProxy::write_attribute(const AttributeValueList_4 &attr_val)
             desc << ends;
 
             if (::strcmp(e.errors[0].reason, DEVICE_UNLOCKED_REASON) == 0)
+            {
                 DeviceUnlockedExcept::re_throw_exception(e, (const char *) DEVICE_UNLOCKED_REASON,
                                                          desc.str(), (const char *) "DeviceProxy::write_attribute()");
+            }
             else
+            {
                 Except::re_throw_exception(e, (const char *) API_AttributeFailed,
                                            desc.str(), (const char *) "DeviceProxy::write_attribute()");
+            }
         }
         catch (CORBA::TRANSIENT &trans)
         {
@@ -6926,7 +7306,9 @@ vector<DeviceDataHistory> *DeviceProxy::command_history(string &cmd_name, int de
     {
         ddh->reserve(hist_4->dates.length());
         for (unsigned int i = 0; i < hist_4->dates.length(); i++)
+        {
             ddh->push_back(DeviceDataHistory());
+        }
         from_hist4_2_DataHistory(hist_4, ddh);
     }
 
@@ -7047,16 +7429,22 @@ vector<DeviceAttributeHistory> *DeviceProxy::attribute_history(string &cmd_name,
     {
         ddh->reserve(hist_5->dates.length());
         for (unsigned int i = 0; i < hist_5->dates.length(); i++)
+        {
             ddh->push_back(DeviceAttributeHistory());
+        }
         from_hist_2_AttHistory(hist_5, ddh);
         for (unsigned int i = 0; i < hist_5->dates.length(); i++)
+        {
             (*ddh)[i].data_type = hist_5->data_type;
+        }
     }
     else if (version == 4)
     {
         ddh->reserve(hist_4->dates.length());
         for (unsigned int i = 0; i < hist_4->dates.length(); i++)
+        {
             ddh->push_back(DeviceAttributeHistory());
+        }
         from_hist_2_AttHistory(hist_4, ddh);
     }
     else if (version == 3)
@@ -7171,14 +7559,18 @@ bool DeviceProxy::is_polled(polled_object obj, string &obj_name, string &upd)
         if (obj_type == "command")
         {
             if (obj == Attr)
+            {
                 continue;
+            }
         }
         else if (obj_type == "attribute")
         {
             if (obj == Cmd)
             {
                 if ((loc_obj_name != "state") && (loc_obj_name != "status"))
+                {
                     continue;
+                }
             }
         }
 
@@ -7186,7 +7578,9 @@ bool DeviceProxy::is_polled(polled_object obj, string &obj_name, string &upd)
         pos = pos + 2;
         end = tmp_str.find(". S", pos + 1);
         if (end == string::npos)
+        {
             end = tmp_str.find('\n', pos + 1);
+        }
         string name = tmp_str.substr(pos, end - pos);
         transform(name.begin(), name.end(), name.begin(), ::tolower);
 
@@ -7243,7 +7637,9 @@ int DeviceProxy::get_command_poll_period(string &cmd_name)
         stream >> ret;
     }
     else
+    {
         ret = 0;
+    }
 
     return ret;
 }
@@ -7269,7 +7665,9 @@ int DeviceProxy::get_attribute_poll_period(string &attr_name)
         stream >> ret;
     }
     else
+    {
         ret = 0;
+    }
 
     return ret;
 }
@@ -7309,7 +7707,9 @@ void DeviceProxy::poll_command(string &cmd_name, int period)
         stream >> per;
 
         if ((per == period) || (per == 0))
+        {
             return;
+        }
         else
         {
 
@@ -7392,7 +7792,9 @@ void DeviceProxy::poll_attribute(string &attr_name, int period)
         stream >> per;
 
         if ((per == period) || (per == 0))
+        {
             return;
+        }
         else
         {
 
@@ -7765,7 +8167,9 @@ int DeviceProxy::subscribe_event(const string &attr_name, EventType event,
                 ->subscribe_event(this, attr_name, event, callback, filters, stateless);
         }
         else
+        {
             throw;
+        }
     }
 
     return ret;
@@ -7816,7 +8220,9 @@ int DeviceProxy::subscribe_event(const string &attr_name, EventType event,
                 ->subscribe_event(this, attr_name, event, event_queue_size, filters, stateless);
         }
         else
+        {
             throw;
+        }
     }
 
     return ret;
@@ -8197,7 +8603,9 @@ int DeviceProxy::event_queue_size(int event_id)
                 (const char *) "DeviceProxy::event_queue_size()");
         }
         else
+        {
             ev = api_ptr->get_notifd_event_consumer();
+        }
     }
 
     return ev->event_queue_size(event_id);
@@ -8246,7 +8654,9 @@ bool DeviceProxy::is_event_queue_empty(int event_id)
                 (const char *) "DeviceProxy::is_event_queue_empty()");
         }
         else
+        {
             ev = api_ptr->get_notifd_event_consumer();
+        }
     }
 
     return (ev->is_event_queue_empty(event_id));
@@ -8295,7 +8705,9 @@ TimeVal DeviceProxy::get_last_event_date(int event_id)
                 (const char *) "DeviceProxy::get_last_event_date()");
         }
         else
+        {
             ev = api_ptr->get_notifd_event_consumer();
+        }
     }
 
     return (ev->get_last_event_date(event_id));
@@ -8311,9 +8723,13 @@ TimeVal DeviceProxy::get_last_event_date(int event_id)
 Database *DeviceProxy::get_device_db()
 {
     if ((db_port_num != 0) && (db_dev != NULL))
+    {
         return db_dev->get_dbase();
+    }
     else
+    {
         return (Database *) NULL;
+    }
 }
 
 //-----------------------------------------------------------------------------
@@ -8547,9 +8963,13 @@ void DeviceProxy::unlock(bool force)
     sent_data.svalue[0] = CORBA::string_dup(device_name.c_str());
     sent_data.lvalue.length(1);
     if (force == true)
+    {
         sent_data.lvalue[0] = 1;
+    }
     else
+    {
         sent_data.lvalue[0] = 0;
+    }
     din << sent_data;
 
 //
@@ -8573,7 +8993,9 @@ void DeviceProxy::unlock(bool force)
 
         lock_ctr--;
         if (glob_ctr != lock_ctr)
+        {
             lock_ctr = glob_ctr;
+        }
         local_lock_ctr = lock_ctr;
     }
 
@@ -8741,7 +9163,9 @@ bool DeviceProxy::is_locked_by_me()
     bool ret = false;
 
     if (v_l[0] == 0)
+    {
         ret = false;
+    }
     else
     {
 #ifndef _TG_WINDOWS_
@@ -8749,9 +9173,13 @@ bool DeviceProxy::is_locked_by_me()
 #else
             if (_getpid() != v_l[1])
 #endif
+        {
             ret = false;
+        }
         else if ((v_l[2] != 0) || (v_l[3] != 0) || (v_l[4] != 0) || (v_l[5] != 0))
+        {
             ret = false;
+        }
         else
         {
             string full_ip_str;
@@ -8762,7 +9190,9 @@ bool DeviceProxy::is_locked_by_me()
 //
 
             if (full_ip_str == TG_LOCAL_HOST)
+            {
                 ret = true;
+            }
             else
             {
 
@@ -8807,7 +9237,9 @@ bool DeviceProxy::get_locker(LockerInfo &lock_info)
     ask_locking_status(v_str, v_l);
 
     if (v_l[0] == 0)
+    {
         return false;
+    }
     else
     {
 
@@ -8827,7 +9259,9 @@ bool DeviceProxy::get_locker(LockerInfo &lock_info)
         {
             lock_info.ll = Tango::JAVA;
             for (int loop = 0; loop < 4; loop++)
+            {
                 lock_info.li.UUID[loop] = v_l[2 + loop];
+            }
 
             string full_ip;
             get_locker_host(v_str[1], full_ip);
@@ -8863,9 +9297,13 @@ bool DeviceProxy::get_locker(LockerInfo &lock_info)
             int res = getnameinfo((const sockaddr *) &si, sizeof(si), host_os, 512, 0, 0, 0);
 
             if (res == 0)
+            {
                 lock_info.locker_host = host_os;
+            }
             else
+            {
                 lock_info.locker_host = full_ip;
+            }
         }
         else
         {
@@ -8942,7 +9380,9 @@ void DeviceProxy::get_locker_host(string &f_addr, string &ip_addr)
     bool ipv6 = false;
 
     if (f_addr.find('[') != string::npos)
+    {
         ipv6 = true;
+    }
 
     if (f_addr.find(":unix:") != string::npos)
     {
@@ -9037,31 +9477,57 @@ DeviceAttribute DeviceProxy::write_read_attribute(DeviceAttribute &dev_attr)
     attr_value_list[0].w_dim.dim_y = dev_attr.dim_y;
 
     if (dev_attr.LongSeq.operator->() != NULL)
+    {
         attr_value_list[0].value.long_att_value(dev_attr.LongSeq.in());
+    }
     else if (dev_attr.Long64Seq.operator->() != NULL)
+    {
         attr_value_list[0].value.long64_att_value(dev_attr.Long64Seq.in());
+    }
     else if (dev_attr.ShortSeq.operator->() != NULL)
+    {
         attr_value_list[0].value.short_att_value(dev_attr.ShortSeq.in());
+    }
     else if (dev_attr.DoubleSeq.operator->() != NULL)
+    {
         attr_value_list[0].value.double_att_value(dev_attr.DoubleSeq.in());
+    }
     else if (dev_attr.StringSeq.operator->() != NULL)
+    {
         attr_value_list[0].value.string_att_value(dev_attr.StringSeq.in());
+    }
     else if (dev_attr.FloatSeq.operator->() != NULL)
+    {
         attr_value_list[0].value.float_att_value(dev_attr.FloatSeq.in());
+    }
     else if (dev_attr.BooleanSeq.operator->() != NULL)
+    {
         attr_value_list[0].value.bool_att_value(dev_attr.BooleanSeq.in());
+    }
     else if (dev_attr.UShortSeq.operator->() != NULL)
+    {
         attr_value_list[0].value.ushort_att_value(dev_attr.UShortSeq.in());
+    }
     else if (dev_attr.UCharSeq.operator->() != NULL)
+    {
         attr_value_list[0].value.uchar_att_value(dev_attr.UCharSeq.in());
+    }
     else if (dev_attr.ULongSeq.operator->() != NULL)
+    {
         attr_value_list[0].value.ulong_att_value(dev_attr.ULongSeq.in());
+    }
     else if (dev_attr.ULong64Seq.operator->() != NULL)
+    {
         attr_value_list[0].value.ulong64_att_value(dev_attr.ULong64Seq.in());
+    }
     else if (dev_attr.StateSeq.operator->() != NULL)
+    {
         attr_value_list[0].value.state_att_value(dev_attr.StateSeq.in());
+    }
     else if (dev_attr.EncodedSeq.operator->() != NULL)
+    {
         attr_value_list[0].value.encoded_att_value(dev_attr.EncodedSeq.in());
+    }
 
     Tango::DevVarStringArray dvsa;
     dvsa.length(1);
@@ -9150,13 +9616,17 @@ DeviceAttribute DeviceProxy::write_read_attribute(DeviceAttribute &dev_attr)
             desc << ends;
 
             if (::strcmp(e.errors[0].reason, DEVICE_UNLOCKED_REASON) == 0)
+            {
                 DeviceUnlockedExcept::re_throw_exception(e,
                                                          (const char *) DEVICE_UNLOCKED_REASON,
                                                          desc.str(),
                                                          (const char *) "DeviceProxy::write_read_attribute()");
+            }
             else
+            {
                 Except::re_throw_exception(e, (const char *) API_AttributeFailed,
                                            desc.str(), (const char *) "DeviceProxy::write_read_attribute()");
+            }
         }
         catch (CORBA::TRANSIENT &trans)
         {
@@ -9215,9 +9685,13 @@ DeviceAttribute DeviceProxy::write_read_attribute(DeviceAttribute &dev_attr)
 
     DeviceAttribute ret_dev_attr;
     if (version >= 5)
+    {
         ApiUtil::attr_to_device(&(attr_value_list_5[0]), version, &ret_dev_attr);
+    }
     else
+    {
         ApiUtil::attr_to_device(&(attr_value_list_4[0]), version, &ret_dev_attr);
+    }
 
 //
 // Add an error in the error stack in case there is one
@@ -9283,31 +9757,57 @@ vector<DeviceAttribute> *DeviceProxy::write_read_attributes(vector<DeviceAttribu
         attr_value_list[i].w_dim.dim_y = attr_list[i].dim_y;
 
         if (attr_list[i].LongSeq.operator->() != NULL)
+        {
             attr_value_list[i].value.long_att_value(attr_list[i].LongSeq.in());
+        }
         else if (attr_list[i].Long64Seq.operator->() != NULL)
+        {
             attr_value_list[i].value.long64_att_value(attr_list[i].Long64Seq.in());
+        }
         else if (attr_list[i].ShortSeq.operator->() != NULL)
+        {
             attr_value_list[i].value.short_att_value(attr_list[i].ShortSeq.in());
+        }
         else if (attr_list[i].DoubleSeq.operator->() != NULL)
+        {
             attr_value_list[i].value.double_att_value(attr_list[i].DoubleSeq.in());
+        }
         else if (attr_list[i].StringSeq.operator->() != NULL)
+        {
             attr_value_list[i].value.string_att_value(attr_list[i].StringSeq.in());
+        }
         else if (attr_list[i].FloatSeq.operator->() != NULL)
+        {
             attr_value_list[i].value.float_att_value(attr_list[i].FloatSeq.in());
+        }
         else if (attr_list[i].BooleanSeq.operator->() != NULL)
+        {
             attr_value_list[i].value.bool_att_value(attr_list[i].BooleanSeq.in());
+        }
         else if (attr_list[i].UShortSeq.operator->() != NULL)
+        {
             attr_value_list[i].value.ushort_att_value(attr_list[i].UShortSeq.in());
+        }
         else if (attr_list[i].UCharSeq.operator->() != NULL)
+        {
             attr_value_list[i].value.uchar_att_value(attr_list[i].UCharSeq.in());
+        }
         else if (attr_list[i].ULongSeq.operator->() != NULL)
+        {
             attr_value_list[i].value.ulong_att_value(attr_list[i].ULongSeq.in());
+        }
         else if (attr_list[i].ULong64Seq.operator->() != NULL)
+        {
             attr_value_list[i].value.ulong64_att_value(attr_list[i].ULong64Seq.in());
+        }
         else if (attr_list[i].StateSeq.operator->() != NULL)
+        {
             attr_value_list[i].value.state_att_value(attr_list[i].StateSeq.in());
+        }
         else if (attr_list[i].EncodedSeq.operator->() != NULL)
+        {
             attr_value_list[i].value.encoded_att_value(attr_list[i].EncodedSeq.in());
+        }
     }
 
 //
@@ -9394,13 +9894,17 @@ vector<DeviceAttribute> *DeviceProxy::write_read_attributes(vector<DeviceAttribu
             desc << ends;
 
             if (::strcmp(e.errors[0].reason, DEVICE_UNLOCKED_REASON) == 0)
+            {
                 DeviceUnlockedExcept::re_throw_exception(e,
                                                          (const char *) DEVICE_UNLOCKED_REASON,
                                                          desc.str(),
                                                          (const char *) "DeviceProxy::write_read_attributes()");
+            }
             else
+            {
                 Except::re_throw_exception(e, (const char *) API_AttributeFailed,
                                            desc.str(), (const char *) "DeviceProxy::write_read_attributes()");
+            }
         }
         catch (CORBA::TRANSIENT &trans)
         {
@@ -9512,7 +10016,9 @@ void DeviceProxy::same_att_name(vector<string> &attr_list, const char *met_name)
         vector<string> same_att = attr_list;
 
         for (i = 0; i < same_att.size(); ++i)
+        {
             transform(same_att[i].begin(), same_att[i].end(), same_att[i].begin(), ::tolower);
+        }
         sort(same_att.begin(), same_att.end());
         vector<string> same_att_lower = same_att;
 
@@ -9533,7 +10039,9 @@ void DeviceProxy::same_att_name(vector<string> &attr_list, const char *met_name)
                     ctr++;
                     desc << same_att_lower[i];
                     if (ctr < duplicate_att)
+                    {
                         desc << ", ";
+                    }
                 }
             }
             desc << ends;
@@ -9567,7 +10075,9 @@ void DeviceProxy::local_import(string &local_ior)
     {
         string reas(e.errors[0].reason);
         if (reas == "API_UtilSingletonNotCreated")
+        {
             return;
+        }
     }
 
     const vector<Tango::DeviceClass *> *cl_list_ptr = tg->get_class_list();
@@ -9583,7 +10093,9 @@ void DeviceProxy::local_import(string &local_ior)
                 {
                     Database *db = tg->get_database();
                     if (db->get_db_host() != get_db_host())
+                    {
                         return;
+                    }
                 }
 
                 Tango::Device_var d_var = dev_list[lo]->get_d_var();
@@ -9662,9 +10174,13 @@ int DeviceProxy::get_tango_lib_version()
 		}
 #endif
             if (pos != (*cmd_list).end())
+            {
                 ret = 520;
+            }
             else
+            {
                 ret = 500;
+            }
             break;
         }
 
@@ -9688,7 +10204,9 @@ int DeviceProxy::get_tango_lib_version()
                 }
 
                 if (cmd.cmd_name == "ZmqEventSubscriptionChange")
+                {
                     zesc = true;
+                }
             }
 #else
                                                                                                                                     vector<CommandInfo>::iterator pos,pos_end;
@@ -9705,11 +10223,17 @@ int DeviceProxy::get_tango_lib_version()
 		}
 #endif
             if (ecs == true)
+            {
                 ret = 810;
+            }
             else if (zesc == true)
+            {
                 ret = 800;
+            }
             else
+            {
                 ret = 700;
+            }
 
             break;
         }

--- a/cppapi/client/devapi_base.cpp
+++ b/cppapi/client/devapi_base.cpp
@@ -36,7 +36,7 @@
 #include <devapi_utils.tpp>
 
 #ifdef _TG_WINDOWS_
-#include <sys/timeb.h>
+                                                                                                                        #include <sys/timeb.h>
 #include <process.h>
 #include <ws2tcpip.h>
 #else
@@ -67,7 +67,7 @@ namespace Tango
 
 Connection::ConnectionExt &Connection::ConnectionExt::operator=(TANGO_UNUSED(const Connection::ConnectionExt &rval))
 {
-	return *this;
+    return *this;
 }
 
 
@@ -77,60 +77,60 @@ Connection::ConnectionExt &Connection::ConnectionExt::operator=(TANGO_UNUSED(con
 //
 //-----------------------------------------------------------------------------
 
-Connection::Connection(ORB *orb_in):pasyn_ctr(0),pasyn_cb_ctr(0),
-				    timeout(CLNT_TIMEOUT),
-				    version(0),source(Tango::CACHE_DEV),ext(new ConnectionExt()),
-				    tr_reco(true),prev_failed(false),prev_failed_t0(0.0),
-				    user_connect_timeout(-1),tango_host_localhost(false)
+Connection::Connection(ORB *orb_in)
+    : pasyn_ctr(0), pasyn_cb_ctr(0),
+      timeout(CLNT_TIMEOUT),
+      version(0), source(Tango::CACHE_DEV), ext(new ConnectionExt()),
+      tr_reco(true), prev_failed(false), prev_failed_t0(0.0),
+      user_connect_timeout(-1), tango_host_localhost(false)
 {
 
 //
 // Some default init for access control
 //
 
-	check_acc = true;
-	access = ACCESS_READ;
+    check_acc = true;
+    access = ACCESS_READ;
 
 //
 // If the proxy is created from inside a device server, use the server orb
 //
 
-	ApiUtil *au = ApiUtil::instance();
-	if ((orb_in == NULL) && (CORBA::is_nil(au->get_orb()) == true))
-	{
-		if (au->in_server() == true)
-			ApiUtil::instance()->set_orb(Util::instance()->get_orb());
-		else
-			ApiUtil::instance()->create_orb();
-	}
-	else
-	{
-		if (orb_in != NULL)
-			au->set_orb(orb_in);
-	}
+    ApiUtil *au = ApiUtil::instance();
+    if ((orb_in == NULL) && (CORBA::is_nil(au->get_orb()) == true))
+    {
+        if (au->in_server() == true)
+            ApiUtil::instance()->set_orb(Util::instance()->get_orb());
+        else
+            ApiUtil::instance()->create_orb();
+    }
+    else
+    {
+        if (orb_in != NULL)
+            au->set_orb(orb_in);
+    }
 
 //
 // Get user connect timeout if one is defined
 //
 
-	int ucto = au->get_user_connect_timeout();
-	if (ucto != -1)
-		user_connect_timeout = ucto;
+    int ucto = au->get_user_connect_timeout();
+    if (ucto != -1)
+        user_connect_timeout = ucto;
 }
 
-
-
-Connection::Connection(bool dummy):ext(Tango_nullptr),tr_reco(true),prev_failed(false),prev_failed_t0(0.0),
-				    user_connect_timeout(-1),tango_host_localhost(false)
+Connection::Connection(bool dummy)
+    : ext(Tango_nullptr), tr_reco(true), prev_failed(false), prev_failed_t0(0.0),
+      user_connect_timeout(-1), tango_host_localhost(false)
 {
-	if (dummy)
-	{
+    if (dummy)
+    {
 #ifdef HAS_UNIQUE_PTR
         ext.reset(new ConnectionExt());
 #else
-		ext = new ConnectionExt();
+        ext = new ConnectionExt();
 #endif
-	}
+    }
 }
 
 //-----------------------------------------------------------------------------
@@ -152,33 +152,34 @@ Connection::~Connection()
 //
 //-----------------------------------------------------------------------------
 
-Connection::Connection(const Connection &sou):ext(Tango_nullptr)
+Connection::Connection(const Connection &sou)
+    : ext(Tango_nullptr)
 {
-	dbase_used = sou.dbase_used;
-	from_env_var = sou.from_env_var;
-	host = sou.host;
-	port = sou.port;
-	port_num = sou.port_num;
+    dbase_used = sou.dbase_used;
+    from_env_var = sou.from_env_var;
+    host = sou.host;
+    port = sou.port;
+    port_num = sou.port_num;
 
-	db_host = sou.db_host;
-	db_port = sou.db_port;
-	db_port_num = sou.db_port_num;
+    db_host = sou.db_host;
+    db_port = sou.db_port;
+    db_port_num = sou.db_port_num;
 
-	ior = sou.ior;
-	pasyn_ctr = sou.pasyn_ctr;
-	pasyn_cb_ctr = sou.pasyn_cb_ctr;
+    ior = sou.ior;
+    pasyn_ctr = sou.pasyn_ctr;
+    pasyn_cb_ctr = sou.pasyn_cb_ctr;
 
-	device = sou.device;
-	if (sou.version >= 2)
-		device_2 = sou.device_2;
+    device = sou.device;
+    if (sou.version >= 2)
+        device_2 = sou.device_2;
 
-	timeout = sou.timeout;
-	connection_state = sou.connection_state;
-	version = sou.version;
-	source = sou.source;
+    timeout = sou.timeout;
+    connection_state = sou.connection_state;
+    version = sou.version;
+    source = sou.source;
 
-	check_acc = sou.check_acc;
-	access = sou.access;
+    check_acc = sou.check_acc;
+    access = sou.access;
 
     tr_reco = sou.tr_reco;
     device_3 = sou.device_3;
@@ -200,7 +201,7 @@ Connection::Connection(const Connection &sou):ext(Tango_nullptr)
         *(ext.get()) = *(sou.ext.get());
     }
 #else
-	if (sou.ext != NULL)
+                                                                                                                            if (sou.ext != NULL)
 	{
 		ext = new ConnectionExt();
 		*ext = *(sou.ext);
@@ -218,31 +219,31 @@ Connection::Connection(const Connection &sou):ext(Tango_nullptr)
 
 Connection &Connection::operator=(const Connection &rval)
 {
-	dbase_used = rval.dbase_used;
-	from_env_var = rval.from_env_var;
-	host = rval.host;
-	port = rval.port;
-	port_num = rval.port_num;
+    dbase_used = rval.dbase_used;
+    from_env_var = rval.from_env_var;
+    host = rval.host;
+    port = rval.port;
+    port_num = rval.port_num;
 
-	db_host = rval.db_host;
-	db_port = rval.db_port;
-	db_port_num = rval.db_port_num;
+    db_host = rval.db_host;
+    db_port = rval.db_port;
+    db_port_num = rval.db_port_num;
 
-	ior = rval.ior;
-	pasyn_ctr = rval.pasyn_ctr;
-	pasyn_cb_ctr = rval.pasyn_cb_ctr;
+    ior = rval.ior;
+    pasyn_ctr = rval.pasyn_ctr;
+    pasyn_cb_ctr = rval.pasyn_cb_ctr;
 
-	device = rval.device;
-	if (rval.version >= 2)
-		device_2 = rval.device_2;
+    device = rval.device;
+    if (rval.version >= 2)
+        device_2 = rval.device_2;
 
-	timeout = rval.timeout;
-	connection_state = rval.connection_state;
-	version = rval.version;
-	source = rval.source;
+    timeout = rval.timeout;
+    connection_state = rval.connection_state;
+    version = rval.version;
+    source = rval.source;
 
-	check_acc = rval.check_acc;
-	access = rval.access;
+    check_acc = rval.check_acc;
+    access = rval.access;
 
     tr_reco = rval.tr_reco;
     device_3 = rval.device_3;
@@ -266,7 +267,7 @@ Connection &Connection::operator=(const Connection &rval)
     else
         ext.reset(Tango_nullptr);
 #else
-	if (rval.ext != NULL)
+                                                                                                                            if (rval.ext != NULL)
 	{
 		ext = new ConnectionExt();
 		*ext = *(rval.ext);
@@ -291,90 +292,90 @@ Connection &Connection::operator=(const Connection &rval)
 
 void Connection::check_and_reconnect()
 {
-	int local_connection_state;
-	{
-		ReaderLock guard(con_to_mon);
-		local_connection_state = connection_state;
-	}
-	if (local_connection_state != CONNECTION_OK)
-	{
-		WriterLock guard(con_to_mon);
-		if (connection_state != CONNECTION_OK)
-			reconnect(dbase_used);
-	}
+    int local_connection_state;
+    {
+        ReaderLock guard(con_to_mon);
+        local_connection_state = connection_state;
+    }
+    if (local_connection_state != CONNECTION_OK)
+    {
+        WriterLock guard(con_to_mon);
+        if (connection_state != CONNECTION_OK)
+            reconnect(dbase_used);
+    }
 }
 
 void Connection::check_and_reconnect(Tango::DevSource &sou)
 {
-	int local_connection_state;
-	{
-		ReaderLock guard(con_to_mon);
-		local_connection_state = connection_state;
-		sou = source;
-	}
-	if (local_connection_state != CONNECTION_OK)
-	{
-		WriterLock guard(con_to_mon);
-		if (connection_state != CONNECTION_OK)
-			reconnect(dbase_used);
-	}
+    int local_connection_state;
+    {
+        ReaderLock guard(con_to_mon);
+        local_connection_state = connection_state;
+        sou = source;
+    }
+    if (local_connection_state != CONNECTION_OK)
+    {
+        WriterLock guard(con_to_mon);
+        if (connection_state != CONNECTION_OK)
+            reconnect(dbase_used);
+    }
 }
 
 void Connection::check_and_reconnect(Tango::AccessControlType &act)
 {
-	int local_connection_state;
-	{
-		ReaderLock guard(con_to_mon);
-		local_connection_state = connection_state;
-		act = access;
-	}
-	if (local_connection_state != CONNECTION_OK)
-	{
-		WriterLock guard(con_to_mon);
-		if (connection_state != CONNECTION_OK)
-		{
-			reconnect(dbase_used);
-			act = access;
-		}
-	}
+    int local_connection_state;
+    {
+        ReaderLock guard(con_to_mon);
+        local_connection_state = connection_state;
+        act = access;
+    }
+    if (local_connection_state != CONNECTION_OK)
+    {
+        WriterLock guard(con_to_mon);
+        if (connection_state != CONNECTION_OK)
+        {
+            reconnect(dbase_used);
+            act = access;
+        }
+    }
 }
 
-void Connection::check_and_reconnect(Tango::DevSource &sou,Tango::AccessControlType &act)
+void Connection::check_and_reconnect(Tango::DevSource &sou, Tango::AccessControlType &act)
 {
-	int local_connection_state;
-	{
-		ReaderLock guard(con_to_mon);
-		local_connection_state = connection_state;
-		act = access;
-		sou = source;
-	}
-	if (local_connection_state != CONNECTION_OK)
-	{
-		WriterLock guard(con_to_mon);
-		if (connection_state != CONNECTION_OK)
-		{
-			reconnect(dbase_used);
-			act = access;
-		}
-	}
+    int local_connection_state;
+    {
+        ReaderLock guard(con_to_mon);
+        local_connection_state = connection_state;
+        act = access;
+        sou = source;
+    }
+    if (local_connection_state != CONNECTION_OK)
+    {
+        WriterLock guard(con_to_mon);
+        if (connection_state != CONNECTION_OK)
+        {
+            reconnect(dbase_used);
+            act = access;
+        }
+    }
 }
 
 void Connection::set_connection_state(int con)
 {
-	WriterLock guard(con_to_mon);
-	connection_state = con;
+    WriterLock guard(con_to_mon);
+    connection_state = con;
 }
 
 Tango::DevSource Connection::get_source()
 {
-	ReaderLock guard(con_to_mon);
-	return source;
+    ReaderLock guard(con_to_mon);
+    return source;
 }
 
 void Connection::set_source(Tango::DevSource sou)
 {
-	WriterLock guard(con_to_mon);
-	source = sou;
+    WriterLock guard(con_to_mon);
+    source = sou;
 }
 
 //-----------------------------------------------------------------------------
@@ -386,17 +387,17 @@ void Connection::set_source(Tango::DevSource sou)
 
 void Connection::connect(string &corba_name)
 {
-	bool retry = true;
-	long db_retries = DB_START_PHASE_RETRIES;
-	bool connect_to_db = false;
+    bool retry = true;
+    long db_retries = DB_START_PHASE_RETRIES;
+    bool connect_to_db = false;
 
-	while (retry == true)
-	{
-		try
-		{
+    while (retry == true)
+    {
+        try
+        {
 
-			Object_var obj;
-			obj = ApiUtil::instance()->get_orb()->string_to_object(corba_name.c_str());
+            Object_var obj;
+            obj = ApiUtil::instance()->get_orb()->string_to_object(corba_name.c_str());
 
 //
 // Narrow CORBA string name to CORBA object
@@ -413,18 +414,18 @@ void Connection::connect(string &corba_name)
 // Reset the connection timeout only after the _non_existent call.
 //
 
-			if (corba_name.find(DbObjName) != string::npos)
-				connect_to_db = true;
+            if (corba_name.find(DbObjName) != string::npos)
+                connect_to_db = true;
 
-			if (connect_to_db == false)
-			{
-				if (user_connect_timeout != -1)
-					omniORB::setClientConnectTimeout(user_connect_timeout);
-				else
-					omniORB::setClientConnectTimeout(NARROW_CLNT_TIMEOUT);
-			}
+            if (connect_to_db == false)
+            {
+                if (user_connect_timeout != -1)
+                    omniORB::setClientConnectTimeout(user_connect_timeout);
+                else
+                    omniORB::setClientConnectTimeout(NARROW_CLNT_TIMEOUT);
+            }
 
-			device_5 = Device_5::_narrow(obj);
+            device_5 = Device_5::_narrow(obj);
 
             if (CORBA::is_nil(device_5))
             {
@@ -442,32 +443,32 @@ void Connection::connect(string &corba_name)
                             device = Device::_narrow(obj);
                             if (CORBA::is_nil(device))
                             {
-                                cerr << "Can't build connection to object " << corba_name <<  endl;
+                                cerr << "Can't build connection to object " << corba_name << endl;
                                 connection_state = CONNECTION_NOTOK;
 
                                 TangoSys_OMemStream desc;
                                 desc << "Failed to connect to device " << dev_name();
                                 desc << " (device nil after _narrowing)" << ends;
-                                ApiConnExcept::throw_exception((const char*)API_CantConnectToDevice,
-                                                        desc.str(),
-                                                        (const char*)"Connection::connect()");
+                                ApiConnExcept::throw_exception((const char *) API_CantConnectToDevice,
+                                                               desc.str(),
+                                                               (const char *) "Connection::connect()");
                             }
                             else
                             {
-                            	device->_non_existent();
+                                device->_non_existent();
                                 version = 1;
                             }
                         }
                         else
                         {
-                        	device_2->_non_existent();
+                            device_2->_non_existent();
                             version = 2;
                             device = Device_2::_duplicate(device_2);
                         }
                     }
                     else
                     {
-						device_3->_non_existent();
+                        device_3->_non_existent();
                         version = 3;
                         device_2 = Device_3::_duplicate(device_3);
                         device = Device_3::_duplicate(device_3);
@@ -475,7 +476,7 @@ void Connection::connect(string &corba_name)
                 }
                 else
                 {
-					device_4->_non_existent();
+                    device_4->_non_existent();
                     version = 4;
                     device_3 = Device_4::_duplicate(device_4);
                     device_2 = Device_4::_duplicate(device_4);
@@ -484,7 +485,7 @@ void Connection::connect(string &corba_name)
             }
             else
             {
-				device_5->_non_existent();
+                device_5->_non_existent();
                 version = 5;
                 device_4 = Device_5::_duplicate(device_5);
                 device_3 = Device_5::_duplicate(device_5);
@@ -501,15 +502,15 @@ void Connection::connect(string &corba_name)
             if (corba_name[0] == 'I' && corba_name[1] == 'O' && corba_name[2] == 'R')
             {
                 IOP::IOR ior;
-                toIOR(corba_name.c_str(),ior);
+                toIOR(corba_name.c_str(), ior);
                 IIOP::ProfileBody pBody;
-                IIOP::unmarshalProfile(ior.profiles[0],pBody);
+                IIOP::unmarshalProfile(ior.profiles[0], pBody);
 
                 CORBA::ULong total = pBody.components.length();
 
-                for (CORBA::ULong index=0; index < total; index++)
+                for (CORBA::ULong index = 0; index < total; index++)
                 {
-                    IOP::TaggedComponent& c = pBody.components[index];
+                    IOP::TaggedComponent &c = pBody.components[index];
                     if (c.tag == 3)
                     {
                         ext->has_alt_adr = true;
@@ -522,84 +523,84 @@ void Connection::connect(string &corba_name)
 
 //			if (connect_to_db == false)
 //				omniORB::setClientConnectTimeout(0);
-			retry = false;
+            retry = false;
 
 //
 // Mark the connection as OK and set timeout to its value
 // (The default is 3 seconds)
 //
 
-			connection_state = CONNECTION_OK;
-			if (timeout != CLNT_TIMEOUT)
-				set_timeout_millis(timeout);
-		}
-		catch (CORBA::SystemException &ce)
-		{
+            connection_state = CONNECTION_OK;
+            if (timeout != CLNT_TIMEOUT)
+                set_timeout_millis(timeout);
+        }
+        catch (CORBA::SystemException &ce)
+        {
 //			if (connect_to_db == false)
 //				omniORB::setClientConnectTimeout(0);
 
-			TangoSys_OMemStream desc;
-			TangoSys_MemStream reason;
-			bool db_connect = false;
+            TangoSys_OMemStream desc;
+            TangoSys_MemStream reason;
+            bool db_connect = false;
 
-			desc << "Failed to connect to ";
+            desc << "Failed to connect to ";
 
-			string::size_type pos = corba_name.find(':');
-			if (pos == string::npos)
-			{
-				desc << "device " << dev_name() << ends;
-				reason << API_CantConnectToDevice << ends;
-			}
-			else
-			{
-				string prot = corba_name.substr(0,pos);
-				if (prot == "corbaloc")
-				{
-					string::size_type tmp = corba_name.find('/');
-					if (tmp != string::npos)
-					{
-						string dev = corba_name.substr(tmp + 1);
-						if (dev == "database")
-						{
-							desc << "database on host ";
-							desc << db_host << " with port ";
-							desc << db_port << ends;
-							reason << "API_CantConnectToDatabase" << ends;
-							db_retries--;
-							if (db_retries != 0)
-								db_connect = true;
-						}
-						else
-						{
-							desc << "device " << dev_name() << ends;
-							if (CORBA::OBJECT_NOT_EXIST::_downcast(&ce) != 0)
-								reason << "API_DeviceNotDefined" << ends;
-							else if (CORBA::TRANSIENT::_downcast(&ce) != 0)
-								reason << "API_ServerNotRunning" << ends;
-							else
-								reason << API_CantConnectToDevice << ends;
-						}
-					}
-					else
-					{
-						desc << "device " << dev_name() << ends;
-						reason << API_CantConnectToDevice << ends;
-					}
-				}
-				else
-				{
-					desc << "device " << dev_name() << ends;
-					reason << API_CantConnectToDevice << ends;
-				}
-			}
+            string::size_type pos = corba_name.find(':');
+            if (pos == string::npos)
+            {
+                desc << "device " << dev_name() << ends;
+                reason << API_CantConnectToDevice << ends;
+            }
+            else
+            {
+                string prot = corba_name.substr(0, pos);
+                if (prot == "corbaloc")
+                {
+                    string::size_type tmp = corba_name.find('/');
+                    if (tmp != string::npos)
+                    {
+                        string dev = corba_name.substr(tmp + 1);
+                        if (dev == "database")
+                        {
+                            desc << "database on host ";
+                            desc << db_host << " with port ";
+                            desc << db_port << ends;
+                            reason << "API_CantConnectToDatabase" << ends;
+                            db_retries--;
+                            if (db_retries != 0)
+                                db_connect = true;
+                        }
+                        else
+                        {
+                            desc << "device " << dev_name() << ends;
+                            if (CORBA::OBJECT_NOT_EXIST::_downcast(&ce) != 0)
+                                reason << "API_DeviceNotDefined" << ends;
+                            else if (CORBA::TRANSIENT::_downcast(&ce) != 0)
+                                reason << "API_ServerNotRunning" << ends;
+                            else
+                                reason << API_CantConnectToDevice << ends;
+                        }
+                    }
+                    else
+                    {
+                        desc << "device " << dev_name() << ends;
+                        reason << API_CantConnectToDevice << ends;
+                    }
+                }
+                else
+                {
+                    desc << "device " << dev_name() << ends;
+                    reason << API_CantConnectToDevice << ends;
+                }
+            }
 
-			if (db_connect == false)
-			{
-				ApiConnExcept::re_throw_exception(ce,reason.str(),desc.str(),
-					        	  (const char *)"Connection::connect");
-			}
-		}
-	}
+            if (db_connect == false)
+            {
+                ApiConnExcept::re_throw_exception(ce, reason.str(), desc.str(),
+                                                  (const char *) "Connection::connect");
+            }
+        }
+    }
 }
 
 
@@ -611,26 +612,26 @@ void Connection::connect(string &corba_name)
 //-----------------------------------------------------------------------------
 
 
-void Connection::toIOR(const char* iorstr,IOP::IOR& ior)
+void Connection::toIOR(const char *iorstr, IOP::IOR &ior)
 {
     size_t s = (iorstr ? strlen(iorstr) : 0);
-    if (s<4)
-        throw CORBA::MARSHAL(0,CORBA::COMPLETED_NO);
+    if (s < 4)
+        throw CORBA::MARSHAL(0, CORBA::COMPLETED_NO);
     const char *p = iorstr;
     if (p[0] != 'I' ||
         p[1] != 'O' ||
         p[2] != 'R' ||
         p[3] != ':')
-        throw CORBA::MARSHAL(0,CORBA::COMPLETED_NO);
+        throw CORBA::MARSHAL(0, CORBA::COMPLETED_NO);
 
-    s = (s-4)/2;  // how many octets are there in the string
+    s = (s - 4) / 2;  // how many octets are there in the string
     p += 4;
 
-    cdrMemoryStream buf((CORBA::ULong)s,0);
+    cdrMemoryStream buf((CORBA::ULong) s, 0);
 
-    for (int i=0; i<(int)s; i++)
+    for (int i = 0; i < (int) s; i++)
     {
-        int j = i*2;
+        int j = i * 2;
         CORBA::Octet v;
 
         if (p[j] >= '0' && p[j] <= '9')
@@ -646,22 +647,22 @@ void Connection::toIOR(const char* iorstr,IOP::IOR& ior)
             v = ((p[j] - 'A' + 10) << 4);
         }
         else
-            throw CORBA::MARSHAL(0,CORBA::COMPLETED_NO);
+            throw CORBA::MARSHAL(0, CORBA::COMPLETED_NO);
 
-        if (p[j+1] >= '0' && p[j+1] <= '9')
+        if (p[j + 1] >= '0' && p[j + 1] <= '9')
         {
-            v += (p[j+1] - '0');
+            v += (p[j + 1] - '0');
         }
-        else if (p[j+1] >= 'a' && p[j+1] <= 'f')
+        else if (p[j + 1] >= 'a' && p[j + 1] <= 'f')
         {
-            v += (p[j+1] - 'a' + 10);
+            v += (p[j + 1] - 'a' + 10);
         }
-        else if (p[j+1] >= 'A' && p[j+1] <= 'F')
+        else if (p[j + 1] >= 'A' && p[j + 1] <= 'F')
         {
-            v += (p[j+1] - 'A' + 10);
+            v += (p[j + 1] - 'A' + 10);
         }
         else
-            throw CORBA::MARSHAL(0,CORBA::COMPLETED_NO);
+            throw CORBA::MARSHAL(0, CORBA::COMPLETED_NO);
 
         buf.marshalOctet(v);
     }
@@ -683,59 +684,59 @@ void Connection::toIOR(const char* iorstr,IOP::IOR& ior)
 
 void Connection::reconnect(bool db_used)
 {
-	struct timeval now;
+    struct timeval now;
 #ifndef _TG_WINDOWS_
-	gettimeofday(&now, NULL);
+    gettimeofday(&now, NULL);
 #else
-	struct _timeb now_win;
+                                                                                                                            struct _timeb now_win;
 	_ftime(&now_win);
 	now.tv_sec = (unsigned long)now_win.time;
 	now.tv_usec = (long)now_win.millitm * 1000;
 #endif /* _TG_WINDOWS_ */
 
-	double	t = (double)now.tv_sec + ((double)now.tv_usec / 1000000);
-	double	delay = t - prev_failed_t0;
+    double t = (double) now.tv_sec + ((double) now.tv_usec / 1000000);
+    double delay = t - prev_failed_t0;
 
-	if (connection_state != CONNECTION_OK)
-	{
-		//	Do not reconnect if to soon
-		if ( (prev_failed == true) && delay < (RECONNECTION_DELAY / 1000) )
-		{
-			TangoSys_OMemStream desc;
-			desc << "Failed to connect to device " << dev_name() << endl;
-			desc << "The connection request was delayed." << endl;
-			desc << "The last connection request was done less than " << RECONNECTION_DELAY << " ms ago" << ends;
+    if (connection_state != CONNECTION_OK)
+    {
+        //	Do not reconnect if to soon
+        if ((prev_failed == true) && delay < (RECONNECTION_DELAY / 1000))
+        {
+            TangoSys_OMemStream desc;
+            desc << "Failed to connect to device " << dev_name() << endl;
+            desc << "The connection request was delayed." << endl;
+            desc << "The last connection request was done less than " << RECONNECTION_DELAY << " ms ago" << ends;
 
-			Tango::Except::throw_exception ( (const char *)API_CantConnectToDevice,
-													desc.str(),
-													(const char *)"Connection::reconnect");
-		}
-	}
+            Tango::Except::throw_exception((const char *) API_CantConnectToDevice,
+                                           desc.str(),
+                                           (const char *) "Connection::reconnect");
+        }
+    }
 
-	try
-	{
-		string corba_name;
-		if (connection_state != CONNECTION_OK)
-		{
-			if (db_used == true)
-			{
-				corba_name = get_corba_name(check_acc);
-				if (check_acc == false)
-				{
-					ApiUtil *au = ApiUtil::instance();
-					int db_num;
-					if (get_from_env_var() == true)
-						db_num = au->get_db_ind();
-					else
-						db_num = au->get_db_ind(get_db_host(),get_db_port_num());
-					(au->get_db_vect())[db_num]->clear_access_except_errors();
-				}
-			}
-			else
-				corba_name = build_corba_name();
+    try
+    {
+        string corba_name;
+        if (connection_state != CONNECTION_OK)
+        {
+            if (db_used == true)
+            {
+                corba_name = get_corba_name(check_acc);
+                if (check_acc == false)
+                {
+                    ApiUtil *au = ApiUtil::instance();
+                    int db_num;
+                    if (get_from_env_var() == true)
+                        db_num = au->get_db_ind();
+                    else
+                        db_num = au->get_db_ind(get_db_host(), get_db_port_num());
+                    (au->get_db_vect())[db_num]->clear_access_except_errors();
+                }
+            }
+            else
+                corba_name = build_corba_name();
 
-			connect(corba_name);
-		}
+            connect(corba_name);
+        }
 
 //
 // Try to ping the device. With omniORB, it is possible that the first
@@ -743,19 +744,19 @@ void Connection::reconnect(bool db_used)
 // operation is done. Do it now.
 //
 
-		if (connection_state == CONNECTION_OK)
-		{
-			try
-			{
+        if (connection_state == CONNECTION_OK)
+        {
+            try
+            {
 //				if (user_connect_timeout != -1)
 //					omniORB::setClientConnectTimeout(user_connect_timeout);
 //				else
 //					omniORB::setClientConnectTimeout(NARROW_CLNT_TIMEOUT);
-				device->ping();
+                device->ping();
 //				omniORB::setClientConnectTimeout(0);
 
-				prev_failed_t0 = t;
-				prev_failed    = false;
+                prev_failed_t0 = t;
+                prev_failed = false;
 
 //
 // If the device is the database, call its post-reconnection method
@@ -764,33 +765,33 @@ void Connection::reconnect(bool db_used)
 // class. Doing it now, will break compatibility (one more virtual method)
 //
 
-				if (corba_name.find("database") != string::npos)
-				{
-					static_cast<Database *>(this)->post_reconnection();
-				}
-			}
-			catch (CORBA::SystemException &ce)
-			{
+                if (corba_name.find("database") != string::npos)
+                {
+                    static_cast<Database *>(this)->post_reconnection();
+                }
+            }
+            catch (CORBA::SystemException &ce)
+            {
 //				omniORB::setClientConnectTimeout(0);
-				connection_state = CONNECTION_NOTOK;
+                connection_state = CONNECTION_NOTOK;
 
-				TangoSys_OMemStream desc;
-				desc << "Failed to connect to device " << dev_name() << ends;
+                TangoSys_OMemStream desc;
+                desc << "Failed to connect to device " << dev_name() << ends;
 
-				ApiConnExcept::re_throw_exception(ce,
-						  (const char *)API_CantConnectToDevice,
-						  desc.str(),
-					     (const char *)"Connection::reconnect");
-			}
-		}
-	}
-	catch (DevFailed &)
-	{
-		prev_failed    = true;
-		prev_failed_t0 = t;
+                ApiConnExcept::re_throw_exception(ce,
+                                                  (const char *) API_CantConnectToDevice,
+                                                  desc.str(),
+                                                  (const char *) "Connection::reconnect");
+            }
+        }
+    }
+    catch (DevFailed &)
+    {
+        prev_failed = true;
+        prev_failed_t0 = t;
 
-		throw;
-	}
+        throw;
+    }
 }
 
 //-----------------------------------------------------------------------------
@@ -801,11 +802,11 @@ void Connection::reconnect(bool db_used)
 
 bool Connection::is_connected()
 {
-	bool connected = true;
-	ReaderLock guard(con_to_mon);
-	if(connection_state != CONNECTION_OK)
-		connected = false;
-	return connected;
+    bool connected = true;
+    ReaderLock guard(con_to_mon);
+    if (connection_state != CONNECTION_OK)
+        connected = false;
+    return connected;
 }
 
 //-----------------------------------------------------------------------------
@@ -827,69 +828,69 @@ bool Connection::is_connected()
 //
 //-----------------------------------------------------------------------------
 
-int Connection::get_env_var(const char *env_var_name,string &env_var)
+int Connection::get_env_var(const char *env_var_name, string &env_var)
 {
-	int ret = -1;
-	char *env_c_str;
+    int ret = -1;
+    char *env_c_str;
 
 //
 // try to get it as a classical env. variable
 //
 
-	env_c_str = getenv(env_var_name);
+    env_c_str = getenv(env_var_name);
 
-	if (env_c_str == NULL)
-	{
+    if (env_c_str == NULL)
+    {
 #ifndef _TG_WINDOWS_
-		uid_t user_id = geteuid();
+        uid_t user_id = geteuid();
 
-		struct passwd pw;
-		struct passwd *pw_ptr;
-		char buffer[1024];
+        struct passwd pw;
+        struct passwd *pw_ptr;
+        char buffer[1024];
 
-		if (getpwuid_r(user_id,&pw,buffer,sizeof(buffer),&pw_ptr) != 0)
-		{
-			return ret;
-		}
+        if (getpwuid_r(user_id, &pw, buffer, sizeof(buffer), &pw_ptr) != 0)
+        {
+            return ret;
+        }
 
-		if (pw_ptr == NULL)
-		{
-			return ret;
-		}
+        if (pw_ptr == NULL)
+        {
+            return ret;
+        }
 
 //
 // Try to get it from the user home dir file
 //
 
-		string home_file(pw.pw_dir);
-		home_file = home_file + "/" + USER_ENV_VAR_FILE;
+        string home_file(pw.pw_dir);
+        home_file = home_file + "/" + USER_ENV_VAR_FILE;
 
-		int local_ret;
-		string local_env_var;
-		local_ret = get_env_var_from_file(home_file,env_var_name,local_env_var);
+        int local_ret;
+        string local_env_var;
+        local_ret = get_env_var_from_file(home_file, env_var_name, local_env_var);
 
-		if (local_ret == 0)
-		{
-			env_var = local_env_var;
-			ret = 0;
-		}
-		else
-		{
+        if (local_ret == 0)
+        {
+            env_var = local_env_var;
+            ret = 0;
+        }
+        else
+        {
 
 //
 // Try to get it from a host defined file
 //
 
-			home_file = TANGO_RC_FILE;
-			local_ret = get_env_var_from_file(home_file,env_var_name,local_env_var);
-			if (local_ret == 0)
-			{
-				env_var = local_env_var;
-				ret = 0;
-			}
-		}
+            home_file = TANGO_RC_FILE;
+            local_ret = get_env_var_from_file(home_file, env_var_name, local_env_var);
+            if (local_ret == 0)
+            {
+                env_var = local_env_var;
+                ret = 0;
+            }
+        }
 #else
-		char *env_tango_root;
+                                                                                                                                char *env_tango_root;
 
 		env_tango_root = getenv(WindowsEnvVariable);
 		if (env_tango_root != NULL)
@@ -909,14 +910,14 @@ int Connection::get_env_var(const char *env_var_name,string &env_var)
 		}
 
 #endif
-	}
-	else
-	{
-		env_var = env_c_str;
-		ret = 0;
-	}
+    }
+    else
+    {
+        env_var = env_c_str;
+        ret = 0;
+    }
 
-	return ret;
+    return ret;
 }
 
 //-----------------------------------------------------------------------------
@@ -932,46 +933,46 @@ int Connection::get_env_var(const char *env_var_name,string &env_var)
 //
 //-----------------------------------------------------------------------------
 
-int Connection::get_env_var_from_file(string &f_name,const char *env_var,string &ret_env_var)
+int Connection::get_env_var_from_file(string &f_name, const char *env_var, string &ret_env_var)
 {
     ifstream inFile;
-	string file_line;
-	string var(env_var);
-	int ret = -1;
+    string file_line;
+    string var(env_var);
+    int ret = -1;
 
     inFile.open(f_name.c_str());
     if (!inFile)
-	{
+    {
         return ret;
     }
 
-	transform(var.begin(),var.end(),var.begin(),::tolower);
+    transform(var.begin(), var.end(), var.begin(), ::tolower);
 
-	string::size_type pos_env,pos_comment;
+    string::size_type pos_env, pos_comment;
 
     while (!inFile.eof())
-	{
-		getline(inFile,file_line);
-		transform(file_line.begin(),file_line.end(),file_line.begin(),::tolower);
+    {
+        getline(inFile, file_line);
+        transform(file_line.begin(), file_line.end(), file_line.begin(), ::tolower);
 
-		if ((pos_env = file_line.find(var)) != string::npos)
-		{
-			pos_comment = file_line.find('#');
-			if ((pos_comment != string::npos) && (pos_comment < pos_env))
-				continue;
+        if ((pos_env = file_line.find(var)) != string::npos)
+        {
+            pos_comment = file_line.find('#');
+            if ((pos_comment != string::npos) && (pos_comment < pos_env))
+                continue;
 
-			string::size_type pos;
-			if ((pos = file_line.find('=')) != string::npos)
-			{
-				string tg_host = file_line.substr(pos + 1);
-				string::iterator end_pos = remove(tg_host.begin(),tg_host.end(),' ');
-				tg_host.erase(end_pos,tg_host.end());
+            string::size_type pos;
+            if ((pos = file_line.find('=')) != string::npos)
+            {
+                string tg_host = file_line.substr(pos + 1);
+                string::iterator end_pos = remove(tg_host.begin(), tg_host.end(), ' ');
+                tg_host.erase(end_pos, tg_host.end());
 
-				ret_env_var = tg_host;
-				ret = 0;
-				break;
-			}
-		}
+                ret_env_var = tg_host;
+                ret = 0;
+                break;
+            }
+        }
     }
 
     inFile.close();
@@ -1003,23 +1004,23 @@ void Connection::get_fqdn(string &the_host)
     char buffer[80];
     bool local_host = false;
 
-	if (gethostname(buffer,80) == 0)
-	{
-        if (::strcmp(buffer,the_host.c_str()) == 0)
+    if (gethostname(buffer, 80) == 0)
+    {
+        if (::strcmp(buffer, the_host.c_str()) == 0)
             local_host = true;
-	}
+    }
 
-  	struct addrinfo hints;
+    struct addrinfo hints;
 
-	memset(&hints,0,sizeof(struct addrinfo));
+    memset(&hints, 0, sizeof(struct addrinfo));
 
-  	hints.ai_flags     = AI_ADDRCONFIG;
-  	hints.ai_family    = AF_INET;
-  	hints.ai_socktype  = SOCK_STREAM;
+    hints.ai_flags = AI_ADDRCONFIG;
+    hints.ai_family = AF_INET;
+    hints.ai_socktype = SOCK_STREAM;
 
-  	struct addrinfo	*info;
-	struct addrinfo *ptr;
-	char tmp_host[512];
+    struct addrinfo *info;
+    struct addrinfo *ptr;
+    char tmp_host[512];
     bool host_found = false;
     vector<string> ip_list;
 
@@ -1041,9 +1042,9 @@ void Connection::get_fqdn(string &the_host)
 //
 
     size_t i;
-    for(i = 0; i < ip_list.size() && !host_found; i++)
+    for (i = 0; i < ip_list.size() && !host_found; i++)
     {
-        int result = getaddrinfo(ip_list[i].c_str(),NULL,&hints,&info);
+        int result = getaddrinfo(ip_list[i].c_str(), NULL, &hints, &info);
 
         if (result == 0)
         {
@@ -1054,14 +1055,14 @@ void Connection::get_fqdn(string &the_host)
 
             while (ptr != NULL)
             {
-                if (getnameinfo(ptr->ai_addr,ptr->ai_addrlen,tmp_host,512,0,0,NI_NAMEREQD) == 0)
+                if (getnameinfo(ptr->ai_addr, ptr->ai_addrlen, tmp_host, 512, 0, 0, NI_NAMEREQD) == 0)
                 {
-                	nb_loop++;
+                    nb_loop++;
                     myhost = tmp_host;
                     pos = myhost.find('.');
                     if (pos != string::npos)
                     {
-                        string canon = myhost.substr(0,pos);
+                        string canon = myhost.substr(0, pos);
                         if (canon == the_host)
                         {
                             the_host = myhost;
@@ -1075,9 +1076,9 @@ void Connection::get_fqdn(string &the_host)
             freeaddrinfo(info);
 
             if (host_found == false && nb_loop == 1 && i == (ip_list.size() - 1))
-			{
-				the_host = myhost;
-			}
+            {
+                the_host = myhost;
+            }
         }
     }
 }
@@ -1090,8 +1091,8 @@ void Connection::get_fqdn(string &the_host)
 
 int Connection::get_timeout_millis()
 {
-	ReaderLock guard(con_to_mon);
-	return timeout;
+    ReaderLock guard(con_to_mon);
+    return timeout;
 }
 
 
@@ -1103,46 +1104,47 @@ int Connection::get_timeout_millis()
 
 void Connection::set_timeout_millis(int millisecs)
 {
-	WriterLock guard(con_to_mon);
+    WriterLock guard(con_to_mon);
 
-	timeout = millisecs;
+    timeout = millisecs;
 
-	try
-	{
-		if (connection_state != CONNECTION_OK)
-			reconnect(dbase_used);
+    try
+    {
+        if (connection_state != CONNECTION_OK)
+            reconnect(dbase_used);
 
-		omniORB::setClientCallTimeout(device,millisecs);
+        omniORB::setClientCallTimeout(device, millisecs);
 
         switch (version)
         {
-        case 5:
-			omniORB::setClientCallTimeout(device_5,millisecs);
-			omniORB::setClientCallTimeout(device_4,millisecs);
-			omniORB::setClientCallTimeout(device_3,millisecs);
-			omniORB::setClientCallTimeout(device_2,millisecs);
-			break;
+            case 5:
+                omniORB::setClientCallTimeout(device_5, millisecs);
+                omniORB::setClientCallTimeout(device_4, millisecs);
+                omniORB::setClientCallTimeout(device_3, millisecs);
+                omniORB::setClientCallTimeout(device_2, millisecs);
+                break;
 
-        case 4:
-			omniORB::setClientCallTimeout(device_4,millisecs);
-			omniORB::setClientCallTimeout(device_3,millisecs);
-			omniORB::setClientCallTimeout(device_2,millisecs);
-			break;
+            case 4:
+                omniORB::setClientCallTimeout(device_4, millisecs);
+                omniORB::setClientCallTimeout(device_3, millisecs);
+                omniORB::setClientCallTimeout(device_2, millisecs);
+                break;
 
-        case 3:
-			omniORB::setClientCallTimeout(device_3,millisecs);
-			omniORB::setClientCallTimeout(device_2,millisecs);
-			break;
+            case 3:
+                omniORB::setClientCallTimeout(device_3, millisecs);
+                omniORB::setClientCallTimeout(device_2, millisecs);
+                break;
 
-        case 2:
-			omniORB::setClientCallTimeout(device_2,millisecs);
-			break;
+            case 2:
+                omniORB::setClientCallTimeout(device_2, millisecs);
+                break;
 
-        default:
-            break;
-		}
-	}
-	catch (Tango::DevFailed &) {}
+            default:
+                break;
+        }
+    }
+    catch (Tango::DevFailed &)
+    {}
 }
 
 
@@ -1155,9 +1157,9 @@ void Connection::set_timeout_millis(int millisecs)
 
 DeviceData Connection::command_inout(string &command)
 {
-	DeviceData data_in;
+    DeviceData data_in;
 
-	return(command_inout(command,data_in));
+    return (command_inout(command, data_in));
 }
 
 //-----------------------------------------------------------------------------
@@ -1177,16 +1179,16 @@ DeviceData Connection::command_inout(string &command, DeviceData &data_in)
 // memory allocated
 //
 
-	DeviceData data_out;
-	int ctr = 0;
-	DevSource local_source;
-	AccessControlType local_act;
+    DeviceData data_out;
+    int ctr = 0;
+    DevSource local_source;
+    AccessControlType local_act;
 
-	while (ctr < 2)
-	{
-		try
-		{
-			check_and_reconnect(local_source,local_act);
+    while (ctr < 2)
+    {
+        try
+        {
+            check_and_reconnect(local_source, local_act);
 
 //
 // Manage control access in case the access right
@@ -1194,26 +1196,26 @@ DeviceData Connection::command_inout(string &command, DeviceData &data_in)
 // "READ" command or not
 //
 
-			if (local_act == ACCESS_READ)
-			{
-				ApiUtil *au = ApiUtil::instance();
+            if (local_act == ACCESS_READ)
+            {
+                ApiUtil *au = ApiUtil::instance();
 
-				vector<Database *> & v_d = au->get_db_vect();
-				Database *db;
-				if (v_d.empty() == true)
-					db = static_cast<Database *>(this);
-				else
-				{
-				    int db_num;
+                vector<Database *> &v_d = au->get_db_vect();
+                Database *db;
+                if (v_d.empty() == true)
+                    db = static_cast<Database *>(this);
+                else
+                {
+                    int db_num;
 
-					if (get_from_env_var() == true)
-						db_num = au->get_db_ind();
-					else
-						db_num = au->get_db_ind(get_db_host(),get_db_port_num());
-					db = v_d[db_num];
+                    if (get_from_env_var() == true)
+                        db_num = au->get_db_ind();
+                    else
+                        db_num = au->get_db_ind(get_db_host(), get_db_port_num());
+                    db = v_d[db_num];
 /*					if (db->is_control_access_checked() == false)
 						db = static_cast<Database *>(this);*/
-				}
+                }
 
 //
 // If the command is not allowed, throw exception
@@ -1224,149 +1226,151 @@ DeviceData Connection::command_inout(string &command, DeviceData &data_in)
 // error message in case of re-connection
 //
 
-				string d_name = dev_name();
+                string d_name = dev_name();
 
-				if (db->is_command_allowed(d_name,command) == false)
-				{
-					try
-					{
-						Device_var dev = Device::_duplicate(device);
-						dev->ping();
-					}
-					catch(...)
-					{
-						set_connection_state(CONNECTION_NOTOK);
-						throw;
-					}
+                if (db->is_command_allowed(d_name, command) == false)
+                {
+                    try
+                    {
+                        Device_var dev = Device::_duplicate(device);
+                        dev->ping();
+                    }
+                    catch (...)
+                    {
+                        set_connection_state(CONNECTION_NOTOK);
+                        throw;
+                    }
 
-					DevErrorList &e = db->get_access_except_errors();
+                    DevErrorList &e = db->get_access_except_errors();
 /*					if (e.length() != 0)
 					{
 						DevFailed df(e);
 						throw df;
 					}*/
 
-					TangoSys_OMemStream desc;
-					if (e.length() == 0)
-						desc << "Command " << command << " on device " << dev_name() << " is not authorized" << ends;
-					else
-					{
-						desc << "Command " << command << " on device " << dev_name() << " is not authorized because an error occurs while talking to the Controlled Access Service" << ends;
-						string ex(e[0].desc);
-						if (ex.find("defined") != string::npos)
-							desc << "\n" << ex;
-						desc << ends;
-					}
+                    TangoSys_OMemStream desc;
+                    if (e.length() == 0)
+                        desc << "Command " << command << " on device " << dev_name() << " is not authorized" << ends;
+                    else
+                    {
+                        desc << "Command " << command << " on device " << dev_name()
+                             << " is not authorized because an error occurs while talking to the Controlled Access Service"
+                             << ends;
+                        string ex(e[0].desc);
+                        if (ex.find("defined") != string::npos)
+                            desc << "\n" << ex;
+                        desc << ends;
+                    }
 
-					NotAllowedExcept::throw_exception((const char *)API_ReadOnlyMode,desc.str(),
-													  (const char *)"Connection::command_inout()");
-				}
-			}
+                    NotAllowedExcept::throw_exception((const char *) API_ReadOnlyMode, desc.str(),
+                                                      (const char *) "Connection::command_inout()");
+                }
+            }
 
 //
 // Now, try to execute the command
 //
 
-			CORBA::Any *received;
-			if (version >= 4)
-			{
-				ClntIdent ci;
-				ApiUtil *au = ApiUtil::instance();
-				ci.cpp_clnt(au->get_client_pid());
+            CORBA::Any *received;
+            if (version >= 4)
+            {
+                ClntIdent ci;
+                ApiUtil *au = ApiUtil::instance();
+                ci.cpp_clnt(au->get_client_pid());
 
-				Device_4_var dev = Device_4::_duplicate(device_4);
-				received = dev->command_inout_4(command.c_str(),data_in.any,local_source,ci);
-			}
-			else if (version >= 2)
-			{
-				Device_2_var dev = Device_2::_duplicate(device_2);
-				received = dev->command_inout_2(command.c_str(),data_in.any,local_source);
-			}
-			else
-			{
-				Device_var dev = Device::_duplicate(device);
-				received = dev->command_inout(command.c_str(),data_in.any);
-			}
+                Device_4_var dev = Device_4::_duplicate(device_4);
+                received = dev->command_inout_4(command.c_str(), data_in.any, local_source, ci);
+            }
+            else if (version >= 2)
+            {
+                Device_2_var dev = Device_2::_duplicate(device_2);
+                received = dev->command_inout_2(command.c_str(), data_in.any, local_source);
+            }
+            else
+            {
+                Device_var dev = Device::_duplicate(device);
+                received = dev->command_inout(command.c_str(), data_in.any);
+            }
 
-			ctr = 2;
-			data_out.any = received;
-		}
-		catch (Tango::ConnectionFailed &e)
-		{
-			TangoSys_OMemStream desc;
-			desc << "Failed to execute command_inout on device " << dev_name();
-			desc << ", command " << command << ends;
-			ApiConnExcept::re_throw_exception(e,(const char*)API_CommandFailed,
-                        	desc.str(), (const char*)"Connection::command_inout()");
-		}
-		catch (Tango::DevFailed &e)
-		{
-			TangoSys_OMemStream desc;
-			desc << "Failed to execute command_inout on device " << dev_name();
-			desc << ", command " << command << ends;
+            ctr = 2;
+            data_out.any = received;
+        }
+        catch (Tango::ConnectionFailed &e)
+        {
+            TangoSys_OMemStream desc;
+            desc << "Failed to execute command_inout on device " << dev_name();
+            desc << ", command " << command << ends;
+            ApiConnExcept::re_throw_exception(e, (const char *) API_CommandFailed,
+                                              desc.str(), (const char *) "Connection::command_inout()");
+        }
+        catch (Tango::DevFailed &e)
+        {
+            TangoSys_OMemStream desc;
+            desc << "Failed to execute command_inout on device " << dev_name();
+            desc << ", command " << command << ends;
 
-			if (::strcmp(e.errors[0].reason,DEVICE_UNLOCKED_REASON) == 0)
-				DeviceUnlockedExcept::re_throw_exception(e,(const char*)DEVICE_UNLOCKED_REASON,
-							desc.str(), (const char*)"Connection::command_inout()");
-			else
-				Except::re_throw_exception(e,(const char*)API_CommandFailed,
-                        	desc.str(), (const char*)"Connection::command_inout()");
-		}
-		catch (CORBA::TRANSIENT &trans)
-		{
-			TRANSIENT_NOT_EXIST_EXCEPT_CMD(trans);
-		}
-		catch (CORBA::OBJECT_NOT_EXIST &one)
-		{
-			if (one.minor() == omni::OBJECT_NOT_EXIST_NoMatch || one.minor() == 0)
-			{
-				TRANSIENT_NOT_EXIST_EXCEPT_CMD(one);
-			}
-			else
-			{
-				set_connection_state(CONNECTION_NOTOK);
-				TangoSys_OMemStream desc;
-				desc << "Failed to execute command_inout on device " << dev_name();
-				desc << ", command " << command << ends;
-				ApiCommExcept::re_throw_exception(one,
-							      (const char*)"API_CommunicationFailed",
-                        				      desc.str(),
-							      (const char*)"Connection::command_inout()");
-			}
-		}
-		catch (CORBA::COMM_FAILURE &comm)
-		{
-			if (comm.minor() == omni::COMM_FAILURE_WaitingForReply)
-			{
-				TRANSIENT_NOT_EXIST_EXCEPT_CMD(comm);
-			}
-			else
-			{
-				set_connection_state(CONNECTION_NOTOK);
-				TangoSys_OMemStream desc;
-				desc << "Failed to execute command_inout on device " << dev_name();
-				desc << ", command " << command << ends;
-				ApiCommExcept::re_throw_exception(comm,
-							      (const char*)"API_CommunicationFailed",
-                        				      desc.str(),
-							      (const char*)"Connection::command_inout()");
-			}
-		}
+            if (::strcmp(e.errors[0].reason, DEVICE_UNLOCKED_REASON) == 0)
+                DeviceUnlockedExcept::re_throw_exception(e, (const char *) DEVICE_UNLOCKED_REASON,
+                                                         desc.str(), (const char *) "Connection::command_inout()");
+            else
+                Except::re_throw_exception(e, (const char *) API_CommandFailed,
+                                           desc.str(), (const char *) "Connection::command_inout()");
+        }
+        catch (CORBA::TRANSIENT &trans)
+        {
+            TRANSIENT_NOT_EXIST_EXCEPT_CMD(trans);
+        }
+        catch (CORBA::OBJECT_NOT_EXIST &one)
+        {
+            if (one.minor() == omni::OBJECT_NOT_EXIST_NoMatch || one.minor() == 0)
+            {
+                TRANSIENT_NOT_EXIST_EXCEPT_CMD(one);
+            }
+            else
+            {
+                set_connection_state(CONNECTION_NOTOK);
+                TangoSys_OMemStream desc;
+                desc << "Failed to execute command_inout on device " << dev_name();
+                desc << ", command " << command << ends;
+                ApiCommExcept::re_throw_exception(one,
+                                                  (const char *) "API_CommunicationFailed",
+                                                  desc.str(),
+                                                  (const char *) "Connection::command_inout()");
+            }
+        }
+        catch (CORBA::COMM_FAILURE &comm)
+        {
+            if (comm.minor() == omni::COMM_FAILURE_WaitingForReply)
+            {
+                TRANSIENT_NOT_EXIST_EXCEPT_CMD(comm);
+            }
+            else
+            {
+                set_connection_state(CONNECTION_NOTOK);
+                TangoSys_OMemStream desc;
+                desc << "Failed to execute command_inout on device " << dev_name();
+                desc << ", command " << command << ends;
+                ApiCommExcept::re_throw_exception(comm,
+                                                  (const char *) "API_CommunicationFailed",
+                                                  desc.str(),
+                                                  (const char *) "Connection::command_inout()");
+            }
+        }
         catch (CORBA::SystemException &ce)
         {
-			set_connection_state(CONNECTION_NOTOK);
+            set_connection_state(CONNECTION_NOTOK);
 
-			TangoSys_OMemStream desc;
-			desc << "Failed to execute command_inout on device " << dev_name();
-			desc << ", command " << command << ends;
-			ApiCommExcept::re_throw_exception(ce,
-						   (const char*)"API_CommunicationFailed",
-                        			   desc.str(),
-						   (const char*)"Connection::command_inout()");
-		}
-	}
+            TangoSys_OMemStream desc;
+            desc << "Failed to execute command_inout on device " << dev_name();
+            desc << ", command " << command << ends;
+            ApiCommExcept::re_throw_exception(ce,
+                                              (const char *) "API_CommunicationFailed",
+                                              desc.str(),
+                                              (const char *) "Connection::command_inout()");
+        }
+    }
 
-	return data_out;
+    return data_out;
 }
 
 //-----------------------------------------------------------------------------
@@ -1379,15 +1383,15 @@ DeviceData Connection::command_inout(string &command, DeviceData &data_in)
 
 CORBA::Any_var Connection::command_inout(string &command, CORBA::Any &any)
 {
-	int ctr = 0;
-	Tango::DevSource local_source;
-	Tango::AccessControlType local_act;
+    int ctr = 0;
+    Tango::DevSource local_source;
+    Tango::AccessControlType local_act;
 
-	while (ctr < 2)
-	{
-		try
-		{
-			check_and_reconnect(local_source,local_act);
+    while (ctr < 2)
+    {
+        try
+        {
+            check_and_reconnect(local_source, local_act);
 
 //
 // Manage control access in case the access right
@@ -1395,26 +1399,26 @@ CORBA::Any_var Connection::command_inout(string &command, CORBA::Any &any)
 // "READ" command or not
 //
 
-			if (local_act == ACCESS_READ)
-			{
-				ApiUtil *au = ApiUtil::instance();
+            if (local_act == ACCESS_READ)
+            {
+                ApiUtil *au = ApiUtil::instance();
 
-				vector<Database *> & v_d = au->get_db_vect();
-				Database *db;
-				if (v_d.empty() == true)
-					db = static_cast<Database *>(this);
-				else
-				{
-				    int db_num;
+                vector<Database *> &v_d = au->get_db_vect();
+                Database *db;
+                if (v_d.empty() == true)
+                    db = static_cast<Database *>(this);
+                else
+                {
+                    int db_num;
 
-					if (get_from_env_var() == true)
-						db_num = au->get_db_ind();
-					else
-						db_num = au->get_db_ind(get_db_host(),get_db_port_num());
-					db = v_d[db_num];
+                    if (get_from_env_var() == true)
+                        db_num = au->get_db_ind();
+                    else
+                        db_num = au->get_db_ind(get_db_host(), get_db_port_num());
+                    db = v_d[db_num];
 /*					if (db->is_control_access_checked() == false)
 						db = static_cast<Database *>(this);*/
-				}
+                }
 
 //
 // If the command is not allowed, throw exception
@@ -1425,146 +1429,148 @@ CORBA::Any_var Connection::command_inout(string &command, CORBA::Any &any)
 // error message in case of re-connection
 //
 
-				string d_name = dev_name();
-				if (db->is_command_allowed(d_name,command) == false)
-				{
-					try
-					{
-						Device_var dev = Device::_duplicate(device);
-						dev->ping();
-					}
-					catch(...)
-					{
-						set_connection_state(CONNECTION_NOTOK);
-						throw;
-					}
+                string d_name = dev_name();
+                if (db->is_command_allowed(d_name, command) == false)
+                {
+                    try
+                    {
+                        Device_var dev = Device::_duplicate(device);
+                        dev->ping();
+                    }
+                    catch (...)
+                    {
+                        set_connection_state(CONNECTION_NOTOK);
+                        throw;
+                    }
 
-					DevErrorList &e = db->get_access_except_errors();
+                    DevErrorList &e = db->get_access_except_errors();
 /*					if (e.length() != 0)
 					{
 						DevFailed df(e);
 						throw df;
 					}*/
 
-					TangoSys_OMemStream desc;
-					if (e.length() == 0)
-						desc << "Command " << command << " on device " << dev_name() << " is not authorized" << ends;
-					else
-					{
-						desc << "Command " << command << " on device " << dev_name() << " is not authorized because an error occurs while talking to the Controlled Access Service" << ends;
-						string ex(e[0].desc);
-						if (ex.find("defined") != string::npos)
-							desc << "\n" << ex;
-						desc << ends;
-					}
+                    TangoSys_OMemStream desc;
+                    if (e.length() == 0)
+                        desc << "Command " << command << " on device " << dev_name() << " is not authorized" << ends;
+                    else
+                    {
+                        desc << "Command " << command << " on device " << dev_name()
+                             << " is not authorized because an error occurs while talking to the Controlled Access Service"
+                             << ends;
+                        string ex(e[0].desc);
+                        if (ex.find("defined") != string::npos)
+                            desc << "\n" << ex;
+                        desc << ends;
+                    }
 
-					NotAllowedExcept::throw_exception((const char *)API_ReadOnlyMode,desc.str(),
-													  (const char *)"Connection::command_inout()");
-				}
-			}
+                    NotAllowedExcept::throw_exception((const char *) API_ReadOnlyMode, desc.str(),
+                                                      (const char *) "Connection::command_inout()");
+                }
+            }
 
-			if (version >= 4)
-			{
-				ClntIdent ci;
-				ApiUtil *au = ApiUtil::instance();
-				ci.cpp_clnt(au->get_client_pid());
+            if (version >= 4)
+            {
+                ClntIdent ci;
+                ApiUtil *au = ApiUtil::instance();
+                ci.cpp_clnt(au->get_client_pid());
 
-				Device_4_var dev = Device_4::_duplicate(device_4);
-				return (dev->command_inout_4(command.c_str(),any,local_source,ci));
-			}
-			else if (version >= 2)
-			{
-				Device_2_var dev = Device_2::_duplicate(device_2);
-				return (dev->command_inout_2(command.c_str(),any,local_source));
-			}
-			else
-			{
-				Device_var dev = Device::_duplicate(device);
-				return (dev->command_inout(command.c_str(),any));
-			}
-			ctr = 2;
-		}
-		catch (Tango::ConnectionFailed &e)
-		{
-			TangoSys_OMemStream desc;
-			desc << "Failed to execute command_inout on device " << dev_name();
-			desc << ", command " << command << ends;
-			ApiConnExcept::re_throw_exception(e,(const char*)API_CommandFailed,
-                        	desc.str(), (const char*)"Connection::command_inout()");
-		}
-		catch (Tango::DevFailed &e)
-		{
-			TangoSys_OMemStream desc;
-			desc << "Failed to execute command_inout on device " << dev_name();
-			desc << ", command " << command << ends;
+                Device_4_var dev = Device_4::_duplicate(device_4);
+                return (dev->command_inout_4(command.c_str(), any, local_source, ci));
+            }
+            else if (version >= 2)
+            {
+                Device_2_var dev = Device_2::_duplicate(device_2);
+                return (dev->command_inout_2(command.c_str(), any, local_source));
+            }
+            else
+            {
+                Device_var dev = Device::_duplicate(device);
+                return (dev->command_inout(command.c_str(), any));
+            }
+            ctr = 2;
+        }
+        catch (Tango::ConnectionFailed &e)
+        {
+            TangoSys_OMemStream desc;
+            desc << "Failed to execute command_inout on device " << dev_name();
+            desc << ", command " << command << ends;
+            ApiConnExcept::re_throw_exception(e, (const char *) API_CommandFailed,
+                                              desc.str(), (const char *) "Connection::command_inout()");
+        }
+        catch (Tango::DevFailed &e)
+        {
+            TangoSys_OMemStream desc;
+            desc << "Failed to execute command_inout on device " << dev_name();
+            desc << ", command " << command << ends;
 
-			if (::strcmp(e.errors[0].reason,DEVICE_UNLOCKED_REASON) == 0)
-				DeviceUnlockedExcept::re_throw_exception(e,(const char*)DEVICE_UNLOCKED_REASON,
-							desc.str(), (const char*)"Connection::command_inout()");
-			else
-				Except::re_throw_exception(e,(const char*)API_CommandFailed,
-                        	desc.str(), (const char*)"Connection::command_inout()");
-		}
-		catch (CORBA::TRANSIENT &trans)
-		{
-			TRANSIENT_NOT_EXIST_EXCEPT_CMD(trans);
-		}
-		catch (CORBA::OBJECT_NOT_EXIST &one)
-		{
-			if (one.minor() == omni::OBJECT_NOT_EXIST_NoMatch || one.minor() == 0)
-			{
-				TRANSIENT_NOT_EXIST_EXCEPT_CMD(one);
-			}
-			else
-			{
-				set_connection_state(CONNECTION_NOTOK);
-				TangoSys_OMemStream desc;
-				desc << "Failed to execute command_inout on device " << dev_name();
-				desc << ", command " << command << ends;
-				ApiCommExcept::re_throw_exception(one,
-							      (const char*)"API_CommunicationFailed",
-                        				      desc.str(),
-							      (const char*)"Connection::command_inout()");
-			}
-		}
-		catch (CORBA::COMM_FAILURE &comm)
-		{
-			if (comm.minor() == omni::COMM_FAILURE_WaitingForReply)
-			{
-				TRANSIENT_NOT_EXIST_EXCEPT_CMD(comm);
-			}
-			else
-			{
-				set_connection_state(CONNECTION_NOTOK);
-				TangoSys_OMemStream desc;
-				desc << "Failed to execute command_inout on device " << dev_name();
-				desc << ", command " << command << ends;
-				ApiCommExcept::re_throw_exception(comm,
-							      (const char*)"API_CommunicationFailed",
-                        				      desc.str(),
-							      (const char*)"Connection::command_inout()");
-			}
-		}
+            if (::strcmp(e.errors[0].reason, DEVICE_UNLOCKED_REASON) == 0)
+                DeviceUnlockedExcept::re_throw_exception(e, (const char *) DEVICE_UNLOCKED_REASON,
+                                                         desc.str(), (const char *) "Connection::command_inout()");
+            else
+                Except::re_throw_exception(e, (const char *) API_CommandFailed,
+                                           desc.str(), (const char *) "Connection::command_inout()");
+        }
+        catch (CORBA::TRANSIENT &trans)
+        {
+            TRANSIENT_NOT_EXIST_EXCEPT_CMD(trans);
+        }
+        catch (CORBA::OBJECT_NOT_EXIST &one)
+        {
+            if (one.minor() == omni::OBJECT_NOT_EXIST_NoMatch || one.minor() == 0)
+            {
+                TRANSIENT_NOT_EXIST_EXCEPT_CMD(one);
+            }
+            else
+            {
+                set_connection_state(CONNECTION_NOTOK);
+                TangoSys_OMemStream desc;
+                desc << "Failed to execute command_inout on device " << dev_name();
+                desc << ", command " << command << ends;
+                ApiCommExcept::re_throw_exception(one,
+                                                  (const char *) "API_CommunicationFailed",
+                                                  desc.str(),
+                                                  (const char *) "Connection::command_inout()");
+            }
+        }
+        catch (CORBA::COMM_FAILURE &comm)
+        {
+            if (comm.minor() == omni::COMM_FAILURE_WaitingForReply)
+            {
+                TRANSIENT_NOT_EXIST_EXCEPT_CMD(comm);
+            }
+            else
+            {
+                set_connection_state(CONNECTION_NOTOK);
+                TangoSys_OMemStream desc;
+                desc << "Failed to execute command_inout on device " << dev_name();
+                desc << ", command " << command << ends;
+                ApiCommExcept::re_throw_exception(comm,
+                                                  (const char *) "API_CommunicationFailed",
+                                                  desc.str(),
+                                                  (const char *) "Connection::command_inout()");
+            }
+        }
         catch (CORBA::SystemException &ce)
         {
-			set_connection_state(CONNECTION_NOTOK);
+            set_connection_state(CONNECTION_NOTOK);
 
-			TangoSys_OMemStream desc;
-			desc << "Failed to execute command_inout on device " << dev_name();
-			desc << ", command " << command << ends;
-			ApiCommExcept::re_throw_exception(ce,
-						   (const char*)"API_CommunicationFailed",
-                        			   desc.str(),
-						   (const char*)"Connection::command_inout()");
-		}
-	}
+            TangoSys_OMemStream desc;
+            desc << "Failed to execute command_inout on device " << dev_name();
+            desc << ", command " << command << ends;
+            ApiCommExcept::re_throw_exception(ce,
+                                              (const char *) "API_CommunicationFailed",
+                                              desc.str(),
+                                              (const char *) "Connection::command_inout()");
+        }
+    }
 
 //
 // Just to make VC++ quiet (will never reach this code !)
 //
 
-	CORBA::Any_var tmp;
-	return tmp;
+    CORBA::Any_var tmp;
+    return tmp;
 }
 
 //-----------------------------------------------------------------------------
@@ -1573,80 +1579,84 @@ CORBA::Any_var Connection::command_inout(string &command, CORBA::Any &any)
 //
 //-----------------------------------------------------------------------------
 
-DeviceProxy::DeviceProxy (string &name, CORBA::ORB *orb) : Connection(orb),
-							   db_dev(NULL),
-							   is_alias(false),
-							   adm_device(NULL),
-							   lock_ctr(0),
-							   ext_proxy(new DeviceProxyExt())
+DeviceProxy::DeviceProxy(string &name, CORBA::ORB *orb)
+    : Connection(orb),
+      db_dev(NULL),
+      is_alias(false),
+      adm_device(NULL),
+      lock_ctr(0),
+      ext_proxy(new DeviceProxyExt())
 {
-	real_constructor(name,true);
+    real_constructor(name, true);
 }
 
-DeviceProxy::DeviceProxy (const char *na, CORBA::ORB *orb) : Connection(orb),
-							     db_dev(NULL),
-								 is_alias(false),
-							     adm_device(NULL),
-							     lock_ctr(0),
-                                 ext_proxy(new DeviceProxyExt())
+DeviceProxy::DeviceProxy(const char *na, CORBA::ORB *orb)
+    : Connection(orb),
+      db_dev(NULL),
+      is_alias(false),
+      adm_device(NULL),
+      lock_ctr(0),
+      ext_proxy(new DeviceProxyExt())
 {
-	string name(na);
-	real_constructor(name,true);
+    string name(na);
+    real_constructor(name, true);
 }
 
-DeviceProxy::DeviceProxy (string &name, bool need_check_acc,CORBA::ORB *orb) : Connection(orb),
-								 db_dev(NULL),
-								 is_alias(false),
-								 adm_device(NULL),
-								 lock_ctr(0),
-							     ext_proxy(new DeviceProxyExt())
+DeviceProxy::DeviceProxy(string &name, bool need_check_acc, CORBA::ORB *orb)
+    : Connection(orb),
+      db_dev(NULL),
+      is_alias(false),
+      adm_device(NULL),
+      lock_ctr(0),
+      ext_proxy(new DeviceProxyExt())
 {
-	real_constructor(name,need_check_acc);
+    real_constructor(name, need_check_acc);
 }
 
-DeviceProxy::DeviceProxy (const char *na, bool need_check_acc,CORBA::ORB *orb) : Connection(orb),
-								 db_dev(NULL),
-								 is_alias(false),
-								 adm_device(NULL),
-								 lock_ctr(0),
-                                 ext_proxy(new DeviceProxyExt())
+DeviceProxy::DeviceProxy(const char *na, bool need_check_acc, CORBA::ORB *orb)
+    : Connection(orb),
+      db_dev(NULL),
+      is_alias(false),
+      adm_device(NULL),
+      lock_ctr(0),
+      ext_proxy(new DeviceProxyExt())
 {
-	string name(na);
-	real_constructor(name,need_check_acc);
+    string name(na);
+    real_constructor(name, need_check_acc);
 }
 
-void DeviceProxy::real_constructor (string &name,bool need_check_acc)
+void DeviceProxy::real_constructor(string &name, bool need_check_acc)
 {
 
 //
 // Parse device name
 //
 
-	parse_name(name);
-	string corba_name;
-	bool exported = true;
+    parse_name(name);
+    string corba_name;
+    bool exported = true;
 
-	if (dbase_used == true)
-	{
-		try
-		{
-			if (from_env_var == true)
-			{
-				ApiUtil *ui = ApiUtil::instance();
-				db_dev = new DbDevice(device_name);
-				int ind = ui->get_db_ind();
-				db_host = (ui->get_db_vect())[ind]->get_db_host();
-				db_port = (ui->get_db_vect())[ind]->get_db_port();
-				db_port_num = (ui->get_db_vect())[ind]->get_db_port_num();
-			}
-			else
-			{
-                db_dev = new DbDevice(device_name,db_host,db_port);
-			    if (ext_proxy->nethost_alias == true)
-			    {
+    if (dbase_used == true)
+    {
+        try
+        {
+            if (from_env_var == true)
+            {
+                ApiUtil *ui = ApiUtil::instance();
+                db_dev = new DbDevice(device_name);
+                int ind = ui->get_db_ind();
+                db_host = (ui->get_db_vect())[ind]->get_db_host();
+                db_port = (ui->get_db_vect())[ind]->get_db_port();
+                db_port_num = (ui->get_db_vect())[ind]->get_db_port_num();
+            }
+            else
+            {
+                db_dev = new DbDevice(device_name, db_host, db_port);
+                if (ext_proxy->nethost_alias == true)
+                {
                     Database *tmp_db = db_dev->get_dbase();
-			        const string &orig = tmp_db->get_orig_tango_host();
-			        if (orig.empty() == true)
+                    const string &orig = tmp_db->get_orig_tango_host();
+                    if (orig.empty() == true)
                     {
                         string orig_tg_host = ext_proxy->orig_tango_host;
                         if (orig_tg_host.find('.') == string::npos)
@@ -1655,48 +1665,48 @@ void DeviceProxy::real_constructor (string &name,bool need_check_acc)
                         }
                         tmp_db->set_orig_tango_host(ext_proxy->orig_tango_host);
                     }
-			    }
-			}
-		}
-		catch (Tango::DevFailed &e)
-		{
-			if (strcmp(e.errors[0].reason.in(),API_TangoHostNotSet) == 0)
-			{
-				cerr << e.errors[0].desc.in() << endl;
-			}
-			throw;
-		}
+                }
+            }
+        }
+        catch (Tango::DevFailed &e)
+        {
+            if (strcmp(e.errors[0].reason.in(), API_TangoHostNotSet) == 0)
+            {
+                cerr << e.errors[0].desc.in() << endl;
+            }
+            throw;
+        }
 
-		try
-		{
-			corba_name = get_corba_name(need_check_acc);
-		}
-		catch (Tango::DevFailed &dfe)
-		{
-			if (strcmp(dfe.errors[0].reason,"DB_DeviceNotDefined") == 0)
-			{
-				delete db_dev;
-				TangoSys_OMemStream desc;
-				desc << "Can't connect to device " << device_name << ends;
-				ApiConnExcept::re_throw_exception(dfe,
-						(const char *)"API_DeviceNotDefined",
-					 	desc.str(),
-						(const char *)"DeviceProxy::DeviceProxy");
-			}
-			else if (strcmp(dfe.errors[0].reason,API_DeviceNotExported) == 0)
-				exported = false;
-		}
-	}
-	else
-	{
-		corba_name = build_corba_name();
+        try
+        {
+            corba_name = get_corba_name(need_check_acc);
+        }
+        catch (Tango::DevFailed &dfe)
+        {
+            if (strcmp(dfe.errors[0].reason, "DB_DeviceNotDefined") == 0)
+            {
+                delete db_dev;
+                TangoSys_OMemStream desc;
+                desc << "Can't connect to device " << device_name << ends;
+                ApiConnExcept::re_throw_exception(dfe,
+                                                  (const char *) "API_DeviceNotDefined",
+                                                  desc.str(),
+                                                  (const char *) "DeviceProxy::DeviceProxy");
+            }
+            else if (strcmp(dfe.errors[0].reason, API_DeviceNotExported) == 0)
+                exported = false;
+        }
+    }
+    else
+    {
+        corba_name = build_corba_name();
 
 //
 // If we are not using the database, give write access
 //
 
-		access = ACCESS_WRITE;
-	}
+        access = ACCESS_WRITE;
+    }
 
 //
 // Implement stateless new() i.e. even if connect fails continue
@@ -1704,76 +1714,76 @@ void DeviceProxy::real_constructor (string &name,bool need_check_acc)
 // device name.
 //
 
-	try
-	{
-		if (exported == true)
-		{
-			connect(corba_name);
+    try
+    {
+        if (exported == true)
+        {
+            connect(corba_name);
 
-			if (is_alias == true)
-			{
-				CORBA::String_var real_name = device->name();
-				device_name = real_name.in();
-				transform(device_name.begin(),device_name.end(),device_name.begin(),::tolower);
-				db_dev->set_name(device_name);
-			}
-		}
-	}
-	catch (Tango::ConnectionFailed &dfe)
-	{
-		set_connection_state(CONNECTION_NOTOK);
-		if (dbase_used == false)
-		{
-			if (strcmp(dfe.errors[1].reason,"API_DeviceNotDefined") == 0)
-				throw;
-		}
-	}
-	catch (CORBA::SystemException &)
-	{
-		set_connection_state(CONNECTION_NOTOK);
-		if (dbase_used == false)
-			throw;
-	}
+            if (is_alias == true)
+            {
+                CORBA::String_var real_name = device->name();
+                device_name = real_name.in();
+                transform(device_name.begin(), device_name.end(), device_name.begin(), ::tolower);
+                db_dev->set_name(device_name);
+            }
+        }
+    }
+    catch (Tango::ConnectionFailed &dfe)
+    {
+        set_connection_state(CONNECTION_NOTOK);
+        if (dbase_used == false)
+        {
+            if (strcmp(dfe.errors[1].reason, "API_DeviceNotDefined") == 0)
+                throw;
+        }
+    }
+    catch (CORBA::SystemException &)
+    {
+        set_connection_state(CONNECTION_NOTOK);
+        if (dbase_used == false)
+            throw;
+    }
 
 //
 // For non-database device , try to ping them. It's the only way to know that
 // the device is not defined
 //
 
-	if (dbase_used == false)
-	{
-		try
-		{
-			ping();
-		}
-		catch (Tango::ConnectionFailed &dfe)
-		{
-			if (strcmp(dfe.errors[1].reason,"API_DeviceNotDefined") == 0)
-				throw;
-		}
-	}
+    if (dbase_used == false)
+    {
+        try
+        {
+            ping();
+        }
+        catch (Tango::ConnectionFailed &dfe)
+        {
+            if (strcmp(dfe.errors[1].reason, "API_DeviceNotDefined") == 0)
+                throw;
+        }
+    }
 
 //
 // get the name of the asscociated device when connecting
 // inside a device server
 //
 
-	try
-	{
-		ApiUtil *ui = ApiUtil::instance();
-		if (ui->in_server() == true)
-		{
-			Tango::Util *tg  = Tango::Util::instance(false);
-			tg->get_sub_dev_diag().register_sub_device (tg->get_sub_dev_diag().get_associated_device(), name);
-		}
-	}
-	catch (Tango::DevFailed &e)
-	{
-		if (::strcmp(e.errors[0].reason.in(),"API_UtilSingletonNotCreated") != 0)
-			throw;
-	}
+    try
+    {
+        ApiUtil *ui = ApiUtil::instance();
+        if (ui->in_server() == true)
+        {
+            Tango::Util *tg = Tango::Util::instance(false);
+            tg->get_sub_dev_diag().register_sub_device(tg->get_sub_dev_diag().get_associated_device(), name);
+        }
+    }
+    catch (Tango::DevFailed &e)
+    {
+        if (::strcmp(e.errors[0].reason.in(), "API_UtilSingletonNotCreated") != 0)
+            throw;
+    }
 
-	return;
+    return;
 }
 
 //-----------------------------------------------------------------------------
@@ -1782,45 +1792,46 @@ void DeviceProxy::real_constructor (string &name,bool need_check_acc)
 //
 //-----------------------------------------------------------------------------
 
-DeviceProxy::DeviceProxy(const DeviceProxy &sou):Connection(sou),ext_proxy(Tango_nullptr)
+DeviceProxy::DeviceProxy(const DeviceProxy &sou)
+    : Connection(sou), ext_proxy(Tango_nullptr)
 {
 
 //
 // Copy DeviceProxy members
 //
 
-	device_name = sou.device_name;
-	alias_name = sou.alias_name;
-	is_alias = sou.is_alias;
-	adm_dev_name = sou.adm_dev_name;
-	lock_ctr = sou.lock_ctr;
+    device_name = sou.device_name;
+    alias_name = sou.alias_name;
+    is_alias = sou.is_alias;
+    adm_dev_name = sou.adm_dev_name;
+    lock_ctr = sou.lock_ctr;
 
-	if (dbase_used == true)
-	{
-		if (from_env_var == true)
-		{
-			ApiUtil *ui = ApiUtil::instance();
-			if (ui->in_server() == true)
-				db_dev = new DbDevice(device_name,Tango::Util::instance()->get_database());
-			else
-				db_dev = new DbDevice(device_name);
-		}
-		else
-		{
-			db_dev = new DbDevice(device_name,db_host,db_port);
-		}
-	}
+    if (dbase_used == true)
+    {
+        if (from_env_var == true)
+        {
+            ApiUtil *ui = ApiUtil::instance();
+            if (ui->in_server() == true)
+                db_dev = new DbDevice(device_name, Tango::Util::instance()->get_database());
+            else
+                db_dev = new DbDevice(device_name);
+        }
+        else
+        {
+            db_dev = new DbDevice(device_name, db_host, db_port);
+        }
+    }
 
 //
 // Copy adm device pointer
 //
 
-	if (sou.adm_device == NULL)
-		adm_device = NULL;
-	else
-	{
-		adm_device = new DeviceProxy(sou.adm_device->dev_name().c_str());
-	}
+    if (sou.adm_device == NULL)
+        adm_device = NULL;
+    else
+    {
+        adm_device = new DeviceProxy(sou.adm_device->dev_name().c_str());
+    }
 
 //
 // Copy extension class
@@ -1833,7 +1844,7 @@ DeviceProxy::DeviceProxy(const DeviceProxy &sou):Connection(sou),ext_proxy(Tango
         *(ext_proxy.get()) = *(sou.ext_proxy.get());
     }
 #else
-	if (sou.ext_proxy == NULL)
+                                                                                                                            if (sou.ext_proxy == NULL)
 		ext_proxy = NULL;
 	else
 	{
@@ -1875,13 +1886,13 @@ DeviceProxy &DeviceProxy::operator=(const DeviceProxy &rval)
             {
                 ApiUtil *ui = ApiUtil::instance();
                 if (ui->in_server() == true)
-                    db_dev = new DbDevice(device_name,Tango::Util::instance()->get_database());
+                    db_dev = new DbDevice(device_name, Tango::Util::instance()->get_database());
                 else
                     db_dev = new DbDevice(device_name);
             }
             else
             {
-                db_dev = new DbDevice(device_name,db_host,db_port);
+                db_dev = new DbDevice(device_name, db_host, db_port);
             }
         }
 
@@ -1903,7 +1914,7 @@ DeviceProxy &DeviceProxy::operator=(const DeviceProxy &rval)
         else
             ext_proxy.reset();
 #else
-        delete ext_proxy;
+                                                                                                                                delete ext_proxy;
         if (rval.ext_proxy != NULL)
         {
             ext_proxy = new DeviceProxyExt;
@@ -1914,7 +1925,7 @@ DeviceProxy &DeviceProxy::operator=(const DeviceProxy &rval)
 #endif
     }
 
-	return *this;
+    return *this;
 }
 
 //-----------------------------------------------------------------------------
@@ -1928,310 +1939,310 @@ DeviceProxy &DeviceProxy::operator=(const DeviceProxy &rval)
 
 void DeviceProxy::parse_name(string &full_name)
 {
-	string name_wo_prot;
-	string name_wo_db_mod;
-	string dev_name,object_name;
+    string name_wo_prot;
+    string name_wo_db_mod;
+    string dev_name, object_name;
 
 //
 // Error of the string is empty
 //
 
-	if (full_name.empty() == true)
-	{
-		TangoSys_OMemStream desc;
-		desc << "The given name is an empty string!!! " << full_name << endl;
-		desc << "Device name syntax is domain/family/member" << ends;
+    if (full_name.empty() == true)
+    {
+        TangoSys_OMemStream desc;
+        desc << "The given name is an empty string!!! " << full_name << endl;
+        desc << "Device name syntax is domain/family/member" << ends;
 
-		ApiWrongNameExcept::throw_exception((const char *)API_WrongDeviceNameSyntax,
-						desc.str(),
-						(const char *)"DeviceProxy::parse_name()");
-	}
+        ApiWrongNameExcept::throw_exception((const char *) API_WrongDeviceNameSyntax,
+                                            desc.str(),
+                                            (const char *) "DeviceProxy::parse_name()");
+    }
 
 //
 // Device name in lower case letters
 //
 
-	string full_name_low(full_name);
-	transform(full_name_low.begin(),full_name_low.end(),full_name_low.begin(),::tolower);
+    string full_name_low(full_name);
+    transform(full_name_low.begin(), full_name_low.end(), full_name_low.begin(), ::tolower);
 
 //
 // Try to find protocol specification in device name and analyse it
 //
 
-	string::size_type pos = full_name_low.find(PROT_SEP);
-	if (pos == string::npos)
-	{
-		if (full_name_low.size() > 2)
-		{
-			if ((full_name_low[0] == '/') && (full_name_low[1] == '/'))
-				name_wo_prot = full_name_low.substr(2);
-			else
-				name_wo_prot = full_name_low;
-		}
-		else
-			name_wo_prot = full_name_low;
-	}
-	else
-	{
-		string protocol = full_name_low.substr(0,pos);
+    string::size_type pos = full_name_low.find(PROT_SEP);
+    if (pos == string::npos)
+    {
+        if (full_name_low.size() > 2)
+        {
+            if ((full_name_low[0] == '/') && (full_name_low[1] == '/'))
+                name_wo_prot = full_name_low.substr(2);
+            else
+                name_wo_prot = full_name_low;
+        }
+        else
+            name_wo_prot = full_name_low;
+    }
+    else
+    {
+        string protocol = full_name_low.substr(0, pos);
 
-		if (protocol == TANGO_PROTOCOL)
-		{
-			name_wo_prot = full_name_low.substr(pos + 3);
-		}
-		else if (protocol == TACO_PROTOCOL)
-		{
-			TangoSys_OMemStream desc;
-			desc << "Taco protocol is not supported" << ends;
-			ApiWrongNameExcept::throw_exception((const char*)"API_UnsupportedProtocol",
-						desc.str(),
-						(const char*)"DeviceProxy::parse_name()");
-		}
-		else
-		{
-			TangoSys_OMemStream desc;
-			desc << protocol;
-			desc << " protocol is an unsupported protocol" << ends;
-			ApiWrongNameExcept::throw_exception((const char*)"API_UnsupportedProtocol",
-						desc.str(),
-						(const char*)"DeviceProxy::parse_name()");
-		}
-	}
+        if (protocol == TANGO_PROTOCOL)
+        {
+            name_wo_prot = full_name_low.substr(pos + 3);
+        }
+        else if (protocol == TACO_PROTOCOL)
+        {
+            TangoSys_OMemStream desc;
+            desc << "Taco protocol is not supported" << ends;
+            ApiWrongNameExcept::throw_exception((const char *) "API_UnsupportedProtocol",
+                                                desc.str(),
+                                                (const char *) "DeviceProxy::parse_name()");
+        }
+        else
+        {
+            TangoSys_OMemStream desc;
+            desc << protocol;
+            desc << " protocol is an unsupported protocol" << ends;
+            ApiWrongNameExcept::throw_exception((const char *) "API_UnsupportedProtocol",
+                                                desc.str(),
+                                                (const char *) "DeviceProxy::parse_name()");
+        }
+    }
 
 //
 // Try to find database database modifier and analyse it
 //
 
-	pos = name_wo_prot.find(MODIFIER);
-	if (pos != string::npos)
-	{
-		string mod = name_wo_prot.substr(pos + 1);
+    pos = name_wo_prot.find(MODIFIER);
+    if (pos != string::npos)
+    {
+        string mod = name_wo_prot.substr(pos + 1);
 
-		if (mod == DBASE_YES)
-		{
-			string::size_type len = name_wo_prot.size();
-			name_wo_db_mod = name_wo_prot.substr(0,len - (len - pos));
-			dbase_used = true;
-		}
-		else if (mod == DBASE_NO)
-		{
-			string::size_type len = name_wo_prot.size();
-			name_wo_db_mod = name_wo_prot.substr(0,len - (len - pos));
-			dbase_used = false;
-		}
-		else
-		{
-			//cerr << mod << " is a non supported database modifier!" << endl;
+        if (mod == DBASE_YES)
+        {
+            string::size_type len = name_wo_prot.size();
+            name_wo_db_mod = name_wo_prot.substr(0, len - (len - pos));
+            dbase_used = true;
+        }
+        else if (mod == DBASE_NO)
+        {
+            string::size_type len = name_wo_prot.size();
+            name_wo_db_mod = name_wo_prot.substr(0, len - (len - pos));
+            dbase_used = false;
+        }
+        else
+        {
+            //cerr << mod << " is a non supported database modifier!" << endl;
 
-			TangoSys_OMemStream desc;
-			desc << mod;
-			desc << " modifier is an unsupported db modifier" << ends;
-			ApiWrongNameExcept::throw_exception((const char*)"API_UnsupportedDBaseModifier",
-						desc.str(),
-						(const char*)"DeviceProxy::parse_name()");
-		}
-	}
-	else
-	{
-		name_wo_db_mod = name_wo_prot;
-		dbase_used = true;
-	}
+            TangoSys_OMemStream desc;
+            desc << mod;
+            desc << " modifier is an unsupported db modifier" << ends;
+            ApiWrongNameExcept::throw_exception((const char *) "API_UnsupportedDBaseModifier",
+                                                desc.str(),
+                                                (const char *) "DeviceProxy::parse_name()");
+        }
+    }
+    else
+    {
+        name_wo_db_mod = name_wo_prot;
+        dbase_used = true;
+    }
 
-	if (dbase_used == false)
-	{
+    if (dbase_used == false)
+    {
 
 //
 // Extract host name and port number
 //
 
-		pos = name_wo_db_mod.find(HOST_SEP);
-		if (pos == string::npos)
-		{
-			TangoSys_OMemStream desc;
-			desc << "Host and port not correctly defined in device name " << full_name << ends;
+        pos = name_wo_db_mod.find(HOST_SEP);
+        if (pos == string::npos)
+        {
+            TangoSys_OMemStream desc;
+            desc << "Host and port not correctly defined in device name " << full_name << ends;
 
-			ApiWrongNameExcept::throw_exception((const char*)API_WrongDeviceNameSyntax,
-						desc.str(),
-						(const char*)"DeviceProxy::parse_name()");
-		}
+            ApiWrongNameExcept::throw_exception((const char *) API_WrongDeviceNameSyntax,
+                                                desc.str(),
+                                                (const char *) "DeviceProxy::parse_name()");
+        }
 
-		host = name_wo_db_mod.substr(0,pos);
-		string::size_type tmp = name_wo_db_mod.find(PORT_SEP);
-		if (tmp == string::npos)
-		{
-			TangoSys_OMemStream desc;
-			desc << "Host and port not correctly defined in device name " << full_name << ends;
+        host = name_wo_db_mod.substr(0, pos);
+        string::size_type tmp = name_wo_db_mod.find(PORT_SEP);
+        if (tmp == string::npos)
+        {
+            TangoSys_OMemStream desc;
+            desc << "Host and port not correctly defined in device name " << full_name << ends;
 
-			ApiWrongNameExcept::throw_exception((const char*)API_WrongDeviceNameSyntax,
-						desc.str(),
-						(const char*)"DeviceProxy::parse_name()");
-		}
-		port = name_wo_db_mod.substr(pos + 1,tmp - pos - 1);
-		TangoSys_MemStream s;
-		s << port << ends;
-		s >> port_num;
-		device_name = name_wo_db_mod.substr(tmp + 1);
+            ApiWrongNameExcept::throw_exception((const char *) API_WrongDeviceNameSyntax,
+                                                desc.str(),
+                                                (const char *) "DeviceProxy::parse_name()");
+        }
+        port = name_wo_db_mod.substr(pos + 1, tmp - pos - 1);
+        TangoSys_MemStream s;
+        s << port << ends;
+        s >> port_num;
+        device_name = name_wo_db_mod.substr(tmp + 1);
 
 //
 // Check device name syntax (domain/family/member). Alias are forbidden without
 // using the db
 //
 
-		tmp = device_name.find(DEV_NAME_FIELD_SEP);
-		if (tmp == string::npos)
-		{
-			TangoSys_OMemStream desc;
-			desc << "Wrong device name syntax (domain/family/member) in " << full_name << endl;
-			desc << "Rem: Alias are forbidden when not using a database" << ends;
+        tmp = device_name.find(DEV_NAME_FIELD_SEP);
+        if (tmp == string::npos)
+        {
+            TangoSys_OMemStream desc;
+            desc << "Wrong device name syntax (domain/family/member) in " << full_name << endl;
+            desc << "Rem: Alias are forbidden when not using a database" << ends;
 
-			ApiWrongNameExcept::throw_exception((const char *)API_WrongDeviceNameSyntax,
-						desc.str(),
-						(const char *)"DeviceProxy::parse_name()");
-		}
-		string::size_type prev_sep = tmp;
-		tmp = device_name.find(DEV_NAME_FIELD_SEP,tmp + 1);
-		if ((tmp == string::npos) || (tmp == prev_sep + 1))
-		{
-			TangoSys_OMemStream desc;
-			desc << "Wrong device name syntax (domain/family/member) in " << full_name << endl;
-			desc << "Rem: Alias are forbidden when not using a database" << ends;
+            ApiWrongNameExcept::throw_exception((const char *) API_WrongDeviceNameSyntax,
+                                                desc.str(),
+                                                (const char *) "DeviceProxy::parse_name()");
+        }
+        string::size_type prev_sep = tmp;
+        tmp = device_name.find(DEV_NAME_FIELD_SEP, tmp + 1);
+        if ((tmp == string::npos) || (tmp == prev_sep + 1))
+        {
+            TangoSys_OMemStream desc;
+            desc << "Wrong device name syntax (domain/family/member) in " << full_name << endl;
+            desc << "Rem: Alias are forbidden when not using a database" << ends;
 
-			ApiWrongNameExcept::throw_exception((const char *)API_WrongDeviceNameSyntax,
-						desc.str(),
-						(const char *)"DeviceProxy::parse_name()");
-		}
-		prev_sep = tmp;
-		tmp = device_name.find(DEV_NAME_FIELD_SEP,tmp + 1);
-		if (tmp != string::npos)
-		{
-			TangoSys_OMemStream desc;
-			desc << "Wrong device name syntax (domain/family/member) in " << full_name << endl;
-			desc << "Rem: Alias are forbidden when not using a database" << ends;
+            ApiWrongNameExcept::throw_exception((const char *) API_WrongDeviceNameSyntax,
+                                                desc.str(),
+                                                (const char *) "DeviceProxy::parse_name()");
+        }
+        prev_sep = tmp;
+        tmp = device_name.find(DEV_NAME_FIELD_SEP, tmp + 1);
+        if (tmp != string::npos)
+        {
+            TangoSys_OMemStream desc;
+            desc << "Wrong device name syntax (domain/family/member) in " << full_name << endl;
+            desc << "Rem: Alias are forbidden when not using a database" << ends;
 
-			ApiWrongNameExcept::throw_exception((const char *)API_WrongDeviceNameSyntax,
-						desc.str(),
-						(const char *)"DeviceProxy::parse_name()");
-		}
+            ApiWrongNameExcept::throw_exception((const char *) API_WrongDeviceNameSyntax,
+                                                desc.str(),
+                                                (const char *) "DeviceProxy::parse_name()");
+        }
 
-		db_host = db_port = NOT_USED;
-		db_port_num = 0;
-		from_env_var = false;
-	}
-	else
-	{
+        db_host = db_port = NOT_USED;
+        db_port_num = 0;
+        from_env_var = false;
+    }
+    else
+    {
 
 //
 // Search if host and port are specified
 //
 
-		pos = name_wo_db_mod.find(PORT_SEP);
-		if (pos == string::npos)
-		{
+        pos = name_wo_db_mod.find(PORT_SEP);
+        if (pos == string::npos)
+        {
 
 //
 // It could be an alias name, check its syntax
 //
 
-			pos = name_wo_db_mod.find(HOST_SEP);
-			if (pos != string::npos)
-			{
-				TangoSys_OMemStream desc;
-				desc << "Wrong alias name syntax in " << full_name << " (: is not allowed in alias name)" << ends;
+            pos = name_wo_db_mod.find(HOST_SEP);
+            if (pos != string::npos)
+            {
+                TangoSys_OMemStream desc;
+                desc << "Wrong alias name syntax in " << full_name << " (: is not allowed in alias name)" << ends;
 
-				ApiWrongNameExcept::throw_exception((const char *)API_WrongDeviceNameSyntax,
-						desc.str(),
-						(const char *)"DeviceProxy::parse_name()");
-			}
+                ApiWrongNameExcept::throw_exception((const char *) API_WrongDeviceNameSyntax,
+                                                    desc.str(),
+                                                    (const char *) "DeviceProxy::parse_name()");
+            }
 
-			pos = name_wo_db_mod.find(RES_SEP);
-			if (pos != string::npos)
-			{
-				TangoSys_OMemStream desc;
-				desc << "Wrong alias name syntax in " << full_name << " (-> is not allowed in alias name)" << ends;
+            pos = name_wo_db_mod.find(RES_SEP);
+            if (pos != string::npos)
+            {
+                TangoSys_OMemStream desc;
+                desc << "Wrong alias name syntax in " << full_name << " (-> is not allowed in alias name)" << ends;
 
-				ApiWrongNameExcept::throw_exception((const char *)API_WrongDeviceNameSyntax,
-						desc.str(),
-						(const char *)"DeviceProxy::parse_name()");
-			}
+                ApiWrongNameExcept::throw_exception((const char *) API_WrongDeviceNameSyntax,
+                                                    desc.str(),
+                                                    (const char *) "DeviceProxy::parse_name()");
+            }
 
 //
 // Alias name syntax OK
 //
 
-			alias_name = device_name = name_wo_db_mod;
-			is_alias = true;
-			from_env_var = true;
-			port_num = 0;
-			host = FROM_IOR;
-			port = FROM_IOR;
-		}
-		else
-		{
-			string bef_sep = name_wo_db_mod.substr(0,pos);
-			string::size_type tmp = bef_sep.find(HOST_SEP);
-			if (tmp == string::npos)
-			{
+            alias_name = device_name = name_wo_db_mod;
+            is_alias = true;
+            from_env_var = true;
+            port_num = 0;
+            host = FROM_IOR;
+            port = FROM_IOR;
+        }
+        else
+        {
+            string bef_sep = name_wo_db_mod.substr(0, pos);
+            string::size_type tmp = bef_sep.find(HOST_SEP);
+            if (tmp == string::npos)
+            {
 
 //
 // There is at least one / in dev name but it is not a TANGO_HOST definition.
 // A correct dev name must have 2 /. Check this. An alias cannot have any /
 //
 
-				if (pos == 0)
-				{
-					TangoSys_OMemStream desc;
-					desc << "Wrong device name syntax (domain/family/member) in " << full_name << ends;
+                if (pos == 0)
+                {
+                    TangoSys_OMemStream desc;
+                    desc << "Wrong device name syntax (domain/family/member) in " << full_name << ends;
 
-					ApiWrongNameExcept::throw_exception((const char *)API_WrongDeviceNameSyntax,
-						desc.str(),
-						(const char *)"DeviceProxy::parse_name()");
-				}
+                    ApiWrongNameExcept::throw_exception((const char *) API_WrongDeviceNameSyntax,
+                                                        desc.str(),
+                                                        (const char *) "DeviceProxy::parse_name()");
+                }
 
-				string::size_type prev_sep = pos;
-				pos = name_wo_db_mod.find(DEV_NAME_FIELD_SEP,pos + 1);
-				if ((pos == string::npos) || (pos == prev_sep + 1))
-				{
+                string::size_type prev_sep = pos;
+                pos = name_wo_db_mod.find(DEV_NAME_FIELD_SEP, pos + 1);
+                if ((pos == string::npos) || (pos == prev_sep + 1))
+                {
 
-					TangoSys_OMemStream desc;
-					desc << "Wrong device name syntax (domain/family/member) in " << full_name << ends;
+                    TangoSys_OMemStream desc;
+                    desc << "Wrong device name syntax (domain/family/member) in " << full_name << ends;
 
-					ApiWrongNameExcept::throw_exception((const char *)API_WrongDeviceNameSyntax,
-						desc.str(),
-						(const char *)"DeviceProxy::parse_name()");
-				}
+                    ApiWrongNameExcept::throw_exception((const char *) API_WrongDeviceNameSyntax,
+                                                        desc.str(),
+                                                        (const char *) "DeviceProxy::parse_name()");
+                }
 
-				prev_sep = pos;
-				pos = name_wo_db_mod.find(DEV_NAME_FIELD_SEP,prev_sep + 1);
-				if (pos != string::npos)
-				{
-					TangoSys_OMemStream desc;
-					desc << "Wrong device name syntax (domain/family/member) in " << full_name << ends;
+                prev_sep = pos;
+                pos = name_wo_db_mod.find(DEV_NAME_FIELD_SEP, prev_sep + 1);
+                if (pos != string::npos)
+                {
+                    TangoSys_OMemStream desc;
+                    desc << "Wrong device name syntax (domain/family/member) in " << full_name << ends;
 
-					ApiWrongNameExcept::throw_exception((const char *)API_WrongDeviceNameSyntax,
-						desc.str(),
-						(const char *)"DeviceProxy::parse_name()");
-				}
+                    ApiWrongNameExcept::throw_exception((const char *) API_WrongDeviceNameSyntax,
+                                                        desc.str(),
+                                                        (const char *) "DeviceProxy::parse_name()");
+                }
 
-				device_name = name_wo_db_mod;
-				from_env_var = true;
-				port_num = 0;
-				port = FROM_IOR;
-				host = FROM_IOR;
-			}
-			else
-			{
-				string tmp_host(bef_sep.substr(0,tmp));
-				string safe_tmp_host(tmp_host);
+                device_name = name_wo_db_mod;
+                from_env_var = true;
+                port_num = 0;
+                port = FROM_IOR;
+                host = FROM_IOR;
+            }
+            else
+            {
+                string tmp_host(bef_sep.substr(0, tmp));
+                string safe_tmp_host(tmp_host);
 
-				if (tmp_host.find('.') == string::npos)
-					get_fqdn(tmp_host);
+                if (tmp_host.find('.') == string::npos)
+                    get_fqdn(tmp_host);
 
                 string::size_type pos2 = tmp_host.find('.');
                 bool alias_used = false;
                 string fq;
                 if (pos2 != string::npos)
                 {
-                    string h_name = tmp_host.substr(0,pos2);
+                    string h_name = tmp_host.substr(0, pos2);
                     fq = tmp_host.substr(pos2);
                     if (h_name != tmp_host)
                         alias_used = true;
@@ -2248,54 +2259,56 @@ void DeviceProxy::parse_name(string &full_name)
                     ext_proxy->nethost_alias = false;
 
                 db_host = tmp_host;
-				db_port = bef_sep.substr(tmp + 1);
-				TangoSys_MemStream s;
-				s << db_port << ends;
-				s >> db_port_num;
-				object_name = name_wo_db_mod.substr(pos + 1);
+                db_port = bef_sep.substr(tmp + 1);
+                TangoSys_MemStream s;
+                s << db_port << ends;
+                s >> db_port_num;
+                object_name = name_wo_db_mod.substr(pos + 1);
 
 //
 // We should now check if the object name is a device name or an alias
 //
 
-				pos = object_name.find(DEV_NAME_FIELD_SEP);
-				if (pos == string::npos)
-				{
+                pos = object_name.find(DEV_NAME_FIELD_SEP);
+                if (pos == string::npos)
+                {
 
 //
 // It is an alias. Check its syntax
 //
 
-					pos = object_name.find(HOST_SEP);
-					if (pos != string::npos)
-					{
-						TangoSys_OMemStream desc;
-						desc << "Wrong alias name syntax in " << full_name << " (: is not allowed in alias name)" << ends;
+                    pos = object_name.find(HOST_SEP);
+                    if (pos != string::npos)
+                    {
+                        TangoSys_OMemStream desc;
+                        desc << "Wrong alias name syntax in " << full_name << " (: is not allowed in alias name)"
+                             << ends;
 
-						ApiWrongNameExcept::throw_exception((const char *)API_WrongDeviceNameSyntax,
-						desc.str(),
-						(const char *)"DeviceProxy::parse_name()");
-					}
+                        ApiWrongNameExcept::throw_exception((const char *) API_WrongDeviceNameSyntax,
+                                                            desc.str(),
+                                                            (const char *) "DeviceProxy::parse_name()");
+                    }
 
-					pos = object_name.find(RES_SEP);
-					if (pos != string::npos)
-					{
-						TangoSys_OMemStream desc;
-						desc << "Wrong alias name syntax in " << full_name << " (-> is not allowed in alias name)" << ends;
+                    pos = object_name.find(RES_SEP);
+                    if (pos != string::npos)
+                    {
+                        TangoSys_OMemStream desc;
+                        desc << "Wrong alias name syntax in " << full_name << " (-> is not allowed in alias name)"
+                             << ends;
 
-						ApiWrongNameExcept::throw_exception((const char *)API_WrongDeviceNameSyntax,
-						desc.str(),
-						(const char *)"DeviceProxy::parse_name()");
-					}
-					alias_name = device_name = object_name;
-					is_alias = true;
+                        ApiWrongNameExcept::throw_exception((const char *) API_WrongDeviceNameSyntax,
+                                                            desc.str(),
+                                                            (const char *) "DeviceProxy::parse_name()");
+                    }
+                    alias_name = device_name = object_name;
+                    is_alias = true;
 
 //
 // Alias name syntax OK, but is it really an alias defined in db ?
 //
-				}
-				else
-				{
+                }
+                else
+                {
 
 //
 // It's a device name. Check its syntax.
@@ -2303,40 +2316,40 @@ void DeviceProxy::parse_name(string &full_name)
 // A correct dev name must have 2 /. Check this. An alias cannot have any /
 //
 
-					string::size_type prev_sep = pos;
-					pos = object_name.find(DEV_NAME_FIELD_SEP,pos + 1);
-					if ((pos == string::npos) || (pos == prev_sep + 1))
-					{
-						TangoSys_OMemStream desc;
-						desc << "Wrong device name syntax (domain/family/member) in " << full_name << ends;
+                    string::size_type prev_sep = pos;
+                    pos = object_name.find(DEV_NAME_FIELD_SEP, pos + 1);
+                    if ((pos == string::npos) || (pos == prev_sep + 1))
+                    {
+                        TangoSys_OMemStream desc;
+                        desc << "Wrong device name syntax (domain/family/member) in " << full_name << ends;
 
-						ApiWrongNameExcept::throw_exception((const char *)API_WrongDeviceNameSyntax,
-						desc.str(),
-						(const char *)"DeviceProxy::parse_name()");
-					}
+                        ApiWrongNameExcept::throw_exception((const char *) API_WrongDeviceNameSyntax,
+                                                            desc.str(),
+                                                            (const char *) "DeviceProxy::parse_name()");
+                    }
 
-					prev_sep = pos;
-					pos = object_name.find(DEV_NAME_FIELD_SEP,prev_sep + 1);
-					if (pos != string::npos)
-					{
-						TangoSys_OMemStream desc;
-						desc << "Wrong device name syntax (domain/family/member) in " << full_name << ends;
+                    prev_sep = pos;
+                    pos = object_name.find(DEV_NAME_FIELD_SEP, prev_sep + 1);
+                    if (pos != string::npos)
+                    {
+                        TangoSys_OMemStream desc;
+                        desc << "Wrong device name syntax (domain/family/member) in " << full_name << ends;
 
-						ApiWrongNameExcept::throw_exception((const char *)API_WrongDeviceNameSyntax,
-						desc.str(),
-						(const char *)"DeviceProxy::parse_name()");
-					}
+                        ApiWrongNameExcept::throw_exception((const char *) API_WrongDeviceNameSyntax,
+                                                            desc.str(),
+                                                            (const char *) "DeviceProxy::parse_name()");
+                    }
 
-					device_name = object_name;
-				}
-				from_env_var = false;
-				port_num = 0;
-				port = FROM_IOR;
-				host = FROM_IOR;
-			}
-		}
+                    device_name = object_name;
+                }
+                from_env_var = false;
+                port_num = 0;
+                port = FROM_IOR;
+                host = FROM_IOR;
+            }
+        }
 
-	}
+    }
 
 }
 
@@ -2353,45 +2366,45 @@ string DeviceProxy::get_corba_name(bool need_check_acc)
 // (in case the device is embedded in the same process)
 //
 
-	string local_ior;
-	if (ApiUtil::instance()->in_server() == true)
-		local_import(local_ior);
+    string local_ior;
+    if (ApiUtil::instance()->in_server() == true)
+        local_import(local_ior);
 
 //
 // If we are not in a server or if the device is not in the same process,
 // ask the database
 //
 
-	DbDevImportInfo import_info;
+    DbDevImportInfo import_info;
 
-	if (local_ior.size() == 0)
-	{
-		import_info = db_dev->import_device();
+    if (local_ior.size() == 0)
+    {
+        import_info = db_dev->import_device();
 
-		if (import_info.exported != 1)
-		{
-			connection_state = CONNECTION_NOTOK;
+        if (import_info.exported != 1)
+        {
+            connection_state = CONNECTION_NOTOK;
 
-			TangoSys_OMemStream desc;
-			desc << "Device " << device_name << " is not exported (hint: try starting the device server)" << ends;
-			ApiConnExcept::throw_exception(API_DeviceNotExported,desc.str(),
-						       "DeviceProxy::get_corba_name()");
-		}
-	}
+            TangoSys_OMemStream desc;
+            desc << "Device " << device_name << " is not exported (hint: try starting the device server)" << ends;
+            ApiConnExcept::throw_exception(API_DeviceNotExported, desc.str(),
+                                           "DeviceProxy::get_corba_name()");
+        }
+    }
 
 //
 // Get device access right
 //
 
-	if (need_check_acc == true)
-		access = db_dev->check_access_control();
-	else
-		check_acc = false;
+    if (need_check_acc == true)
+        access = db_dev->check_access_control();
+    else
+        check_acc = false;
 
-	if (local_ior.size() != 0)
-		return local_ior;
-	else
-		return import_info.ior;
+    if (local_ior.size() != 0)
+        return local_ior;
+    else
+        return import_info.ior;
 }
 
 //-----------------------------------------------------------------------------
@@ -2405,11 +2418,11 @@ string DeviceProxy::get_corba_name(bool need_check_acc)
 string DeviceProxy::build_corba_name()
 {
 
-	string db_corbaloc = "corbaloc:iiop:";
-	db_corbaloc = db_corbaloc + host + ":" + port;
-	db_corbaloc = db_corbaloc + "/" + device_name;
+    string db_corbaloc = "corbaloc:iiop:";
+    db_corbaloc = db_corbaloc + host + ":" + port;
+    db_corbaloc = db_corbaloc + "/" + device_name;
 
-	return db_corbaloc;
+    return db_corbaloc;
 }
 
 //-----------------------------------------------------------------------------
@@ -2422,18 +2435,18 @@ string DeviceProxy::build_corba_name()
 
 void DeviceProxy::reconnect(bool db_used)
 {
-	Connection::reconnect(db_used);
+    Connection::reconnect(db_used);
 
-	if (connection_state == CONNECTION_OK)
-	{
-		if (is_alias == true)
-		{
-			CORBA::String_var real_name = device->name();
-			device_name = real_name.in();
-			transform(device_name.begin(),device_name.end(),device_name.begin(),::tolower);
-			db_dev->set_name(device_name);
-		}
-	}
+    if (connection_state == CONNECTION_OK)
+    {
+        if (is_alias == true)
+        {
+            CORBA::String_var real_name = device->name();
+            device_name = real_name.in();
+            transform(device_name.begin(), device_name.end(), device_name.begin(), ::tolower);
+            db_dev->set_name(device_name);
+        }
+    }
 }
 
 //-----------------------------------------------------------------------------
@@ -2444,25 +2457,25 @@ void DeviceProxy::reconnect(bool db_used)
 
 DbDevImportInfo DeviceProxy::import_info()
 {
-	DbDevImportInfo import_info;
+    DbDevImportInfo import_info;
 
-	if (dbase_used == false)
-	{
-		TangoSys_OMemStream desc;
-		desc << "Method not available for device ";
-		desc << device_name;
-		desc << " which is a non database device";
+    if (dbase_used == false)
+    {
+        TangoSys_OMemStream desc;
+        desc << "Method not available for device ";
+        desc << device_name;
+        desc << " which is a non database device";
 
-		ApiNonDbExcept::throw_exception((const char *)API_NonDatabaseDevice,
-					        desc.str(),
-					        (const char *)"DeviceProxy::import_info");
-	}
-	else
-	{
-		import_info = db_dev->import_device();
-	}
+        ApiNonDbExcept::throw_exception((const char *) API_NonDatabaseDevice,
+                                        desc.str(),
+                                        (const char *) "DeviceProxy::import_info");
+    }
+    else
+    {
+        import_info = db_dev->import_device();
+    }
 
-	return(import_info);
+    return (import_info);
 }
 
 
@@ -2474,8 +2487,8 @@ DbDevImportInfo DeviceProxy::import_info()
 
 DeviceProxy::~DeviceProxy()
 {
-	if (dbase_used == true)
-		delete db_dev;
+    if (dbase_used == true)
+        delete db_dev;
 
 //
 // If the device has some subscribed event, unsubscribe them
@@ -2488,11 +2501,11 @@ DeviceProxy::~DeviceProxy()
         if (zmq != Tango_nullptr)
         {
             vector<int> ids;
-            zmq->get_subscribed_event_ids(this,ids);
+            zmq->get_subscribed_event_ids(this, ids);
             if (ids.empty() == false)
             {
                 vector<int>::iterator ite;
-                for (ite = ids.begin();ite != ids.end();++ite)
+                for (ite = ids.begin(); ite != ids.end(); ++ite)
                 {
                     unsubscribe_event(*ite);
                 }
@@ -2505,17 +2518,18 @@ DeviceProxy::~DeviceProxy()
 // If the device is locked, unlock it whatever the lock counter is
 //
 
-	if (ApiUtil::_is_instance_null() == false)
-	{
-		if (lock_ctr > 0)
-		{
-			try
-			{
-				unlock(true);
-			}
-			catch(...) {}
-		}
-	}
+    if (ApiUtil::_is_instance_null() == false)
+    {
+        if (lock_ctr > 0)
+        {
+            try
+            {
+                unlock(true);
+            }
+            catch (...)
+            {}
+        }
+    }
 
 //
 // Delete memory
@@ -2537,91 +2551,91 @@ DeviceProxy::~DeviceProxy()
 
 int DeviceProxy::ping()
 {
-	int elapsed;
+    int elapsed;
 
 #ifndef _TG_WINDOWS_
-	struct timeval before, after;
+    struct timeval before, after;
 
-	gettimeofday(&before, NULL);
+    gettimeofday(&before, NULL);
 #else
-	struct _timeb before, after;
+                                                                                                                            struct _timeb before, after;
 
 	_ftime(&before);
 #endif /* _TG_WINDOWS_ */
 
-	int ctr = 0;
+    int ctr = 0;
 
-	while (ctr < 2)
-	{
-		try
-		{
-			check_and_reconnect();
+    while (ctr < 2)
+    {
+        try
+        {
+            check_and_reconnect();
 
-			Device_var dev = Device::_duplicate(device);
-			dev->ping();
-			ctr = 2;
-		}
-		catch (CORBA::TRANSIENT &trans)
-		{
-			TRANSIENT_NOT_EXIST_EXCEPT(trans,"DeviceProxy","ping",this);
-		}
-		catch (CORBA::OBJECT_NOT_EXIST &one)
-		{
-			if (one.minor() == omni::OBJECT_NOT_EXIST_NoMatch || one.minor() == 0)
-			{
-				TRANSIENT_NOT_EXIST_EXCEPT(one,"DeviceProxy","ping",this);
-			}
-			else
-			{
-				set_connection_state(CONNECTION_NOTOK);
-				TangoSys_OMemStream desc;
-				desc << "Failed to execute ping on device " << device_name << ends;
-				ApiCommExcept::re_throw_exception(one,
-							      (const char*)"API_CommunicationFailed",
-                        				      desc.str(),
-							      (const char*)"DeviceProxy::ping()");
-			}
-		}
-		catch (CORBA::COMM_FAILURE &comm)
-		{
-			if (comm.minor() == omni::COMM_FAILURE_WaitingForReply)
-			{
-				TRANSIENT_NOT_EXIST_EXCEPT(comm,"DeviceProxy","ping",this);
-			}
-			else
-			{
-				set_connection_state(CONNECTION_NOTOK);
-				TangoSys_OMemStream desc;
-				desc << "Failed to execute ping on device " << device_name << ends;
-				ApiCommExcept::re_throw_exception(comm,
-							      (const char*)"API_CommunicationFailed",
-                        				      desc.str(),
-							      (const char*)"DeviceProxy::ping()");
-			}
-		}
+            Device_var dev = Device::_duplicate(device);
+            dev->ping();
+            ctr = 2;
+        }
+        catch (CORBA::TRANSIENT &trans)
+        {
+            TRANSIENT_NOT_EXIST_EXCEPT(trans, "DeviceProxy", "ping", this);
+        }
+        catch (CORBA::OBJECT_NOT_EXIST &one)
+        {
+            if (one.minor() == omni::OBJECT_NOT_EXIST_NoMatch || one.minor() == 0)
+            {
+                TRANSIENT_NOT_EXIST_EXCEPT(one, "DeviceProxy", "ping", this);
+            }
+            else
+            {
+                set_connection_state(CONNECTION_NOTOK);
+                TangoSys_OMemStream desc;
+                desc << "Failed to execute ping on device " << device_name << ends;
+                ApiCommExcept::re_throw_exception(one,
+                                                  (const char *) "API_CommunicationFailed",
+                                                  desc.str(),
+                                                  (const char *) "DeviceProxy::ping()");
+            }
+        }
+        catch (CORBA::COMM_FAILURE &comm)
+        {
+            if (comm.minor() == omni::COMM_FAILURE_WaitingForReply)
+            {
+                TRANSIENT_NOT_EXIST_EXCEPT(comm, "DeviceProxy", "ping", this);
+            }
+            else
+            {
+                set_connection_state(CONNECTION_NOTOK);
+                TangoSys_OMemStream desc;
+                desc << "Failed to execute ping on device " << device_name << ends;
+                ApiCommExcept::re_throw_exception(comm,
+                                                  (const char *) "API_CommunicationFailed",
+                                                  desc.str(),
+                                                  (const char *) "DeviceProxy::ping()");
+            }
+        }
         catch (CORBA::SystemException &ce)
         {
-			set_connection_state(CONNECTION_NOTOK);
+            set_connection_state(CONNECTION_NOTOK);
 
-			TangoSys_OMemStream desc;
-			desc << "Failed to execute ping on device " << device_name << ends;
-			ApiCommExcept::re_throw_exception(ce,
-						   (const char*)"API_CommunicationFailed",
-                        	desc.str(),
-						   (const char*)"DeviceProxy::ping()");
-		}
-	}
+            TangoSys_OMemStream desc;
+            desc << "Failed to execute ping on device " << device_name << ends;
+            ApiCommExcept::re_throw_exception(ce,
+                                              (const char *) "API_CommunicationFailed",
+                                              desc.str(),
+                                              (const char *) "DeviceProxy::ping()");
+        }
+    }
 #ifndef _TG_WINDOWS_
-	gettimeofday(&after, NULL);
-	elapsed = (after.tv_sec-before.tv_sec)*1000000;
-	elapsed = (after.tv_usec-before.tv_usec) + elapsed;
+    gettimeofday(&after, NULL);
+    elapsed = (after.tv_sec - before.tv_sec) * 1000000;
+    elapsed = (after.tv_usec - before.tv_usec) + elapsed;
 #else
-	_ftime(&after);
+                                                                                                                            _ftime(&after);
 	elapsed = (after.time-before.time)*1000000;
 	elapsed = (after.millitm-before.millitm)*1000 + elapsed;
 #endif /* _TG_WINDOWS_ */
 
-	return(elapsed);
+    return (elapsed);
 }
 
 //-----------------------------------------------------------------------------
@@ -2632,72 +2646,72 @@ int DeviceProxy::ping()
 
 string DeviceProxy::name()
 {
-	string na;
-	int ctr = 0;
+    string na;
+    int ctr = 0;
 
-	while (ctr < 2)
-	{
-		try
-		{
-			check_and_reconnect();
+    while (ctr < 2)
+    {
+        try
+        {
+            check_and_reconnect();
 
-			Device_var dev = Device::_duplicate(device);
-			CORBA::String_var n = dev->name();
-			ctr = 2;
-			na = n;
-		}
-		catch (CORBA::TRANSIENT &trans)
-		{
-			TRANSIENT_NOT_EXIST_EXCEPT(trans,"DeviceProxy","name",this);
-		}
-		catch (CORBA::OBJECT_NOT_EXIST &one)
-		{
-			if (one.minor() == omni::OBJECT_NOT_EXIST_NoMatch || one.minor() == 0)
-			{
-				TRANSIENT_NOT_EXIST_EXCEPT(one,"DeviceProxy","name",this);
-			}
-			else
-			{
-				set_connection_state(CONNECTION_NOTOK);
-				TangoSys_OMemStream desc;
-				desc << "Failed to execute name() on device " << device_name << ends;
-				ApiCommExcept::re_throw_exception(one,
-							      (const char*)"API_CommunicationFailed",
-                        				      desc.str(),
-							      (const char*)"DeviceProxy::name()");
-			}
-		}
-		catch (CORBA::COMM_FAILURE &comm)
-		{
-			if (comm.minor() == omni::COMM_FAILURE_WaitingForReply)
-			{
-				TRANSIENT_NOT_EXIST_EXCEPT(comm,"DeviceProxy","name",this);
-			}
-			else
-			{
-				set_connection_state(CONNECTION_NOTOK);
-				TangoSys_OMemStream desc;
-				desc << "Failed to execute name() on device " << device_name << ends;
-				ApiCommExcept::re_throw_exception(comm,
-							      (const char*)"API_CommunicationFailed",
-                        				      desc.str(),
-							      (const char*)"DeviceProxy::name()");
-			}
-		}
+            Device_var dev = Device::_duplicate(device);
+            CORBA::String_var n = dev->name();
+            ctr = 2;
+            na = n;
+        }
+        catch (CORBA::TRANSIENT &trans)
+        {
+            TRANSIENT_NOT_EXIST_EXCEPT(trans, "DeviceProxy", "name", this);
+        }
+        catch (CORBA::OBJECT_NOT_EXIST &one)
+        {
+            if (one.minor() == omni::OBJECT_NOT_EXIST_NoMatch || one.minor() == 0)
+            {
+                TRANSIENT_NOT_EXIST_EXCEPT(one, "DeviceProxy", "name", this);
+            }
+            else
+            {
+                set_connection_state(CONNECTION_NOTOK);
+                TangoSys_OMemStream desc;
+                desc << "Failed to execute name() on device " << device_name << ends;
+                ApiCommExcept::re_throw_exception(one,
+                                                  (const char *) "API_CommunicationFailed",
+                                                  desc.str(),
+                                                  (const char *) "DeviceProxy::name()");
+            }
+        }
+        catch (CORBA::COMM_FAILURE &comm)
+        {
+            if (comm.minor() == omni::COMM_FAILURE_WaitingForReply)
+            {
+                TRANSIENT_NOT_EXIST_EXCEPT(comm, "DeviceProxy", "name", this);
+            }
+            else
+            {
+                set_connection_state(CONNECTION_NOTOK);
+                TangoSys_OMemStream desc;
+                desc << "Failed to execute name() on device " << device_name << ends;
+                ApiCommExcept::re_throw_exception(comm,
+                                                  (const char *) "API_CommunicationFailed",
+                                                  desc.str(),
+                                                  (const char *) "DeviceProxy::name()");
+            }
+        }
         catch (CORBA::SystemException &ce)
         {
-			set_connection_state(CONNECTION_NOTOK);
+            set_connection_state(CONNECTION_NOTOK);
 
-			TangoSys_OMemStream desc;
-			desc << "Failed to execute name() on device " << device_name << ends;
-			ApiCommExcept::re_throw_exception(ce,
-						      (const char*)"API_CommunicationFailed",
-                        			      desc.str(),
-						      (const char*)"DeviceProxy::name()");
-		}
-	}
+            TangoSys_OMemStream desc;
+            desc << "Failed to execute name() on device " << device_name << ends;
+            ApiCommExcept::re_throw_exception(ce,
+                                              (const char *) "API_CommunicationFailed",
+                                              desc.str(),
+                                              (const char *) "DeviceProxy::name()");
+        }
+    }
 
-	return(na);
+    return (na);
 }
 
 //-----------------------------------------------------------------------------
@@ -2708,20 +2722,20 @@ string DeviceProxy::name()
 
 string DeviceProxy::alias()
 {
-	if (alias_name.size() == 0)
-	{
-		Database *db = this->get_device_db();
-		if (db != NULL)
-			db->get_alias(device_name,alias_name);
-		else
-		{
-			Tango::Except::throw_exception((const char *)"DB_AliasNotDefined",
-	   						               (const char *)"No alias found for your device",
-							               (const char *)"DeviceProxy::alias()");
-		}
-	}
+    if (alias_name.size() == 0)
+    {
+        Database *db = this->get_device_db();
+        if (db != NULL)
+            db->get_alias(device_name, alias_name);
+        else
+        {
+            Tango::Except::throw_exception((const char *) "DB_AliasNotDefined",
+                                           (const char *) "No alias found for your device",
+                                           (const char *) "DeviceProxy::alias()");
+        }
+    }
 
-	return alias_name;
+    return alias_name;
 }
 
 //-----------------------------------------------------------------------------
@@ -2732,71 +2746,71 @@ string DeviceProxy::alias()
 
 DevState DeviceProxy::state()
 {
-	DevState sta = Tango::UNKNOWN;
-	int ctr = 0;
+    DevState sta = Tango::UNKNOWN;
+    int ctr = 0;
 
-	while (ctr < 2)
-	{
-		try
-		{
-			check_and_reconnect();
+    while (ctr < 2)
+    {
+        try
+        {
+            check_and_reconnect();
 
-			Device_var dev = Device::_duplicate(device);
-			sta = dev->state();
-			ctr = 2;
-		}
-		catch (CORBA::TRANSIENT &transp)
-		{
-			TRANSIENT_NOT_EXIST_EXCEPT(transp,"DeviceProxy","state",this);
-		}
-		catch (CORBA::OBJECT_NOT_EXIST &one)
-		{
-			if (one.minor() == omni::OBJECT_NOT_EXIST_NoMatch || one.minor() == 0)
-			{
-				TRANSIENT_NOT_EXIST_EXCEPT(one,"DeviceProxy","state",this);
-			}
-			else
-			{
-				set_connection_state(CONNECTION_NOTOK);
-				TangoSys_OMemStream desc;
-				desc << "Failed to execute state() on device " << device_name << ends;
-				ApiCommExcept::re_throw_exception(one,
-							      (const char*)"API_CommunicationFailed",
-                        				      desc.str(),
-							      (const char*)"DeviceProxy::state()");
-			}
-		}
-		catch (CORBA::COMM_FAILURE &comm)
-		{
-			if (comm.minor() == omni::COMM_FAILURE_WaitingForReply)
-			{
-				TRANSIENT_NOT_EXIST_EXCEPT(comm,"DeviceProxy","state",this);
-			}
-			else
-			{
-				set_connection_state(CONNECTION_NOTOK);
-				TangoSys_OMemStream desc;
-				desc << "Failed to execute state() on device " << device_name << ends;
-				ApiCommExcept::re_throw_exception(comm,
-							      (const char*)"API_CommunicationFailed",
-                        				      desc.str(),
-							      (const char*)"DeviceProxy::state()");
-			}
-		}
+            Device_var dev = Device::_duplicate(device);
+            sta = dev->state();
+            ctr = 2;
+        }
+        catch (CORBA::TRANSIENT &transp)
+        {
+            TRANSIENT_NOT_EXIST_EXCEPT(transp, "DeviceProxy", "state", this);
+        }
+        catch (CORBA::OBJECT_NOT_EXIST &one)
+        {
+            if (one.minor() == omni::OBJECT_NOT_EXIST_NoMatch || one.minor() == 0)
+            {
+                TRANSIENT_NOT_EXIST_EXCEPT(one, "DeviceProxy", "state", this);
+            }
+            else
+            {
+                set_connection_state(CONNECTION_NOTOK);
+                TangoSys_OMemStream desc;
+                desc << "Failed to execute state() on device " << device_name << ends;
+                ApiCommExcept::re_throw_exception(one,
+                                                  (const char *) "API_CommunicationFailed",
+                                                  desc.str(),
+                                                  (const char *) "DeviceProxy::state()");
+            }
+        }
+        catch (CORBA::COMM_FAILURE &comm)
+        {
+            if (comm.minor() == omni::COMM_FAILURE_WaitingForReply)
+            {
+                TRANSIENT_NOT_EXIST_EXCEPT(comm, "DeviceProxy", "state", this);
+            }
+            else
+            {
+                set_connection_state(CONNECTION_NOTOK);
+                TangoSys_OMemStream desc;
+                desc << "Failed to execute state() on device " << device_name << ends;
+                ApiCommExcept::re_throw_exception(comm,
+                                                  (const char *) "API_CommunicationFailed",
+                                                  desc.str(),
+                                                  (const char *) "DeviceProxy::state()");
+            }
+        }
         catch (CORBA::SystemException &ce)
         {
-			set_connection_state(CONNECTION_NOTOK);
+            set_connection_state(CONNECTION_NOTOK);
 
-			TangoSys_OMemStream desc;
-			desc << "Failed to execute state() on device " << device_name << ends;
-			ApiCommExcept::re_throw_exception(ce,
-						      (const char*)"API_CommunicationFailed",
-                    				      desc.str(),
-						      (const char*)"DeviceProxy::state()");
-		}
-	}
+            TangoSys_OMemStream desc;
+            desc << "Failed to execute state() on device " << device_name << ends;
+            ApiCommExcept::re_throw_exception(ce,
+                                              (const char *) "API_CommunicationFailed",
+                                              desc.str(),
+                                              (const char *) "DeviceProxy::state()");
+        }
+    }
 
-	return sta;
+    return sta;
 }
 
 //-----------------------------------------------------------------------------
@@ -2807,72 +2821,72 @@ DevState DeviceProxy::state()
 
 string DeviceProxy::status()
 {
-	string status_str;
-	int ctr = 0;
+    string status_str;
+    int ctr = 0;
 
-	while (ctr < 2)
-	{
-		try
-		{
-			check_and_reconnect();
+    while (ctr < 2)
+    {
+        try
+        {
+            check_and_reconnect();
 
-			Device_var dev = Device::_duplicate(device);
-			CORBA::String_var st = dev->status();
-			ctr = 2;
-			status_str = st;
-		}
-		catch (CORBA::TRANSIENT &transp)
-		{
-			TRANSIENT_NOT_EXIST_EXCEPT(transp,"DeviceProxy","status",this);
-		}
-		catch (CORBA::OBJECT_NOT_EXIST &one)
-		{
-			if (one.minor() == omni::OBJECT_NOT_EXIST_NoMatch || one.minor() == 0)
-			{
-				TRANSIENT_NOT_EXIST_EXCEPT(one,"DeviceProxy","status",this);
-			}
-			else
-			{
-				set_connection_state(CONNECTION_NOTOK);
-				TangoSys_OMemStream desc;
-				desc << "Failed to execute status() on device " << device_name << ends;
-				ApiCommExcept::re_throw_exception(one,
-							      (const char*)"API_CommunicationFailed",
-                        				      desc.str(),
-							      (const char*)"DeviceProxy::status()");
-			}
-		}
-		catch (CORBA::COMM_FAILURE &comm)
-		{
-			if (comm.minor() == omni::COMM_FAILURE_WaitingForReply)
-			{
-				TRANSIENT_NOT_EXIST_EXCEPT(comm,"DeviceProxy","status",this);
-			}
-			else
-			{
-				set_connection_state(CONNECTION_NOTOK);
-				TangoSys_OMemStream desc;
-				desc << "Failed to execute status() on device " << device_name << ends;
-				ApiCommExcept::re_throw_exception(comm,
-							      (const char*)"API_CommunicationFailed",
-                        				      desc.str(),
-							      (const char*)"DeviceProxy::status()");
-			}
-		}
+            Device_var dev = Device::_duplicate(device);
+            CORBA::String_var st = dev->status();
+            ctr = 2;
+            status_str = st;
+        }
+        catch (CORBA::TRANSIENT &transp)
+        {
+            TRANSIENT_NOT_EXIST_EXCEPT(transp, "DeviceProxy", "status", this);
+        }
+        catch (CORBA::OBJECT_NOT_EXIST &one)
+        {
+            if (one.minor() == omni::OBJECT_NOT_EXIST_NoMatch || one.minor() == 0)
+            {
+                TRANSIENT_NOT_EXIST_EXCEPT(one, "DeviceProxy", "status", this);
+            }
+            else
+            {
+                set_connection_state(CONNECTION_NOTOK);
+                TangoSys_OMemStream desc;
+                desc << "Failed to execute status() on device " << device_name << ends;
+                ApiCommExcept::re_throw_exception(one,
+                                                  (const char *) "API_CommunicationFailed",
+                                                  desc.str(),
+                                                  (const char *) "DeviceProxy::status()");
+            }
+        }
+        catch (CORBA::COMM_FAILURE &comm)
+        {
+            if (comm.minor() == omni::COMM_FAILURE_WaitingForReply)
+            {
+                TRANSIENT_NOT_EXIST_EXCEPT(comm, "DeviceProxy", "status", this);
+            }
+            else
+            {
+                set_connection_state(CONNECTION_NOTOK);
+                TangoSys_OMemStream desc;
+                desc << "Failed to execute status() on device " << device_name << ends;
+                ApiCommExcept::re_throw_exception(comm,
+                                                  (const char *) "API_CommunicationFailed",
+                                                  desc.str(),
+                                                  (const char *) "DeviceProxy::status()");
+            }
+        }
         catch (CORBA::SystemException &ce)
         {
-			set_connection_state(CONNECTION_NOTOK);
+            set_connection_state(CONNECTION_NOTOK);
 
-			TangoSys_OMemStream desc;
-			desc << "Failed to execute status() on device (CORBA exception)" << ends;
-			ApiCommExcept::re_throw_exception(ce,
-						      (const char*)"API_CommunicationFailed",
-                        			      desc.str(),
-						      (const char*)"DeviceProxy::status()");
-		}
-	}
+            TangoSys_OMemStream desc;
+            desc << "Failed to execute status() on device (CORBA exception)" << ends;
+            ApiCommExcept::re_throw_exception(ce,
+                                              (const char *) "API_CommunicationFailed",
+                                              desc.str(),
+                                              (const char *) "DeviceProxy::status()");
+        }
+    }
 
-	return(status_str);
+    return (status_str);
 }
 
 //-----------------------------------------------------------------------------
@@ -2883,88 +2897,88 @@ string DeviceProxy::status()
 
 string DeviceProxy::adm_name()
 {
-	string adm_name_str;
-	int ctr = 0;
+    string adm_name_str;
+    int ctr = 0;
 
-	while (ctr < 2)
-	{
-		try
-		{
-			check_and_reconnect();
+    while (ctr < 2)
+    {
+        try
+        {
+            check_and_reconnect();
 
-			Device_var dev = Device::_duplicate(device);
-			CORBA::String_var st = dev->adm_name();
-			ctr = 2;
-			adm_name_str = st;
+            Device_var dev = Device::_duplicate(device);
+            CORBA::String_var st = dev->adm_name();
+            ctr = 2;
+            adm_name_str = st;
 
-			if (dbase_used == false)
-			{
-				string prot("tango://");
+            if (dbase_used == false)
+            {
+                string prot("tango://");
                 if (host.find('.') == string::npos)
                     Connection::get_fqdn(host);
-				prot = prot + host + ':' + port + '/';
-				adm_name_str.insert(0,prot);
-				adm_name_str.append(MODIFIER_DBASE_NO);
-			}
-			else if (from_env_var == false)
-			{
-				string prot("tango://");
-				prot = prot + db_host + ':' + db_port + '/';
-				adm_name_str.insert(0,prot);
-			}
-		}
-		catch (CORBA::TRANSIENT &transp)
-		{
-			TRANSIENT_NOT_EXIST_EXCEPT(transp,"DeviceProxy","adm_name",this);
-		}
-		catch (CORBA::OBJECT_NOT_EXIST &one)
-		{
-			if (one.minor() == omni::OBJECT_NOT_EXIST_NoMatch || one.minor() == 0)
-			{
-				TRANSIENT_NOT_EXIST_EXCEPT(one,"DeviceProxy","adm_name",this);
-			}
-			else
-			{
-				set_connection_state(CONNECTION_NOTOK);
-				TangoSys_OMemStream desc;
-				desc << "Failed to execute adm_name() on device " << device_name << ends;
-				ApiCommExcept::re_throw_exception(one,
-							      (const char*)"API_CommunicationFailed",
-                        				      desc.str(),
-							      (const char*)"DeviceProxy::adm_name()");
-			}
-		}
-		catch (CORBA::COMM_FAILURE &comm)
-		{
-			if (comm.minor() == omni::COMM_FAILURE_WaitingForReply)
-			{
-				TRANSIENT_NOT_EXIST_EXCEPT(comm,"DeviceProxy","adm_name",this);
-			}
-			else
-			{
-				set_connection_state(CONNECTION_NOTOK);
-				TangoSys_OMemStream desc;
-				desc << "Failed to execute adm_name() on device " << device_name << ends;
-				ApiCommExcept::re_throw_exception(comm,
-							      (const char*)"API_CommunicationFailed",
-                        				      desc.str(),
-							      (const char*)"DeviceProxy::adm_name()");
-			}
-		}
+                prot = prot + host + ':' + port + '/';
+                adm_name_str.insert(0, prot);
+                adm_name_str.append(MODIFIER_DBASE_NO);
+            }
+            else if (from_env_var == false)
+            {
+                string prot("tango://");
+                prot = prot + db_host + ':' + db_port + '/';
+                adm_name_str.insert(0, prot);
+            }
+        }
+        catch (CORBA::TRANSIENT &transp)
+        {
+            TRANSIENT_NOT_EXIST_EXCEPT(transp, "DeviceProxy", "adm_name", this);
+        }
+        catch (CORBA::OBJECT_NOT_EXIST &one)
+        {
+            if (one.minor() == omni::OBJECT_NOT_EXIST_NoMatch || one.minor() == 0)
+            {
+                TRANSIENT_NOT_EXIST_EXCEPT(one, "DeviceProxy", "adm_name", this);
+            }
+            else
+            {
+                set_connection_state(CONNECTION_NOTOK);
+                TangoSys_OMemStream desc;
+                desc << "Failed to execute adm_name() on device " << device_name << ends;
+                ApiCommExcept::re_throw_exception(one,
+                                                  (const char *) "API_CommunicationFailed",
+                                                  desc.str(),
+                                                  (const char *) "DeviceProxy::adm_name()");
+            }
+        }
+        catch (CORBA::COMM_FAILURE &comm)
+        {
+            if (comm.minor() == omni::COMM_FAILURE_WaitingForReply)
+            {
+                TRANSIENT_NOT_EXIST_EXCEPT(comm, "DeviceProxy", "adm_name", this);
+            }
+            else
+            {
+                set_connection_state(CONNECTION_NOTOK);
+                TangoSys_OMemStream desc;
+                desc << "Failed to execute adm_name() on device " << device_name << ends;
+                ApiCommExcept::re_throw_exception(comm,
+                                                  (const char *) "API_CommunicationFailed",
+                                                  desc.str(),
+                                                  (const char *) "DeviceProxy::adm_name()");
+            }
+        }
         catch (CORBA::SystemException &ce)
         {
-			set_connection_state(CONNECTION_NOTOK);
+            set_connection_state(CONNECTION_NOTOK);
 
-			TangoSys_OMemStream desc;
-			desc << "Failed to execute adm_name() on device " << device_name << ends;
-			ApiCommExcept::re_throw_exception(ce,
-						      (const char*)"API_CommunicationFailed",
-                        			      desc.str(),
-						      (const char*)"DeviceProxy::adm_name()");
-		}
-	}
+            TangoSys_OMemStream desc;
+            desc << "Failed to execute adm_name() on device " << device_name << ends;
+            ApiCommExcept::re_throw_exception(ce,
+                                              (const char *) "API_CommunicationFailed",
+                                              desc.str(),
+                                              (const char *) "DeviceProxy::adm_name()");
+        }
+    }
 
-	return(adm_name_str);
+    return (adm_name_str);
 }
 
 //-----------------------------------------------------------------------------
@@ -2975,72 +2989,72 @@ string DeviceProxy::adm_name()
 
 string DeviceProxy::description()
 {
-	string description_str;
-	int ctr = 0;
+    string description_str;
+    int ctr = 0;
 
-	while (ctr < 2)
-	{
-		try
-		{
-			check_and_reconnect();
+    while (ctr < 2)
+    {
+        try
+        {
+            check_and_reconnect();
 
-			Device_var dev = Device::_duplicate(device);
-			CORBA::String_var st = dev->description();
-			ctr = 2;
-			description_str = st;
-		}
-		catch (CORBA::TRANSIENT &trans)
-		{
-			TRANSIENT_NOT_EXIST_EXCEPT(trans,"DeviceProxy","description",this);
-		}
-		catch (CORBA::OBJECT_NOT_EXIST &one)
-		{
-			if (one.minor() == omni::OBJECT_NOT_EXIST_NoMatch || one.minor() == 0)
-			{
-				TRANSIENT_NOT_EXIST_EXCEPT(one,"DeviceProxy","description",this);
-			}
-			else
-			{
-				set_connection_state(CONNECTION_NOTOK);
-				TangoSys_OMemStream desc;
-				desc << "Failed to execute description() on device " << device_name << ends;
-				ApiCommExcept::re_throw_exception(one,
-							      (const char*)"API_CommunicationFailed",
-                        				      desc.str(),
-							      (const char*)"DeviceProxy::description()");
-			}
-		}
-		catch (CORBA::COMM_FAILURE &comm)
-		{
-			if (comm.minor() == omni::COMM_FAILURE_WaitingForReply)
-			{
-				TRANSIENT_NOT_EXIST_EXCEPT(comm,"DeviceProxy","description",this);
-			}
-			else
-			{
-				set_connection_state(CONNECTION_NOTOK);
-				TangoSys_OMemStream desc;
-				desc << "Failed to execute description() on device " << device_name << ends;
-				ApiCommExcept::re_throw_exception(comm,
-							      (const char*)"API_CommunicationFailed",
-                        				      desc.str(),
-							      (const char*)"DeviceProxy::description()");
-			}
-		}
+            Device_var dev = Device::_duplicate(device);
+            CORBA::String_var st = dev->description();
+            ctr = 2;
+            description_str = st;
+        }
+        catch (CORBA::TRANSIENT &trans)
+        {
+            TRANSIENT_NOT_EXIST_EXCEPT(trans, "DeviceProxy", "description", this);
+        }
+        catch (CORBA::OBJECT_NOT_EXIST &one)
+        {
+            if (one.minor() == omni::OBJECT_NOT_EXIST_NoMatch || one.minor() == 0)
+            {
+                TRANSIENT_NOT_EXIST_EXCEPT(one, "DeviceProxy", "description", this);
+            }
+            else
+            {
+                set_connection_state(CONNECTION_NOTOK);
+                TangoSys_OMemStream desc;
+                desc << "Failed to execute description() on device " << device_name << ends;
+                ApiCommExcept::re_throw_exception(one,
+                                                  (const char *) "API_CommunicationFailed",
+                                                  desc.str(),
+                                                  (const char *) "DeviceProxy::description()");
+            }
+        }
+        catch (CORBA::COMM_FAILURE &comm)
+        {
+            if (comm.minor() == omni::COMM_FAILURE_WaitingForReply)
+            {
+                TRANSIENT_NOT_EXIST_EXCEPT(comm, "DeviceProxy", "description", this);
+            }
+            else
+            {
+                set_connection_state(CONNECTION_NOTOK);
+                TangoSys_OMemStream desc;
+                desc << "Failed to execute description() on device " << device_name << ends;
+                ApiCommExcept::re_throw_exception(comm,
+                                                  (const char *) "API_CommunicationFailed",
+                                                  desc.str(),
+                                                  (const char *) "DeviceProxy::description()");
+            }
+        }
         catch (CORBA::SystemException &ce)
         {
-			set_connection_state(CONNECTION_NOTOK);
+            set_connection_state(CONNECTION_NOTOK);
 
-			TangoSys_OMemStream desc;
-			desc << "Failed to execute description() on device " << device_name << ends;
-			ApiCommExcept::re_throw_exception(ce,
-						      (const char*)"API_CommunicationFailed",
-                        			      desc.str(),
-						      (const char*)"DeviceProxy::description()");
-		}
-	}
+            TangoSys_OMemStream desc;
+            desc << "Failed to execute description() on device " << device_name << ends;
+            ApiCommExcept::re_throw_exception(ce,
+                                              (const char *) "API_CommunicationFailed",
+                                              desc.str(),
+                                              (const char *) "DeviceProxy::description()");
+        }
+    }
 
-	return(description_str);
+    return (description_str);
 }
 
 //-----------------------------------------------------------------------------
@@ -3052,79 +3066,79 @@ string DeviceProxy::description()
 
 vector<string> *DeviceProxy::black_box(int last_n_commands)
 {
-	DevVarStringArray_var last_commands;
-	int ctr = 0;
+    DevVarStringArray_var last_commands;
+    int ctr = 0;
 
-	while (ctr < 2)
-	{
-		try
-		{
-			check_and_reconnect();
+    while (ctr < 2)
+    {
+        try
+        {
+            check_and_reconnect();
 
-			Device_var dev = Device::_duplicate(device);
-			last_commands = dev->black_box(last_n_commands);
-			ctr = 2;
-		}
-		catch (CORBA::TRANSIENT &trans)
-		{
-			TRANSIENT_NOT_EXIST_EXCEPT(trans,"DeviceProxy","black_box",this);
-		}
-		catch (CORBA::OBJECT_NOT_EXIST &one)
-		{
-			if (one.minor() == omni::OBJECT_NOT_EXIST_NoMatch || one.minor() == 0)
-			{
-				TRANSIENT_NOT_EXIST_EXCEPT(one,"DeviceProxy","black_box",this);
-			}
-			else
-			{
-				set_connection_state(CONNECTION_NOTOK);
-				TangoSys_OMemStream desc;
-				desc << "Failed to execute black_box on device " << device_name << ends;
-				ApiCommExcept::re_throw_exception(one,
-							      (const char*)"API_CommunicationFailed",
-                        				      desc.str(),
-							      (const char*)"DeviceProxy::black_box()");
-			}
-		}
-		catch (CORBA::COMM_FAILURE &comm)
-		{
-			if (comm.minor() == omni::COMM_FAILURE_WaitingForReply)
-			{
-				TRANSIENT_NOT_EXIST_EXCEPT(comm,"DeviceProxy","black_box",this);
-			}
-			else
-			{
-				set_connection_state(CONNECTION_NOTOK);
-				TangoSys_OMemStream desc;
-				desc << "Failed to execute black_box on device " << device_name << ends;
-				ApiCommExcept::re_throw_exception(comm,
-							      (const char*)"API_CommunicationFailed",
-                        				      desc.str(),
-							      (const char*)"DeviceProxy::black_box()");
-			}
-		}
+            Device_var dev = Device::_duplicate(device);
+            last_commands = dev->black_box(last_n_commands);
+            ctr = 2;
+        }
+        catch (CORBA::TRANSIENT &trans)
+        {
+            TRANSIENT_NOT_EXIST_EXCEPT(trans, "DeviceProxy", "black_box", this);
+        }
+        catch (CORBA::OBJECT_NOT_EXIST &one)
+        {
+            if (one.minor() == omni::OBJECT_NOT_EXIST_NoMatch || one.minor() == 0)
+            {
+                TRANSIENT_NOT_EXIST_EXCEPT(one, "DeviceProxy", "black_box", this);
+            }
+            else
+            {
+                set_connection_state(CONNECTION_NOTOK);
+                TangoSys_OMemStream desc;
+                desc << "Failed to execute black_box on device " << device_name << ends;
+                ApiCommExcept::re_throw_exception(one,
+                                                  (const char *) "API_CommunicationFailed",
+                                                  desc.str(),
+                                                  (const char *) "DeviceProxy::black_box()");
+            }
+        }
+        catch (CORBA::COMM_FAILURE &comm)
+        {
+            if (comm.minor() == omni::COMM_FAILURE_WaitingForReply)
+            {
+                TRANSIENT_NOT_EXIST_EXCEPT(comm, "DeviceProxy", "black_box", this);
+            }
+            else
+            {
+                set_connection_state(CONNECTION_NOTOK);
+                TangoSys_OMemStream desc;
+                desc << "Failed to execute black_box on device " << device_name << ends;
+                ApiCommExcept::re_throw_exception(comm,
+                                                  (const char *) "API_CommunicationFailed",
+                                                  desc.str(),
+                                                  (const char *) "DeviceProxy::black_box()");
+            }
+        }
         catch (CORBA::SystemException &ce)
         {
-			set_connection_state(CONNECTION_NOTOK);
+            set_connection_state(CONNECTION_NOTOK);
 
-			TangoSys_OMemStream desc;
-			desc << "Failed to execute black_box on device " << device_name << ends;
-			ApiCommExcept::re_throw_exception(ce,
-						      (const char*)"API_CommunicationFailed",
-                      				      desc.str(),
-						      (const char*)"DeviceProxy::black_box()");
-		}
-	}
+            TangoSys_OMemStream desc;
+            desc << "Failed to execute black_box on device " << device_name << ends;
+            ApiCommExcept::re_throw_exception(ce,
+                                              (const char *) "API_CommunicationFailed",
+                                              desc.str(),
+                                              (const char *) "DeviceProxy::black_box()");
+        }
+    }
 
-	vector<string> *last_commands_vector = new(vector<string>);
-	last_commands_vector->resize(last_commands->length());
+    vector<string> *last_commands_vector = new(vector<string>);
+    last_commands_vector->resize(last_commands->length());
 
-	for (unsigned int i=0; i<last_commands->length(); i++)
-	{
-		(*last_commands_vector)[i] = last_commands[i];
-	}
+    for (unsigned int i = 0; i < last_commands->length(); i++)
+    {
+        (*last_commands_vector)[i] = last_commands[i];
+    }
 
-	return(last_commands_vector);
+    return (last_commands_vector);
 }
 
 //-----------------------------------------------------------------------------
@@ -3135,94 +3149,94 @@ vector<string> *DeviceProxy::black_box(int last_n_commands)
 
 DeviceInfo const &DeviceProxy::info()
 {
-	DevInfo_var dev_info;
-	DevInfo_3_var dev_info_3;
-	int ctr = 0;
+    DevInfo_var dev_info;
+    DevInfo_3_var dev_info_3;
+    int ctr = 0;
 
-	while (ctr < 2)
-	{
-		try
-		{
-			check_and_reconnect();
+    while (ctr < 2)
+    {
+        try
+        {
+            check_and_reconnect();
 
-			if (version >= 3)
-			{
-				Device_3_var dev = Device_3::_duplicate(device_3);
-				dev_info_3 = dev->info_3();
+            if (version >= 3)
+            {
+                Device_3_var dev = Device_3::_duplicate(device_3);
+                dev_info_3 = dev->info_3();
 
-				_info.dev_class = dev_info_3->dev_class;
-				_info.server_id = dev_info_3->server_id;
-				_info.server_host = dev_info_3->server_host;
-				_info.server_version = dev_info_3->server_version;
-				_info.doc_url = dev_info_3->doc_url;
-				_info.dev_type = dev_info_3->dev_type;
-			}
-			else
-			{
-				Device_var dev = Device::_duplicate(device);
-				dev_info = dev->info();
+                _info.dev_class = dev_info_3->dev_class;
+                _info.server_id = dev_info_3->server_id;
+                _info.server_host = dev_info_3->server_host;
+                _info.server_version = dev_info_3->server_version;
+                _info.doc_url = dev_info_3->doc_url;
+                _info.dev_type = dev_info_3->dev_type;
+            }
+            else
+            {
+                Device_var dev = Device::_duplicate(device);
+                dev_info = dev->info();
 
-				_info.dev_class = dev_info->dev_class;
-				_info.server_id = dev_info->server_id;
-				_info.server_host = dev_info->server_host;
-				_info.server_version = dev_info->server_version;
-				_info.doc_url = dev_info->doc_url;
-				_info.dev_type = NotSet;
-			}
-			ctr = 2;
-		}
-		catch (CORBA::TRANSIENT &trans)
-		{
-			TRANSIENT_NOT_EXIST_EXCEPT(trans,"DeviceProxy","info",this);
-		}
-		catch (CORBA::OBJECT_NOT_EXIST &one)
-		{
-			if (one.minor() == omni::OBJECT_NOT_EXIST_NoMatch || one.minor() == 0)
-			{
-				TRANSIENT_NOT_EXIST_EXCEPT(one,"DeviceProxy","info",this);
-			}
-			else
-			{
-				set_connection_state(CONNECTION_NOTOK);
-				TangoSys_OMemStream desc;
-				desc << "Failed to execute info() on device " << device_name << ends;
-				ApiCommExcept::re_throw_exception(one,
-							      (const char*)"API_CommunicationFailed",
-                        				      desc.str(),
-							      (const char*)"DeviceProxy::info()");
-			}
-		}
-		catch (CORBA::COMM_FAILURE &comm)
-		{
-			if (comm.minor() == omni::COMM_FAILURE_WaitingForReply)
-			{
-				TRANSIENT_NOT_EXIST_EXCEPT(comm,"DeviceProxy","info",this);
-			}
-			else
-			{
-				set_connection_state(CONNECTION_NOTOK);
-				TangoSys_OMemStream desc;
-				desc << "Failed to execute info() on device " << device_name << ends;
-				ApiCommExcept::re_throw_exception(comm,
-							      (const char*)"API_CommunicationFailed",
-                        				      desc.str(),
-							      (const char*)"DeviceProxy::info()");
-			}
-		}
+                _info.dev_class = dev_info->dev_class;
+                _info.server_id = dev_info->server_id;
+                _info.server_host = dev_info->server_host;
+                _info.server_version = dev_info->server_version;
+                _info.doc_url = dev_info->doc_url;
+                _info.dev_type = NotSet;
+            }
+            ctr = 2;
+        }
+        catch (CORBA::TRANSIENT &trans)
+        {
+            TRANSIENT_NOT_EXIST_EXCEPT(trans, "DeviceProxy", "info", this);
+        }
+        catch (CORBA::OBJECT_NOT_EXIST &one)
+        {
+            if (one.minor() == omni::OBJECT_NOT_EXIST_NoMatch || one.minor() == 0)
+            {
+                TRANSIENT_NOT_EXIST_EXCEPT(one, "DeviceProxy", "info", this);
+            }
+            else
+            {
+                set_connection_state(CONNECTION_NOTOK);
+                TangoSys_OMemStream desc;
+                desc << "Failed to execute info() on device " << device_name << ends;
+                ApiCommExcept::re_throw_exception(one,
+                                                  (const char *) "API_CommunicationFailed",
+                                                  desc.str(),
+                                                  (const char *) "DeviceProxy::info()");
+            }
+        }
+        catch (CORBA::COMM_FAILURE &comm)
+        {
+            if (comm.minor() == omni::COMM_FAILURE_WaitingForReply)
+            {
+                TRANSIENT_NOT_EXIST_EXCEPT(comm, "DeviceProxy", "info", this);
+            }
+            else
+            {
+                set_connection_state(CONNECTION_NOTOK);
+                TangoSys_OMemStream desc;
+                desc << "Failed to execute info() on device " << device_name << ends;
+                ApiCommExcept::re_throw_exception(comm,
+                                                  (const char *) "API_CommunicationFailed",
+                                                  desc.str(),
+                                                  (const char *) "DeviceProxy::info()");
+            }
+        }
         catch (CORBA::SystemException &ce)
         {
-			set_connection_state(CONNECTION_NOTOK);
+            set_connection_state(CONNECTION_NOTOK);
 
-			TangoSys_OMemStream desc;
-			desc << "Failed to execute info() on device " << device_name << ends;
-			ApiCommExcept::re_throw_exception(ce,
-						   (const char*)"API_CommunicationFailed",
-                        			   desc.str(),
-						   (const char*)"DeviceProxy::info()");
-		}
-	}
+            TangoSys_OMemStream desc;
+            desc << "Failed to execute info() on device " << device_name << ends;
+            ApiCommExcept::re_throw_exception(ce,
+                                              (const char *) "API_CommunicationFailed",
+                                              desc.str(),
+                                              (const char *) "DeviceProxy::info()");
+        }
+    }
 
-	return(_info);
+    return (_info);
 }
 
 //-----------------------------------------------------------------------------
@@ -3234,97 +3248,97 @@ DeviceInfo const &DeviceProxy::info()
 
 CommandInfo DeviceProxy::command_query(string cmd)
 {
-	CommandInfo command_info;
-	DevCmdInfo_var cmd_info;
-	DevCmdInfo_2_var cmd_info_2;
-	int ctr = 0;
+    CommandInfo command_info;
+    DevCmdInfo_var cmd_info;
+    DevCmdInfo_2_var cmd_info_2;
+    int ctr = 0;
 
-	while (ctr < 2)
-	{
-		try
-		{
-			check_and_reconnect();
+    while (ctr < 2)
+    {
+        try
+        {
+            check_and_reconnect();
 
-			if (version == 1)
-			{
-				Device_var dev = Device::_duplicate(device);
-				cmd_info = dev->command_query(cmd.c_str());
+            if (version == 1)
+            {
+                Device_var dev = Device::_duplicate(device);
+                cmd_info = dev->command_query(cmd.c_str());
 
-				command_info.cmd_name = cmd_info->cmd_name;
-				command_info.cmd_tag = cmd_info->cmd_tag;
-				command_info.in_type = cmd_info->in_type;
-				command_info.out_type = cmd_info->out_type;
-				command_info.in_type_desc = cmd_info->in_type_desc;
-				command_info.out_type_desc = cmd_info->out_type_desc;
-				command_info.disp_level = Tango::OPERATOR;
-			}
-			else
-			{
-				Device_2_var dev = Device_2::_duplicate(device_2);
-				cmd_info_2 = dev->command_query_2(cmd.c_str());
+                command_info.cmd_name = cmd_info->cmd_name;
+                command_info.cmd_tag = cmd_info->cmd_tag;
+                command_info.in_type = cmd_info->in_type;
+                command_info.out_type = cmd_info->out_type;
+                command_info.in_type_desc = cmd_info->in_type_desc;
+                command_info.out_type_desc = cmd_info->out_type_desc;
+                command_info.disp_level = Tango::OPERATOR;
+            }
+            else
+            {
+                Device_2_var dev = Device_2::_duplicate(device_2);
+                cmd_info_2 = dev->command_query_2(cmd.c_str());
 
-				command_info.cmd_name = cmd_info_2->cmd_name;
-				command_info.cmd_tag = cmd_info_2->cmd_tag;
-				command_info.in_type = cmd_info_2->in_type;
-				command_info.out_type = cmd_info_2->out_type;
-				command_info.in_type_desc = cmd_info_2->in_type_desc;
-				command_info.out_type_desc = cmd_info_2->out_type_desc;
-				command_info.disp_level = cmd_info_2->level;
-			}
-			ctr = 2;
-		}
-		catch (CORBA::TRANSIENT &trans)
-		{
-			TRANSIENT_NOT_EXIST_EXCEPT(trans,"DeviceProxy","command_query",this);
-		}
-		catch (CORBA::OBJECT_NOT_EXIST &one)
-		{
-			if (one.minor() == omni::OBJECT_NOT_EXIST_NoMatch || one.minor() == 0)
-			{
-				TRANSIENT_NOT_EXIST_EXCEPT(one,"DeviceProxy","command_query",this);
-			}
-			else
-			{
-				set_connection_state(CONNECTION_NOTOK);
-				TangoSys_OMemStream desc;
-				desc << "Failed to execute command_query on device " << device_name << ends;
-				ApiCommExcept::re_throw_exception(one,
-							      (const char*)"API_CommunicationFailed",
-                        				      desc.str(),
-							      (const char*)"DeviceProxy::command_query()");
-			}
-		}
-		catch (CORBA::COMM_FAILURE &comm)
-		{
-			if (comm.minor() == omni::COMM_FAILURE_WaitingForReply)
-			{
-				TRANSIENT_NOT_EXIST_EXCEPT(comm,"DeviceProxy","command_query",this);
-			}
-			else
-			{
-				set_connection_state(CONNECTION_NOTOK);
-				TangoSys_OMemStream desc;
-				desc << "Failed to execute command_query on device " << device_name << ends;
-				ApiCommExcept::re_throw_exception(comm,
-							      (const char*)"API_CommunicationFailed",
-                        				      desc.str(),
-							      (const char*)"DeviceProxy::command_query()");
-			}
-		}
+                command_info.cmd_name = cmd_info_2->cmd_name;
+                command_info.cmd_tag = cmd_info_2->cmd_tag;
+                command_info.in_type = cmd_info_2->in_type;
+                command_info.out_type = cmd_info_2->out_type;
+                command_info.in_type_desc = cmd_info_2->in_type_desc;
+                command_info.out_type_desc = cmd_info_2->out_type_desc;
+                command_info.disp_level = cmd_info_2->level;
+            }
+            ctr = 2;
+        }
+        catch (CORBA::TRANSIENT &trans)
+        {
+            TRANSIENT_NOT_EXIST_EXCEPT(trans, "DeviceProxy", "command_query", this);
+        }
+        catch (CORBA::OBJECT_NOT_EXIST &one)
+        {
+            if (one.minor() == omni::OBJECT_NOT_EXIST_NoMatch || one.minor() == 0)
+            {
+                TRANSIENT_NOT_EXIST_EXCEPT(one, "DeviceProxy", "command_query", this);
+            }
+            else
+            {
+                set_connection_state(CONNECTION_NOTOK);
+                TangoSys_OMemStream desc;
+                desc << "Failed to execute command_query on device " << device_name << ends;
+                ApiCommExcept::re_throw_exception(one,
+                                                  (const char *) "API_CommunicationFailed",
+                                                  desc.str(),
+                                                  (const char *) "DeviceProxy::command_query()");
+            }
+        }
+        catch (CORBA::COMM_FAILURE &comm)
+        {
+            if (comm.minor() == omni::COMM_FAILURE_WaitingForReply)
+            {
+                TRANSIENT_NOT_EXIST_EXCEPT(comm, "DeviceProxy", "command_query", this);
+            }
+            else
+            {
+                set_connection_state(CONNECTION_NOTOK);
+                TangoSys_OMemStream desc;
+                desc << "Failed to execute command_query on device " << device_name << ends;
+                ApiCommExcept::re_throw_exception(comm,
+                                                  (const char *) "API_CommunicationFailed",
+                                                  desc.str(),
+                                                  (const char *) "DeviceProxy::command_query()");
+            }
+        }
         catch (CORBA::SystemException &ce)
         {
-			set_connection_state(CONNECTION_NOTOK);
+            set_connection_state(CONNECTION_NOTOK);
 
-			TangoSys_OMemStream desc;
-			desc << "Failed to execute command_query on device " << device_name << ends;
-			ApiCommExcept::re_throw_exception(ce,
-						   (const char*)"API_CommunicationFailed",
-                        			   desc.str(),
-						   (const char*)"DeviceProxy::command_query()");
-		}
-	}
+            TangoSys_OMemStream desc;
+            desc << "Failed to execute command_query on device " << device_name << ends;
+            ApiCommExcept::re_throw_exception(ce,
+                                              (const char *) "API_CommunicationFailed",
+                                              desc.str(),
+                                              (const char *) "DeviceProxy::command_query()");
+        }
+    }
 
-	return(command_info);
+    return (command_info);
 }
 
 //-----------------------------------------------------------------------------
@@ -3335,42 +3349,42 @@ CommandInfo DeviceProxy::command_query(string cmd)
 
 CommandInfoList *DeviceProxy::get_command_config(vector<string> &cmd_names)
 {
-	CommandInfoList *all_cmds = command_list_query();
+    CommandInfoList *all_cmds = command_list_query();
 
 //
 // Leave method if the user requires config for all commands
 //
 
-	if (cmd_names.size() == 1 && cmd_names[0] == AllCmd)
-		return all_cmds;
+    if (cmd_names.size() == 1 && cmd_names[0] == AllCmd)
+        return all_cmds;
 
 //
 // Return only the required commands config
 //
 
-	CommandInfoList *ret_cmds = new CommandInfoList;
-	vector<string>::iterator ite;
-	for (ite = cmd_names.begin();ite != cmd_names.end();++ite)
-	{
-		string w_str(*ite);
-		transform(w_str.begin(),w_str.end(),w_str.begin(),::tolower);
+    CommandInfoList *ret_cmds = new CommandInfoList;
+    vector<string>::iterator ite;
+    for (ite = cmd_names.begin(); ite != cmd_names.end(); ++ite)
+    {
+        string w_str(*ite);
+        transform(w_str.begin(), w_str.end(), w_str.begin(), ::tolower);
 
-		vector<CommandInfo>::iterator pos;
-		for (pos = all_cmds->begin();pos != all_cmds->end();++pos)
-		{
-			string lower_cmd(pos->cmd_name);
-			transform(lower_cmd.begin(),lower_cmd.end(),lower_cmd.begin(),::tolower);
-			if (w_str == lower_cmd)
-			{
-				ret_cmds->push_back(*pos);
-				break;
-			}
-		}
-	}
+        vector<CommandInfo>::iterator pos;
+        for (pos = all_cmds->begin(); pos != all_cmds->end(); ++pos)
+        {
+            string lower_cmd(pos->cmd_name);
+            transform(lower_cmd.begin(), lower_cmd.end(), lower_cmd.begin(), ::tolower);
+            if (w_str == lower_cmd)
+            {
+                ret_cmds->push_back(*pos);
+                break;
+            }
+        }
+    }
 
     delete all_cmds;
 
-	return ret_cmds;
+    return ret_cmds;
 }
 
 //-----------------------------------------------------------------------------
@@ -3381,109 +3395,109 @@ CommandInfoList *DeviceProxy::get_command_config(vector<string> &cmd_names)
 
 CommandInfoList *DeviceProxy::command_list_query()
 {
-	CommandInfoList *command_info_list = NULL;
-	DevCmdInfoList_var cmd_info_list;
-	DevCmdInfoList_2_var cmd_info_list_2;
-	int ctr = 0;
+    CommandInfoList *command_info_list = NULL;
+    DevCmdInfoList_var cmd_info_list;
+    DevCmdInfoList_2_var cmd_info_list_2;
+    int ctr = 0;
 
-	while (ctr < 2)
-	{
-		try
-		{
-			check_and_reconnect();
+    while (ctr < 2)
+    {
+        try
+        {
+            check_and_reconnect();
 
-			if (version == 1)
-			{
-				Device_var dev = Device::_duplicate(device);
-				cmd_info_list = dev->command_list_query();
+            if (version == 1)
+            {
+                Device_var dev = Device::_duplicate(device);
+                cmd_info_list = dev->command_list_query();
 
-				command_info_list = new CommandInfoList(cmd_info_list->length());
+                command_info_list = new CommandInfoList(cmd_info_list->length());
 //				command_info_list->resize(cmd_info_list->length());
 
-				for (unsigned int i=0; i < cmd_info_list->length(); i++)
-				{
-					(*command_info_list)[i].cmd_name = cmd_info_list[i].cmd_name;
-					(*command_info_list)[i].cmd_tag = cmd_info_list[i].cmd_tag;
-					(*command_info_list)[i].in_type = cmd_info_list[i].in_type;
-					(*command_info_list)[i].out_type = cmd_info_list[i].out_type;
-					(*command_info_list)[i].in_type_desc = cmd_info_list[i].in_type_desc;
-					(*command_info_list)[i].out_type_desc = cmd_info_list[i].out_type_desc;
-					(*command_info_list)[i].disp_level = Tango::OPERATOR;
-				}
-			}
-			else
-			{
-				Device_2_var dev = Device_2::_duplicate(device_2);
-				cmd_info_list_2 = dev->command_list_query_2();
+                for (unsigned int i = 0; i < cmd_info_list->length(); i++)
+                {
+                    (*command_info_list)[i].cmd_name = cmd_info_list[i].cmd_name;
+                    (*command_info_list)[i].cmd_tag = cmd_info_list[i].cmd_tag;
+                    (*command_info_list)[i].in_type = cmd_info_list[i].in_type;
+                    (*command_info_list)[i].out_type = cmd_info_list[i].out_type;
+                    (*command_info_list)[i].in_type_desc = cmd_info_list[i].in_type_desc;
+                    (*command_info_list)[i].out_type_desc = cmd_info_list[i].out_type_desc;
+                    (*command_info_list)[i].disp_level = Tango::OPERATOR;
+                }
+            }
+            else
+            {
+                Device_2_var dev = Device_2::_duplicate(device_2);
+                cmd_info_list_2 = dev->command_list_query_2();
 
-				command_info_list = new CommandInfoList(cmd_info_list_2->length());
+                command_info_list = new CommandInfoList(cmd_info_list_2->length());
 //				command_info_list->resize(cmd_info_list_2->length());
 
-				for (unsigned int i=0; i < cmd_info_list_2->length(); i++)
-				{
-					(*command_info_list)[i].cmd_name = cmd_info_list_2[i].cmd_name;
-					(*command_info_list)[i].cmd_tag = cmd_info_list_2[i].cmd_tag;
-					(*command_info_list)[i].in_type = cmd_info_list_2[i].in_type;
-					(*command_info_list)[i].out_type = cmd_info_list_2[i].out_type;
-					(*command_info_list)[i].in_type_desc = cmd_info_list_2[i].in_type_desc;
-					(*command_info_list)[i].out_type_desc = cmd_info_list_2[i].out_type_desc;
-					(*command_info_list)[i].disp_level = cmd_info_list_2[i].level;
-				}
-			}
-			ctr = 2;
-		}
-		catch (CORBA::TRANSIENT &trans)
-		{
-			TRANSIENT_NOT_EXIST_EXCEPT(trans,"DeviceProxy","command_list_query",this);
-		}
-		catch (CORBA::OBJECT_NOT_EXIST &one)
-		{
-			if (one.minor() == omni::OBJECT_NOT_EXIST_NoMatch || one.minor() == 0)
-			{
-				TRANSIENT_NOT_EXIST_EXCEPT(one,"DeviceProxy","command_list_query",this);
-			}
-			else
-			{
-				set_connection_state(CONNECTION_NOTOK);
-				TangoSys_OMemStream desc;
-				desc << "Failed to execute command_list_query on device " << device_name << ends;
-				ApiCommExcept::re_throw_exception(one,
-							      (const char*)"API_CommunicationFailed",
-                        				      desc.str(),
-							      (const char*)"DeviceProxy::command_list_query()");
-			}
-		}
-		catch (CORBA::COMM_FAILURE &comm)
-		{
-			if (comm.minor() == omni::COMM_FAILURE_WaitingForReply)
-			{
-				TRANSIENT_NOT_EXIST_EXCEPT(comm,"DeviceProxy","command_list_query",this);
-			}
-			else
-			{
-				set_connection_state(CONNECTION_NOTOK);
-				TangoSys_OMemStream desc;
-				desc << "Failed to execute command_list_query on device " << device_name << ends;
-				ApiCommExcept::re_throw_exception(comm,
-							      (const char*)"API_CommunicationFailed",
-                        				      desc.str(),
-							      (const char*)"DeviceProxy::command_list_query()");
-			}
-		}
+                for (unsigned int i = 0; i < cmd_info_list_2->length(); i++)
+                {
+                    (*command_info_list)[i].cmd_name = cmd_info_list_2[i].cmd_name;
+                    (*command_info_list)[i].cmd_tag = cmd_info_list_2[i].cmd_tag;
+                    (*command_info_list)[i].in_type = cmd_info_list_2[i].in_type;
+                    (*command_info_list)[i].out_type = cmd_info_list_2[i].out_type;
+                    (*command_info_list)[i].in_type_desc = cmd_info_list_2[i].in_type_desc;
+                    (*command_info_list)[i].out_type_desc = cmd_info_list_2[i].out_type_desc;
+                    (*command_info_list)[i].disp_level = cmd_info_list_2[i].level;
+                }
+            }
+            ctr = 2;
+        }
+        catch (CORBA::TRANSIENT &trans)
+        {
+            TRANSIENT_NOT_EXIST_EXCEPT(trans, "DeviceProxy", "command_list_query", this);
+        }
+        catch (CORBA::OBJECT_NOT_EXIST &one)
+        {
+            if (one.minor() == omni::OBJECT_NOT_EXIST_NoMatch || one.minor() == 0)
+            {
+                TRANSIENT_NOT_EXIST_EXCEPT(one, "DeviceProxy", "command_list_query", this);
+            }
+            else
+            {
+                set_connection_state(CONNECTION_NOTOK);
+                TangoSys_OMemStream desc;
+                desc << "Failed to execute command_list_query on device " << device_name << ends;
+                ApiCommExcept::re_throw_exception(one,
+                                                  (const char *) "API_CommunicationFailed",
+                                                  desc.str(),
+                                                  (const char *) "DeviceProxy::command_list_query()");
+            }
+        }
+        catch (CORBA::COMM_FAILURE &comm)
+        {
+            if (comm.minor() == omni::COMM_FAILURE_WaitingForReply)
+            {
+                TRANSIENT_NOT_EXIST_EXCEPT(comm, "DeviceProxy", "command_list_query", this);
+            }
+            else
+            {
+                set_connection_state(CONNECTION_NOTOK);
+                TangoSys_OMemStream desc;
+                desc << "Failed to execute command_list_query on device " << device_name << ends;
+                ApiCommExcept::re_throw_exception(comm,
+                                                  (const char *) "API_CommunicationFailed",
+                                                  desc.str(),
+                                                  (const char *) "DeviceProxy::command_list_query()");
+            }
+        }
         catch (CORBA::SystemException &ce)
         {
-			set_connection_state(CONNECTION_NOTOK);
+            set_connection_state(CONNECTION_NOTOK);
 
-			TangoSys_OMemStream desc;
-			desc << "Failed to execute command_list_query on device " << device_name << ends;
-			ApiCommExcept::re_throw_exception(ce,
-						      (const char*)"API_CommunicationFailed",
-                        			      desc.str(),
-						      (const char*)"DeviceProxy::command_list_query()");
-		}
-	}
+            TangoSys_OMemStream desc;
+            desc << "Failed to execute command_list_query on device " << device_name << ends;
+            ApiCommExcept::re_throw_exception(ce,
+                                              (const char *) "API_CommunicationFailed",
+                                              desc.str(),
+                                              (const char *) "DeviceProxy::command_list_query()");
+        }
+    }
 
-	return(command_info_list);
+    return (command_info_list);
 }
 
 //-----------------------------------------------------------------------------
@@ -3494,19 +3508,19 @@ CommandInfoList *DeviceProxy::command_list_query()
 
 vector<string> *DeviceProxy::get_command_list()
 {
-	CommandInfoList *all_cmd_config;
+    CommandInfoList *all_cmd_config;
 
-	all_cmd_config = command_list_query();
+    all_cmd_config = command_list_query();
 
-	vector<string> *cmd_list = new vector<string>;
-	cmd_list->resize(all_cmd_config->size());
-	for (unsigned int i=0; i<all_cmd_config->size(); i++)
-	{
-		(*cmd_list)[i] = (*all_cmd_config)[i].cmd_name;
-	}
-	delete all_cmd_config;
+    vector<string> *cmd_list = new vector<string>;
+    cmd_list->resize(all_cmd_config->size());
+    for (unsigned int i = 0; i < all_cmd_config->size(); i++)
+    {
+        (*cmd_list)[i] = (*all_cmd_config)[i].cmd_name;
+    }
+    delete all_cmd_config;
 
-	return cmd_list;
+    return cmd_list;
 }
 
 //-----------------------------------------------------------------------------
@@ -3517,26 +3531,26 @@ vector<string> *DeviceProxy::get_command_list()
 
 void DeviceProxy::get_property(string &property_name, DbData &db_data)
 {
-	if (dbase_used == false)
-	{
-		TangoSys_OMemStream desc;
-		desc << "Method not available for device ";
-		desc << device_name;
-		desc << " which is a non database device";
+    if (dbase_used == false)
+    {
+        TangoSys_OMemStream desc;
+        desc << "Method not available for device ";
+        desc << device_name;
+        desc << " which is a non database device";
 
-		ApiNonDbExcept::throw_exception((const char *)API_NonDatabaseDevice,
-					desc.str(),
-					(const char *)"DeviceProxy::get_property");
-	}
-	else
-	{
-		db_data.resize(1);
-		db_data[0] = DbDatum(property_name);
+        ApiNonDbExcept::throw_exception((const char *) API_NonDatabaseDevice,
+                                        desc.str(),
+                                        (const char *) "DeviceProxy::get_property");
+    }
+    else
+    {
+        db_data.resize(1);
+        db_data[0] = DbDatum(property_name);
 
-		db_dev->get_property(db_data);
-	}
+        db_dev->get_property(db_data);
+    }
 
-	return;
+    return;
 }
 
 //-----------------------------------------------------------------------------
@@ -3547,29 +3561,29 @@ void DeviceProxy::get_property(string &property_name, DbData &db_data)
 
 void DeviceProxy::get_property(vector<string> &property_names, DbData &db_data)
 {
-	if (dbase_used == false)
-	{
-		TangoSys_OMemStream desc;
-		desc << "Method not available for device ";
-		desc << device_name;
-		desc << " which is a non database device";
+    if (dbase_used == false)
+    {
+        TangoSys_OMemStream desc;
+        desc << "Method not available for device ";
+        desc << device_name;
+        desc << " which is a non database device";
 
-		ApiNonDbExcept::throw_exception((const char *)API_NonDatabaseDevice,
-					desc.str(),
-					(const char *)"DeviceProxy::get_property");
-	}
-	else
-	{
-		db_data.resize(property_names.size());
-		for (unsigned int i=0; i<property_names.size(); i++)
-		{
-			db_data[i] = DbDatum(property_names[i]);
-		}
+        ApiNonDbExcept::throw_exception((const char *) API_NonDatabaseDevice,
+                                        desc.str(),
+                                        (const char *) "DeviceProxy::get_property");
+    }
+    else
+    {
+        db_data.resize(property_names.size());
+        for (unsigned int i = 0; i < property_names.size(); i++)
+        {
+            db_data[i] = DbDatum(property_names[i]);
+        }
 
-		db_dev->get_property(db_data);
-	}
+        db_dev->get_property(db_data);
+    }
 
-	return;
+    return;
 }
 
 //-----------------------------------------------------------------------------
@@ -3580,23 +3594,23 @@ void DeviceProxy::get_property(vector<string> &property_names, DbData &db_data)
 
 void DeviceProxy::get_property(DbData &db_data)
 {
-	if (dbase_used == false)
-	{
-		TangoSys_OMemStream desc;
-		desc << "Method not available for device ";
-		desc << device_name;
-		desc << " which is a non database device";
+    if (dbase_used == false)
+    {
+        TangoSys_OMemStream desc;
+        desc << "Method not available for device ";
+        desc << device_name;
+        desc << " which is a non database device";
 
-		ApiNonDbExcept::throw_exception((const char *)API_NonDatabaseDevice,
-					desc.str(),
-					(const char *)"DeviceProxy::get_property");
-	}
-	else
-	{
-		db_dev->get_property(db_data);
-	}
+        ApiNonDbExcept::throw_exception((const char *) API_NonDatabaseDevice,
+                                        desc.str(),
+                                        (const char *) "DeviceProxy::get_property");
+    }
+    else
+    {
+        db_dev->get_property(db_data);
+    }
 
-	return;
+    return;
 }
 
 //-----------------------------------------------------------------------------
@@ -3607,23 +3621,23 @@ void DeviceProxy::get_property(DbData &db_data)
 
 void DeviceProxy::put_property(DbData &db_data)
 {
-	if (dbase_used == false)
-	{
-		TangoSys_OMemStream desc;
-		desc << "Method not available for device ";
-		desc << device_name;
-		desc << " which is a non database device";
+    if (dbase_used == false)
+    {
+        TangoSys_OMemStream desc;
+        desc << "Method not available for device ";
+        desc << device_name;
+        desc << " which is a non database device";
 
-		ApiNonDbExcept::throw_exception((const char *)API_NonDatabaseDevice,
-					desc.str(),
-					(const char *)"DeviceProxy::put_property");
-	}
-	else
-	{
-		db_dev->put_property(db_data);
-	}
+        ApiNonDbExcept::throw_exception((const char *) API_NonDatabaseDevice,
+                                        desc.str(),
+                                        (const char *) "DeviceProxy::put_property");
+    }
+    else
+    {
+        db_dev->put_property(db_data);
+    }
 
-	return;
+    return;
 }
 
 //-----------------------------------------------------------------------------
@@ -3634,27 +3648,27 @@ void DeviceProxy::put_property(DbData &db_data)
 
 void DeviceProxy::delete_property(string &property_name)
 {
-	if (dbase_used == false)
-	{
-		TangoSys_OMemStream desc;
-		desc << "Method not available for device ";
-		desc << device_name;
-		desc << " which is a non database device";
+    if (dbase_used == false)
+    {
+        TangoSys_OMemStream desc;
+        desc << "Method not available for device ";
+        desc << device_name;
+        desc << " which is a non database device";
 
-		ApiNonDbExcept::throw_exception((const char *)API_NonDatabaseDevice,
-					desc.str(),
-					(const char *)"DeviceProxy::delete_property");
-	}
-	else
-	{
-		DbData db_data;
+        ApiNonDbExcept::throw_exception((const char *) API_NonDatabaseDevice,
+                                        desc.str(),
+                                        (const char *) "DeviceProxy::delete_property");
+    }
+    else
+    {
+        DbData db_data;
 
-		db_data.push_back(DbDatum(property_name));
+        db_data.push_back(DbDatum(property_name));
 
-		db_dev->delete_property(db_data);
-	}
+        db_dev->delete_property(db_data);
+    }
 
-	return;
+    return;
 }
 
 //-----------------------------------------------------------------------------
@@ -3665,30 +3679,30 @@ void DeviceProxy::delete_property(string &property_name)
 
 void DeviceProxy::delete_property(vector<string> &property_names)
 {
-	if (dbase_used == false)
-	{
-		TangoSys_OMemStream desc;
-		desc << "Method not available for device ";
-		desc << device_name;
-		desc << " which is a non database device";
+    if (dbase_used == false)
+    {
+        TangoSys_OMemStream desc;
+        desc << "Method not available for device ";
+        desc << device_name;
+        desc << " which is a non database device";
 
-		ApiNonDbExcept::throw_exception((const char *)API_NonDatabaseDevice,
-					desc.str(),
-					(const char *)"DeviceProxy::delete_property");
-	}
-	else
-	{
-		DbData db_data;
+        ApiNonDbExcept::throw_exception((const char *) API_NonDatabaseDevice,
+                                        desc.str(),
+                                        (const char *) "DeviceProxy::delete_property");
+    }
+    else
+    {
+        DbData db_data;
 
-		for (unsigned int i=0; i<property_names.size(); i++)
-		{
-			db_data.push_back(DbDatum(property_names[i]));
-		}
+        for (unsigned int i = 0; i < property_names.size(); i++)
+        {
+            db_data.push_back(DbDatum(property_names[i]));
+        }
 
-		db_dev->delete_property(db_data);
-	}
+        db_dev->delete_property(db_data);
+    }
 
-	return;
+    return;
 }
 
 //-----------------------------------------------------------------------------
@@ -3699,23 +3713,23 @@ void DeviceProxy::delete_property(vector<string> &property_names)
 
 void DeviceProxy::delete_property(DbData &db_data)
 {
-	if (dbase_used == false)
-	{
-		TangoSys_OMemStream desc;
-		desc << "Method not available for device ";
-		desc << device_name;
-		desc << " which is a non database device";
+    if (dbase_used == false)
+    {
+        TangoSys_OMemStream desc;
+        desc << "Method not available for device ";
+        desc << device_name;
+        desc << " which is a non database device";
 
-		ApiNonDbExcept::throw_exception((const char *)API_NonDatabaseDevice,
-					desc.str(),
-					(const char *)"DeviceProxy::delete_property");
-	}
-	else
-	{
-		db_dev->delete_property(db_data);
-	}
+        ApiNonDbExcept::throw_exception((const char *) API_NonDatabaseDevice,
+                                        desc.str(),
+                                        (const char *) "DeviceProxy::delete_property");
+    }
+    else
+    {
+        db_dev->delete_property(db_data);
+    }
 
-	return;
+    return;
 }
 
 
@@ -3725,34 +3739,34 @@ void DeviceProxy::delete_property(DbData &db_data)
 //
 //-----------------------------------------------------------------------------
 
-void DeviceProxy::get_property_list(const string &wildcard,vector<string> &prop_list)
+void DeviceProxy::get_property_list(const string &wildcard, vector<string> &prop_list)
 {
-	if (dbase_used == false)
-	{
-		TangoSys_OMemStream desc;
-		desc << "Method not available for device ";
-		desc << device_name;
-		desc << " which is a non database device";
+    if (dbase_used == false)
+    {
+        TangoSys_OMemStream desc;
+        desc << "Method not available for device ";
+        desc << device_name;
+        desc << " which is a non database device";
 
-		ApiNonDbExcept::throw_exception((const char *)API_NonDatabaseDevice,
-					desc.str(),
-					(const char *)"DeviceProxy::get_property_list");
-	}
-	else
-	{
-		int num = 0;
-		num = count(wildcard.begin(),wildcard.end(),'*');
+        ApiNonDbExcept::throw_exception((const char *) API_NonDatabaseDevice,
+                                        desc.str(),
+                                        (const char *) "DeviceProxy::get_property_list");
+    }
+    else
+    {
+        int num = 0;
+        num = count(wildcard.begin(), wildcard.end(), '*');
 
-		if (num > 1)
-		{
-			ApiWrongNameExcept::throw_exception((const char*)"API_WrongWildcardUsage",
-						(const char *)"Only one wildcard character (*) allowed!",
-						(const char *)"DeviceProxy::get_property_list");
-		}
-		db_dev->get_property_list(wildcard,prop_list);
-	}
+        if (num > 1)
+        {
+            ApiWrongNameExcept::throw_exception((const char *) "API_WrongWildcardUsage",
+                                                (const char *) "Only one wildcard character (*) allowed!",
+                                                (const char *) "DeviceProxy::get_property_list");
+        }
+        db_dev->get_property_list(wildcard, prop_list);
+    }
 
-	return;
+    return;
 }
 
 //-----------------------------------------------------------------------------
@@ -3761,168 +3775,168 @@ void DeviceProxy::get_property_list(const string &wildcard,vector<string> &prop_
 //
 //-----------------------------------------------------------------------------
 
-AttributeInfoList *DeviceProxy::get_attribute_config(vector<string>& attr_string_list)
+AttributeInfoList *DeviceProxy::get_attribute_config(vector<string> &attr_string_list)
 {
-	AttributeConfigList_var attr_config_list;
-	AttributeConfigList_2_var attr_config_list_2;
-	AttributeInfoList *dev_attr_config = new AttributeInfoList();
-	DevVarStringArray attr_list;
-	int ctr = 0;
+    AttributeConfigList_var attr_config_list;
+    AttributeConfigList_2_var attr_config_list_2;
+    AttributeInfoList *dev_attr_config = new AttributeInfoList();
+    DevVarStringArray attr_list;
+    int ctr = 0;
 
-	attr_list.length(attr_string_list.size());
-	for (unsigned int i=0; i<attr_string_list.size(); i++)
-	{
-		if (attr_string_list[i] == AllAttr)
-		{
-			if (version >= 3)
-				attr_list[i] = string_dup(AllAttr_3);
-			else
-				attr_list[i] = string_dup(AllAttr);
-		}
-		else if (attr_string_list[i] == AllAttr_3)
-		{
-			if (version < 3)
-				attr_list[i] = string_dup(AllAttr);
-			else
-				attr_list[i] = string_dup(AllAttr_3);
-		}
-		else
-			attr_list[i] = string_dup(attr_string_list[i].c_str());
-	}
+    attr_list.length(attr_string_list.size());
+    for (unsigned int i = 0; i < attr_string_list.size(); i++)
+    {
+        if (attr_string_list[i] == AllAttr)
+        {
+            if (version >= 3)
+                attr_list[i] = string_dup(AllAttr_3);
+            else
+                attr_list[i] = string_dup(AllAttr);
+        }
+        else if (attr_string_list[i] == AllAttr_3)
+        {
+            if (version < 3)
+                attr_list[i] = string_dup(AllAttr);
+            else
+                attr_list[i] = string_dup(AllAttr_3);
+        }
+        else
+            attr_list[i] = string_dup(attr_string_list[i].c_str());
+    }
 
-	while (ctr < 2)
-	{
-		try
-		{
-			check_and_reconnect();
+    while (ctr < 2)
+    {
+        try
+        {
+            check_and_reconnect();
 
-			if (version == 1)
-			{
-				Device_var dev = Device::_duplicate(device);
-				attr_config_list = dev->get_attribute_config(attr_list);
+            if (version == 1)
+            {
+                Device_var dev = Device::_duplicate(device);
+                attr_config_list = dev->get_attribute_config(attr_list);
 
-				dev_attr_config->resize(attr_config_list->length());
+                dev_attr_config->resize(attr_config_list->length());
 
-				for (unsigned int i=0; i<attr_config_list->length(); i++)
-				{
-					(*dev_attr_config)[i].name = attr_config_list[i].name;
-					(*dev_attr_config)[i].writable = attr_config_list[i].writable;
-					(*dev_attr_config)[i].data_format = attr_config_list[i].data_format;
-					(*dev_attr_config)[i].data_type = attr_config_list[i].data_type;
-					(*dev_attr_config)[i].max_dim_x = attr_config_list[i].max_dim_x;
-					(*dev_attr_config)[i].max_dim_y = attr_config_list[i].max_dim_y;
-					(*dev_attr_config)[i].description = attr_config_list[i].description;
-					(*dev_attr_config)[i].label = attr_config_list[i].label;
-					(*dev_attr_config)[i].unit = attr_config_list[i].unit;
-					(*dev_attr_config)[i].standard_unit = attr_config_list[i].standard_unit;
-					(*dev_attr_config)[i].display_unit = attr_config_list[i].display_unit;
-					(*dev_attr_config)[i].format = attr_config_list[i].format;
-					(*dev_attr_config)[i].min_value = attr_config_list[i].min_value;
-					(*dev_attr_config)[i].max_value = attr_config_list[i].max_value;
-					(*dev_attr_config)[i].min_alarm = attr_config_list[i].min_alarm;
-					(*dev_attr_config)[i].max_alarm = attr_config_list[i].max_alarm;
-					(*dev_attr_config)[i].writable_attr_name = attr_config_list[i].writable_attr_name;
-					(*dev_attr_config)[i].extensions.resize(attr_config_list[i].extensions.length());
-					for (unsigned int j=0; j<attr_config_list[i].extensions.length(); j++)
-					{
-						(*dev_attr_config)[i].extensions[j] = attr_config_list[i].extensions[j];
-					}
-					(*dev_attr_config)[i].disp_level = Tango::OPERATOR;
-				}
-			}
-			else
-			{
-				Device_2_var dev = Device_2::_duplicate(device_2);
-				attr_config_list_2 = dev->get_attribute_config_2(attr_list);
+                for (unsigned int i = 0; i < attr_config_list->length(); i++)
+                {
+                    (*dev_attr_config)[i].name = attr_config_list[i].name;
+                    (*dev_attr_config)[i].writable = attr_config_list[i].writable;
+                    (*dev_attr_config)[i].data_format = attr_config_list[i].data_format;
+                    (*dev_attr_config)[i].data_type = attr_config_list[i].data_type;
+                    (*dev_attr_config)[i].max_dim_x = attr_config_list[i].max_dim_x;
+                    (*dev_attr_config)[i].max_dim_y = attr_config_list[i].max_dim_y;
+                    (*dev_attr_config)[i].description = attr_config_list[i].description;
+                    (*dev_attr_config)[i].label = attr_config_list[i].label;
+                    (*dev_attr_config)[i].unit = attr_config_list[i].unit;
+                    (*dev_attr_config)[i].standard_unit = attr_config_list[i].standard_unit;
+                    (*dev_attr_config)[i].display_unit = attr_config_list[i].display_unit;
+                    (*dev_attr_config)[i].format = attr_config_list[i].format;
+                    (*dev_attr_config)[i].min_value = attr_config_list[i].min_value;
+                    (*dev_attr_config)[i].max_value = attr_config_list[i].max_value;
+                    (*dev_attr_config)[i].min_alarm = attr_config_list[i].min_alarm;
+                    (*dev_attr_config)[i].max_alarm = attr_config_list[i].max_alarm;
+                    (*dev_attr_config)[i].writable_attr_name = attr_config_list[i].writable_attr_name;
+                    (*dev_attr_config)[i].extensions.resize(attr_config_list[i].extensions.length());
+                    for (unsigned int j = 0; j < attr_config_list[i].extensions.length(); j++)
+                    {
+                        (*dev_attr_config)[i].extensions[j] = attr_config_list[i].extensions[j];
+                    }
+                    (*dev_attr_config)[i].disp_level = Tango::OPERATOR;
+                }
+            }
+            else
+            {
+                Device_2_var dev = Device_2::_duplicate(device_2);
+                attr_config_list_2 = dev->get_attribute_config_2(attr_list);
 
-				dev_attr_config->resize(attr_config_list_2->length());
+                dev_attr_config->resize(attr_config_list_2->length());
 
-				for (unsigned int i=0; i<attr_config_list_2->length(); i++)
-				{
-					(*dev_attr_config)[i].name = attr_config_list_2[i].name;
-					(*dev_attr_config)[i].writable = attr_config_list_2[i].writable;
-					(*dev_attr_config)[i].data_format = attr_config_list_2[i].data_format;
-					(*dev_attr_config)[i].data_type = attr_config_list_2[i].data_type;
-					(*dev_attr_config)[i].max_dim_x = attr_config_list_2[i].max_dim_x;
-					(*dev_attr_config)[i].max_dim_y = attr_config_list_2[i].max_dim_y;
-					(*dev_attr_config)[i].description = attr_config_list_2[i].description;
-					(*dev_attr_config)[i].label = attr_config_list_2[i].label;
-					(*dev_attr_config)[i].unit = attr_config_list_2[i].unit;
-					(*dev_attr_config)[i].standard_unit = attr_config_list_2[i].standard_unit;
-					(*dev_attr_config)[i].display_unit = attr_config_list_2[i].display_unit;
-					(*dev_attr_config)[i].format = attr_config_list_2[i].format;
-					(*dev_attr_config)[i].min_value = attr_config_list_2[i].min_value;
-					(*dev_attr_config)[i].max_value = attr_config_list_2[i].max_value;
-					(*dev_attr_config)[i].min_alarm = attr_config_list_2[i].min_alarm;
-					(*dev_attr_config)[i].max_alarm = attr_config_list_2[i].max_alarm;
-					(*dev_attr_config)[i].writable_attr_name = attr_config_list_2[i].writable_attr_name;
-					(*dev_attr_config)[i].extensions.resize(attr_config_list_2[i].extensions.length());
-					for (unsigned int j=0; j<attr_config_list_2[i].extensions.length(); j++)
-					{
-						(*dev_attr_config)[i].extensions[j] = attr_config_list_2[i].extensions[j];
-					}
-					(*dev_attr_config)[i].disp_level = attr_config_list_2[i].level;
-				}
-			}
-			ctr = 2;
-		}
-		catch (CORBA::TRANSIENT &trans)
-		{
-			TRANSIENT_NOT_EXIST_EXCEPT(trans,"DeviceProxy","get_attribute_config",this);
-		}
-		catch (CORBA::OBJECT_NOT_EXIST &one)
-		{
-			if (one.minor() == omni::OBJECT_NOT_EXIST_NoMatch || one.minor() == 0)
-			{
-				TRANSIENT_NOT_EXIST_EXCEPT(one,"DeviceProxy","get_attribute_config",this);
-			}
-			else
-			{
-				set_connection_state(CONNECTION_NOTOK);
-				TangoSys_OMemStream desc;
-				desc << "Failed to execute get_attribute_config on device " << device_name << ends;
-				ApiCommExcept::re_throw_exception(one,
-							      (const char*)"API_CommunicationFailed",
-                        				      desc.str(),
-							      (const char*)"DeviceProxy::get_attribute_config()");
-			}
-		}
-		catch (CORBA::COMM_FAILURE &comm)
-		{
-			if (comm.minor() == omni::COMM_FAILURE_WaitingForReply)
-			{
-				TRANSIENT_NOT_EXIST_EXCEPT(comm,"DeviceProxy","get_attribute_config",this);
-			}
-			else
-			{
-				set_connection_state(CONNECTION_NOTOK);
-				TangoSys_OMemStream desc;
-				desc << "Failed to execute get_attribute_config on device " << device_name << ends;
-				ApiCommExcept::re_throw_exception(comm,
-							      (const char*)"API_CommunicationFailed",
-                        				      desc.str(),
-							      (const char*)"DeviceProxy::get_attribute_config()");
-			}
-		}
+                for (unsigned int i = 0; i < attr_config_list_2->length(); i++)
+                {
+                    (*dev_attr_config)[i].name = attr_config_list_2[i].name;
+                    (*dev_attr_config)[i].writable = attr_config_list_2[i].writable;
+                    (*dev_attr_config)[i].data_format = attr_config_list_2[i].data_format;
+                    (*dev_attr_config)[i].data_type = attr_config_list_2[i].data_type;
+                    (*dev_attr_config)[i].max_dim_x = attr_config_list_2[i].max_dim_x;
+                    (*dev_attr_config)[i].max_dim_y = attr_config_list_2[i].max_dim_y;
+                    (*dev_attr_config)[i].description = attr_config_list_2[i].description;
+                    (*dev_attr_config)[i].label = attr_config_list_2[i].label;
+                    (*dev_attr_config)[i].unit = attr_config_list_2[i].unit;
+                    (*dev_attr_config)[i].standard_unit = attr_config_list_2[i].standard_unit;
+                    (*dev_attr_config)[i].display_unit = attr_config_list_2[i].display_unit;
+                    (*dev_attr_config)[i].format = attr_config_list_2[i].format;
+                    (*dev_attr_config)[i].min_value = attr_config_list_2[i].min_value;
+                    (*dev_attr_config)[i].max_value = attr_config_list_2[i].max_value;
+                    (*dev_attr_config)[i].min_alarm = attr_config_list_2[i].min_alarm;
+                    (*dev_attr_config)[i].max_alarm = attr_config_list_2[i].max_alarm;
+                    (*dev_attr_config)[i].writable_attr_name = attr_config_list_2[i].writable_attr_name;
+                    (*dev_attr_config)[i].extensions.resize(attr_config_list_2[i].extensions.length());
+                    for (unsigned int j = 0; j < attr_config_list_2[i].extensions.length(); j++)
+                    {
+                        (*dev_attr_config)[i].extensions[j] = attr_config_list_2[i].extensions[j];
+                    }
+                    (*dev_attr_config)[i].disp_level = attr_config_list_2[i].level;
+                }
+            }
+            ctr = 2;
+        }
+        catch (CORBA::TRANSIENT &trans)
+        {
+            TRANSIENT_NOT_EXIST_EXCEPT(trans, "DeviceProxy", "get_attribute_config", this);
+        }
+        catch (CORBA::OBJECT_NOT_EXIST &one)
+        {
+            if (one.minor() == omni::OBJECT_NOT_EXIST_NoMatch || one.minor() == 0)
+            {
+                TRANSIENT_NOT_EXIST_EXCEPT(one, "DeviceProxy", "get_attribute_config", this);
+            }
+            else
+            {
+                set_connection_state(CONNECTION_NOTOK);
+                TangoSys_OMemStream desc;
+                desc << "Failed to execute get_attribute_config on device " << device_name << ends;
+                ApiCommExcept::re_throw_exception(one,
+                                                  (const char *) "API_CommunicationFailed",
+                                                  desc.str(),
+                                                  (const char *) "DeviceProxy::get_attribute_config()");
+            }
+        }
+        catch (CORBA::COMM_FAILURE &comm)
+        {
+            if (comm.minor() == omni::COMM_FAILURE_WaitingForReply)
+            {
+                TRANSIENT_NOT_EXIST_EXCEPT(comm, "DeviceProxy", "get_attribute_config", this);
+            }
+            else
+            {
+                set_connection_state(CONNECTION_NOTOK);
+                TangoSys_OMemStream desc;
+                desc << "Failed to execute get_attribute_config on device " << device_name << ends;
+                ApiCommExcept::re_throw_exception(comm,
+                                                  (const char *) "API_CommunicationFailed",
+                                                  desc.str(),
+                                                  (const char *) "DeviceProxy::get_attribute_config()");
+            }
+        }
         catch (CORBA::SystemException &ce)
         {
-			set_connection_state(CONNECTION_NOTOK);
+            set_connection_state(CONNECTION_NOTOK);
 
-			TangoSys_OMemStream desc;
-			desc << "Failed to execute get_attribute_config on device " << device_name << ends;
-			ApiCommExcept::re_throw_exception(ce,
-						   (const char*)"API_CommunicationFailed",
-                       				   desc.str(),
-						   (const char*)"DeviceProxy::get_attribute_config()");
-		}
-		catch (Tango::DevFailed)
-		{
-			delete dev_attr_config;
-			throw;
-		}
-	}
+            TangoSys_OMemStream desc;
+            desc << "Failed to execute get_attribute_config on device " << device_name << ends;
+            ApiCommExcept::re_throw_exception(ce,
+                                              (const char *) "API_CommunicationFailed",
+                                              desc.str(),
+                                              (const char *) "DeviceProxy::get_attribute_config()");
+        }
+        catch (Tango::DevFailed)
+        {
+            delete dev_attr_config;
+            throw;
+        }
+    }
 
-	return(dev_attr_config);
+    return (dev_attr_config);
 }
 
 //-----------------------------------------------------------------------------
@@ -3931,209 +3945,210 @@ AttributeInfoList *DeviceProxy::get_attribute_config(vector<string>& attr_string
 //
 //-----------------------------------------------------------------------------
 
-AttributeInfoListEx *DeviceProxy::get_attribute_config_ex(vector<string>& attr_string_list)
+AttributeInfoListEx *DeviceProxy::get_attribute_config_ex(vector<string> &attr_string_list)
 {
-	AttributeConfigList_var attr_config_list;
-	AttributeConfigList_2_var attr_config_list_2;
-	AttributeConfigList_3_var attr_config_list_3;
-	AttributeConfigList_5_var attr_config_list_5;
-	AttributeInfoListEx *dev_attr_config = new AttributeInfoListEx();
-	DevVarStringArray attr_list;
-	int ctr = 0;
+    AttributeConfigList_var attr_config_list;
+    AttributeConfigList_2_var attr_config_list_2;
+    AttributeConfigList_3_var attr_config_list_3;
+    AttributeConfigList_5_var attr_config_list_5;
+    AttributeInfoListEx *dev_attr_config = new AttributeInfoListEx();
+    DevVarStringArray attr_list;
+    int ctr = 0;
 
-	attr_list.length(attr_string_list.size());
-	for (unsigned int i=0; i<attr_string_list.size(); i++)
-	{
-		if (attr_string_list[i] == AllAttr)
-		{
-			if (version >= 3)
-				attr_list[i] = string_dup(AllAttr_3);
-			else
-				attr_list[i] = string_dup(AllAttr);
-		}
-		else if (attr_string_list[i] == AllAttr_3)
-		{
-			if (version < 3)
-				attr_list[i] = string_dup(AllAttr);
-			else
-				attr_list[i] = string_dup(AllAttr_3);
-		}
-		else
-			attr_list[i] = string_dup(attr_string_list[i].c_str());
-	}
+    attr_list.length(attr_string_list.size());
+    for (unsigned int i = 0; i < attr_string_list.size(); i++)
+    {
+        if (attr_string_list[i] == AllAttr)
+        {
+            if (version >= 3)
+                attr_list[i] = string_dup(AllAttr_3);
+            else
+                attr_list[i] = string_dup(AllAttr);
+        }
+        else if (attr_string_list[i] == AllAttr_3)
+        {
+            if (version < 3)
+                attr_list[i] = string_dup(AllAttr);
+            else
+                attr_list[i] = string_dup(AllAttr_3);
+        }
+        else
+            attr_list[i] = string_dup(attr_string_list[i].c_str());
+    }
 
-	while (ctr < 2)
-	{
-		try
-		{
-			check_and_reconnect();
+    while (ctr < 2)
+    {
+        try
+        {
+            check_and_reconnect();
 
-			switch (version)
-			{
-			case 1:
-				{
-					Device_var dev = Device::_duplicate(device);
-					attr_config_list = dev->get_attribute_config(attr_list);
-					dev_attr_config->resize(attr_config_list->length());
+            switch (version)
+            {
+                case 1:
+                {
+                    Device_var dev = Device::_duplicate(device);
+                    attr_config_list = dev->get_attribute_config(attr_list);
+                    dev_attr_config->resize(attr_config_list->length());
 
-					for (size_t i=0; i<attr_config_list->length(); i++)
-					{
-						COPY_BASE_CONFIG((*dev_attr_config),attr_config_list)
-						(*dev_attr_config)[i].min_alarm = attr_config_list[i].min_alarm;
-						(*dev_attr_config)[i].max_alarm = attr_config_list[i].max_alarm;
-						(*dev_attr_config)[i].disp_level = Tango::OPERATOR;
-					}
-				}
-				break;
+                    for (size_t i = 0; i < attr_config_list->length(); i++)
+                    {
+                        COPY_BASE_CONFIG((*dev_attr_config), attr_config_list)
+                        (*dev_attr_config)[i].min_alarm = attr_config_list[i].min_alarm;
+                        (*dev_attr_config)[i].max_alarm = attr_config_list[i].max_alarm;
+                        (*dev_attr_config)[i].disp_level = Tango::OPERATOR;
+                    }
+                }
+                    break;
 
 
-			case 2:
-				{
-					Device_2_var dev = Device_2::_duplicate(device_2);
-					attr_config_list_2 = dev->get_attribute_config_2(attr_list);
-					dev_attr_config->resize(attr_config_list_2->length());
+                case 2:
+                {
+                    Device_2_var dev = Device_2::_duplicate(device_2);
+                    attr_config_list_2 = dev->get_attribute_config_2(attr_list);
+                    dev_attr_config->resize(attr_config_list_2->length());
 
-					for (size_t i=0; i<attr_config_list_2->length(); i++)
-					{
-						COPY_BASE_CONFIG((*dev_attr_config),attr_config_list_2)
-						(*dev_attr_config)[i].min_alarm = attr_config_list_2[i].min_alarm;
-						(*dev_attr_config)[i].max_alarm = attr_config_list_2[i].max_alarm;
-						(*dev_attr_config)[i].disp_level = attr_config_list_2[i].level;
-					}
+                    for (size_t i = 0; i < attr_config_list_2->length(); i++)
+                    {
+                        COPY_BASE_CONFIG((*dev_attr_config), attr_config_list_2)
+                        (*dev_attr_config)[i].min_alarm = attr_config_list_2[i].min_alarm;
+                        (*dev_attr_config)[i].max_alarm = attr_config_list_2[i].max_alarm;
+                        (*dev_attr_config)[i].disp_level = attr_config_list_2[i].level;
+                    }
 
-					get_remaining_param(dev_attr_config);
-				}
-				break;
+                    get_remaining_param(dev_attr_config);
+                }
+                    break;
 
-			case 3:
-			case 4:
-				{
-					Device_3_var dev = Device_3::_duplicate(device_3);
-					attr_config_list_3 = dev->get_attribute_config_3(attr_list);
-					dev_attr_config->resize(attr_config_list_3->length());
+                case 3:
+                case 4:
+                {
+                    Device_3_var dev = Device_3::_duplicate(device_3);
+                    attr_config_list_3 = dev->get_attribute_config_3(attr_list);
+                    dev_attr_config->resize(attr_config_list_3->length());
 
-					for (size_t i=0; i<attr_config_list_3->length(); i++)
-					{
-						COPY_BASE_CONFIG((*dev_attr_config),attr_config_list_3)
+                    for (size_t i = 0; i < attr_config_list_3->length(); i++)
+                    {
+                        COPY_BASE_CONFIG((*dev_attr_config), attr_config_list_3)
 
-						for (size_t j=0; j<attr_config_list_3[i].sys_extensions.length(); j++)
-						{
-							(*dev_attr_config)[i].sys_extensions[j] = attr_config_list_3[i].sys_extensions[j];
-						}
-						(*dev_attr_config)[i].min_alarm = attr_config_list_3[i].att_alarm.min_alarm;
-						(*dev_attr_config)[i].max_alarm = attr_config_list_3[i].att_alarm.max_alarm;
-						(*dev_attr_config)[i].disp_level = attr_config_list_3[i].level;
-						(*dev_attr_config)[i].memorized = NOT_KNOWN;
+                        for (size_t j = 0; j < attr_config_list_3[i].sys_extensions.length(); j++)
+                        {
+                            (*dev_attr_config)[i].sys_extensions[j] = attr_config_list_3[i].sys_extensions[j];
+                        }
+                        (*dev_attr_config)[i].min_alarm = attr_config_list_3[i].att_alarm.min_alarm;
+                        (*dev_attr_config)[i].max_alarm = attr_config_list_3[i].att_alarm.max_alarm;
+                        (*dev_attr_config)[i].disp_level = attr_config_list_3[i].level;
+                        (*dev_attr_config)[i].memorized = NOT_KNOWN;
 
-						COPY_ALARM_CONFIG((*dev_attr_config),attr_config_list_3)
+                        COPY_ALARM_CONFIG((*dev_attr_config), attr_config_list_3)
 
-						COPY_EVENT_CONFIG((*dev_attr_config),attr_config_list_3)
-					}
-				}
-				break;
+                        COPY_EVENT_CONFIG((*dev_attr_config), attr_config_list_3)
+                    }
+                }
+                    break;
 
-			case 5:
-				{
-					Device_5_var dev = Device_5::_duplicate(device_5);
-					attr_config_list_5 = dev->get_attribute_config_5(attr_list);
-					dev_attr_config->resize(attr_config_list_5->length());
+                case 5:
+                {
+                    Device_5_var dev = Device_5::_duplicate(device_5);
+                    attr_config_list_5 = dev->get_attribute_config_5(attr_list);
+                    dev_attr_config->resize(attr_config_list_5->length());
 
-					for (size_t i=0; i<attr_config_list_5->length(); i++)
-					{
-						COPY_BASE_CONFIG((*dev_attr_config),attr_config_list_5)
+                    for (size_t i = 0; i < attr_config_list_5->length(); i++)
+                    {
+                        COPY_BASE_CONFIG((*dev_attr_config), attr_config_list_5)
 
-						for (size_t j=0; j<attr_config_list_5[i].sys_extensions.length(); j++)
-						{
-							(*dev_attr_config)[i].sys_extensions[j] = attr_config_list_5[i].sys_extensions[j];
-						}
-						(*dev_attr_config)[i].disp_level = attr_config_list_5[i].level;
-						(*dev_attr_config)[i].min_alarm = attr_config_list_5[i].att_alarm.min_alarm;
-						(*dev_attr_config)[i].max_alarm = attr_config_list_5[i].att_alarm.max_alarm;
-						(*dev_attr_config)[i].root_attr_name = attr_config_list_5[i].root_attr_name;
-						if (attr_config_list_5[i].memorized == false)
-							(*dev_attr_config)[i].memorized	= NONE;
-						else
-						{
-							if (attr_config_list_5[i].mem_init == false)
-								(*dev_attr_config)[i].memorized	= MEMORIZED;
-							else
-								(*dev_attr_config)[i].memorized	= MEMORIZED_WRITE_INIT;
-						}
-						if (attr_config_list_5[i].data_type == DEV_ENUM)
-						{
-							for(size_t loop = 0;loop < attr_config_list_5[i].enum_labels.length();loop++)
-								(*dev_attr_config)[i].enum_labels.push_back(attr_config_list_5[i].enum_labels[loop].in());
-						}
-						COPY_ALARM_CONFIG((*dev_attr_config),attr_config_list_5)
+                        for (size_t j = 0; j < attr_config_list_5[i].sys_extensions.length(); j++)
+                        {
+                            (*dev_attr_config)[i].sys_extensions[j] = attr_config_list_5[i].sys_extensions[j];
+                        }
+                        (*dev_attr_config)[i].disp_level = attr_config_list_5[i].level;
+                        (*dev_attr_config)[i].min_alarm = attr_config_list_5[i].att_alarm.min_alarm;
+                        (*dev_attr_config)[i].max_alarm = attr_config_list_5[i].att_alarm.max_alarm;
+                        (*dev_attr_config)[i].root_attr_name = attr_config_list_5[i].root_attr_name;
+                        if (attr_config_list_5[i].memorized == false)
+                            (*dev_attr_config)[i].memorized = NONE;
+                        else
+                        {
+                            if (attr_config_list_5[i].mem_init == false)
+                                (*dev_attr_config)[i].memorized = MEMORIZED;
+                            else
+                                (*dev_attr_config)[i].memorized = MEMORIZED_WRITE_INIT;
+                        }
+                        if (attr_config_list_5[i].data_type == DEV_ENUM)
+                        {
+                            for (size_t loop = 0; loop < attr_config_list_5[i].enum_labels.length(); loop++)
+                                (*dev_attr_config)[i].enum_labels
+                                    .push_back(attr_config_list_5[i].enum_labels[loop].in());
+                        }
+                        COPY_ALARM_CONFIG((*dev_attr_config), attr_config_list_5)
 
-						COPY_EVENT_CONFIG((*dev_attr_config),attr_config_list_5)
-					}
-				}
-				break;
+                        COPY_EVENT_CONFIG((*dev_attr_config), attr_config_list_5)
+                    }
+                }
+                    break;
 
-			default:
-				break;
-			}
+                default:
+                    break;
+            }
 
-			ctr = 2;
-		}
-		catch (CORBA::TRANSIENT &trans)
-		{
-			TRANSIENT_NOT_EXIST_EXCEPT(trans,"DeviceProxy","get_attribute_config",this);
-		}
-		catch (CORBA::OBJECT_NOT_EXIST &one)
-		{
-			if (one.minor() == omni::OBJECT_NOT_EXIST_NoMatch || one.minor() == 0)
-			{
-				TRANSIENT_NOT_EXIST_EXCEPT(one,"DeviceProxy","get_attribute_config",this);
-			}
-			else
-			{
-				set_connection_state(CONNECTION_NOTOK);
-				TangoSys_OMemStream desc;
-				desc << "Failed to execute get_attribute_config on device " << device_name << ends;
-				ApiCommExcept::re_throw_exception(one,
-							      (const char*)"API_CommunicationFailed",
-                        				      desc.str(),
-							      (const char*)"DeviceProxy::get_attribute_config()");
-			}
-		}
-		catch (CORBA::COMM_FAILURE &comm)
-		{
-			if (comm.minor() == omni::COMM_FAILURE_WaitingForReply)
-			{
-				TRANSIENT_NOT_EXIST_EXCEPT(comm,"DeviceProxy","get_attribute_config",this);
-			}
-			else
-			{
-				set_connection_state(CONNECTION_NOTOK);
-				TangoSys_OMemStream desc;
-				desc << "Failed to execute get_attribute_config on device " << device_name << ends;
-				ApiCommExcept::re_throw_exception(comm,
-							      (const char*)"API_CommunicationFailed",
-                        				      desc.str(),
-							      (const char*)"DeviceProxy::get_attribute_config()");
-			}
-		}
+            ctr = 2;
+        }
+        catch (CORBA::TRANSIENT &trans)
+        {
+            TRANSIENT_NOT_EXIST_EXCEPT(trans, "DeviceProxy", "get_attribute_config", this);
+        }
+        catch (CORBA::OBJECT_NOT_EXIST &one)
+        {
+            if (one.minor() == omni::OBJECT_NOT_EXIST_NoMatch || one.minor() == 0)
+            {
+                TRANSIENT_NOT_EXIST_EXCEPT(one, "DeviceProxy", "get_attribute_config", this);
+            }
+            else
+            {
+                set_connection_state(CONNECTION_NOTOK);
+                TangoSys_OMemStream desc;
+                desc << "Failed to execute get_attribute_config on device " << device_name << ends;
+                ApiCommExcept::re_throw_exception(one,
+                                                  (const char *) "API_CommunicationFailed",
+                                                  desc.str(),
+                                                  (const char *) "DeviceProxy::get_attribute_config()");
+            }
+        }
+        catch (CORBA::COMM_FAILURE &comm)
+        {
+            if (comm.minor() == omni::COMM_FAILURE_WaitingForReply)
+            {
+                TRANSIENT_NOT_EXIST_EXCEPT(comm, "DeviceProxy", "get_attribute_config", this);
+            }
+            else
+            {
+                set_connection_state(CONNECTION_NOTOK);
+                TangoSys_OMemStream desc;
+                desc << "Failed to execute get_attribute_config on device " << device_name << ends;
+                ApiCommExcept::re_throw_exception(comm,
+                                                  (const char *) "API_CommunicationFailed",
+                                                  desc.str(),
+                                                  (const char *) "DeviceProxy::get_attribute_config()");
+            }
+        }
         catch (CORBA::SystemException &ce)
         {
-			set_connection_state(CONNECTION_NOTOK);
+            set_connection_state(CONNECTION_NOTOK);
 
-			TangoSys_OMemStream desc;
-			desc << "Failed to execute get_attribute_config on device " << device_name << ends;
-			ApiCommExcept::re_throw_exception(ce,
-						   (const char*)"API_CommunicationFailed",
-                       				   desc.str(),
-						   (const char*)"DeviceProxy::get_attribute_config()");
-		}
-		catch (Tango::DevFailed)
-		{
-			delete dev_attr_config;
-			throw;
-		}
-	}
+            TangoSys_OMemStream desc;
+            desc << "Failed to execute get_attribute_config on device " << device_name << ends;
+            ApiCommExcept::re_throw_exception(ce,
+                                              (const char *) "API_CommunicationFailed",
+                                              desc.str(),
+                                              (const char *) "DeviceProxy::get_attribute_config()");
+        }
+        catch (Tango::DevFailed)
+        {
+            delete dev_attr_config;
+            throw;
+        }
+    }
 
-	return(dev_attr_config);
+    return (dev_attr_config);
 }
 
 //-----------------------------------------------------------------------------
@@ -4157,191 +4172,191 @@ void DeviceProxy::get_remaining_param(AttributeInfoListEx *dev_attr_config)
 // Give a default value to all param.
 //
 
-	for (unsigned int loop = 0;loop < dev_attr_config->size();loop++)
-	{
-		(*dev_attr_config)[loop].alarms.min_alarm = (*dev_attr_config)[loop].min_alarm;
-		(*dev_attr_config)[loop].alarms.max_alarm = (*dev_attr_config)[loop].max_alarm;
-		(*dev_attr_config)[loop].alarms.min_warning = AlrmValueNotSpec;
-		(*dev_attr_config)[loop].alarms.max_warning = AlrmValueNotSpec;
-		(*dev_attr_config)[loop].alarms.delta_t = AlrmValueNotSpec;
-		(*dev_attr_config)[loop].alarms.delta_val = AlrmValueNotSpec;
-		(*dev_attr_config)[loop].events.ch_event.abs_change = AlrmValueNotSpec;
-		(*dev_attr_config)[loop].events.ch_event.rel_change = AlrmValueNotSpec;
-		(*dev_attr_config)[loop].events.per_event.period = AlrmValueNotSpec;
-		(*dev_attr_config)[loop].events.arch_event.archive_abs_change = AlrmValueNotSpec;
-		(*dev_attr_config)[loop].events.arch_event.archive_rel_change = AlrmValueNotSpec;
-		(*dev_attr_config)[loop].events.arch_event.archive_period = AlrmValueNotSpec;
-	}
+    for (unsigned int loop = 0; loop < dev_attr_config->size(); loop++)
+    {
+        (*dev_attr_config)[loop].alarms.min_alarm = (*dev_attr_config)[loop].min_alarm;
+        (*dev_attr_config)[loop].alarms.max_alarm = (*dev_attr_config)[loop].max_alarm;
+        (*dev_attr_config)[loop].alarms.min_warning = AlrmValueNotSpec;
+        (*dev_attr_config)[loop].alarms.max_warning = AlrmValueNotSpec;
+        (*dev_attr_config)[loop].alarms.delta_t = AlrmValueNotSpec;
+        (*dev_attr_config)[loop].alarms.delta_val = AlrmValueNotSpec;
+        (*dev_attr_config)[loop].events.ch_event.abs_change = AlrmValueNotSpec;
+        (*dev_attr_config)[loop].events.ch_event.rel_change = AlrmValueNotSpec;
+        (*dev_attr_config)[loop].events.per_event.period = AlrmValueNotSpec;
+        (*dev_attr_config)[loop].events.arch_event.archive_abs_change = AlrmValueNotSpec;
+        (*dev_attr_config)[loop].events.arch_event.archive_rel_change = AlrmValueNotSpec;
+        (*dev_attr_config)[loop].events.arch_event.archive_period = AlrmValueNotSpec;
+    }
 
 //
 // If device does not use db, simply retruns
 //
 
-	if (dbase_used == false)
-	{
-		return;
-	}
-	else
-	{
+    if (dbase_used == false)
+    {
+        return;
+    }
+    else
+    {
 
 //
 // First get device class (if not already done)
 //
 
-		if (_info.dev_class.empty() == true)
-		{
-			this->info();
-		}
+        if (_info.dev_class.empty() == true)
+        {
+            this->info();
+        }
 
 //
 // Get class attribute properties
 //
 
-		DbData db_data_class, db_data_device;
-		unsigned int i,k;
-		int j;
-		for (i = 0;i < dev_attr_config->size();i++)
-		{
-			db_data_class.push_back(DbDatum((*dev_attr_config)[i].name));
-			db_data_device.push_back(DbDatum((*dev_attr_config)[i].name));
-		}
-		db_dev->get_dbase()->get_class_attribute_property(_info.dev_class,db_data_class);
+        DbData db_data_class, db_data_device;
+        unsigned int i, k;
+        int j;
+        for (i = 0; i < dev_attr_config->size(); i++)
+        {
+            db_data_class.push_back(DbDatum((*dev_attr_config)[i].name));
+            db_data_device.push_back(DbDatum((*dev_attr_config)[i].name));
+        }
+        db_dev->get_dbase()->get_class_attribute_property(_info.dev_class, db_data_class);
 
 //
 // Now get device attribute properties
 //
 
-		db_dev->get_attribute_property(db_data_device);
+        db_dev->get_attribute_property(db_data_device);
 
 //
 // Init remaining parameters from them retrieve at class level
 //
 
-		for (i = 0;i < db_data_class.size();i++)
-		{
-			long nb_prop;
+        for (i = 0; i < db_data_class.size(); i++)
+        {
+            long nb_prop;
 
-			string &att_name = db_data_class[i].name;
-			db_data_class[i] >> nb_prop;
-			i++;
+            string &att_name = db_data_class[i].name;
+            db_data_class[i] >> nb_prop;
+            i++;
 
-			for (j = 0;j < nb_prop;j++)
-			{
+            for (j = 0; j < nb_prop; j++)
+            {
 
 //
 // Extract prop value
 //
 
-				string prop_value;
-				string &prop_name = db_data_class[i].name;
-				if (db_data_class[i].size() != 1)
-				{
-					vector<string> tmp;
-					db_data_class[i] >> tmp;
-					prop_value = tmp[0] + ", " + tmp[1];
-				}
-				else
-					db_data_class[i] >> prop_value;
-				i++;
+                string prop_value;
+                string &prop_name = db_data_class[i].name;
+                if (db_data_class[i].size() != 1)
+                {
+                    vector<string> tmp;
+                    db_data_class[i] >> tmp;
+                    prop_value = tmp[0] + ", " + tmp[1];
+                }
+                else
+                    db_data_class[i] >> prop_value;
+                i++;
 
 //
 // Store prop value in attribute config vector
 //
 
-				for (k = 0;k < dev_attr_config->size();k++)
-				{
-					if ((*dev_attr_config)[k].name == att_name)
-					{
-						if (prop_name == "min_warning")
-							(*dev_attr_config)[k].alarms.min_warning = prop_value;
-						else if (prop_name == "max_warning")
-							(*dev_attr_config)[k].alarms.max_warning = prop_value;
-						else if (prop_name == "delta_t")
-							(*dev_attr_config)[k].alarms.delta_t = prop_value;
-						else if (prop_name == "delta_val")
-							(*dev_attr_config)[k].alarms.delta_val = prop_value;
-						else if (prop_name == "abs_change")
-							(*dev_attr_config)[k].events.ch_event.abs_change = prop_value;
-						else if (prop_name == "rel_change")
-							(*dev_attr_config)[k].events.ch_event.rel_change = prop_value;
-						else if (prop_name == "period")
-							(*dev_attr_config)[k].events.per_event.period = prop_value;
-						else if (prop_name == "archive_abs_change")
-							(*dev_attr_config)[k].events.arch_event.archive_abs_change = prop_value;
-						else if (prop_name == "archive_rel_change")
-							(*dev_attr_config)[k].events.arch_event.archive_rel_change = prop_value;
-						else if (prop_name == "archive_period")
-							(*dev_attr_config)[k].events.arch_event.archive_period = prop_value;
-					}
-				}
-			}
-		}
+                for (k = 0; k < dev_attr_config->size(); k++)
+                {
+                    if ((*dev_attr_config)[k].name == att_name)
+                    {
+                        if (prop_name == "min_warning")
+                            (*dev_attr_config)[k].alarms.min_warning = prop_value;
+                        else if (prop_name == "max_warning")
+                            (*dev_attr_config)[k].alarms.max_warning = prop_value;
+                        else if (prop_name == "delta_t")
+                            (*dev_attr_config)[k].alarms.delta_t = prop_value;
+                        else if (prop_name == "delta_val")
+                            (*dev_attr_config)[k].alarms.delta_val = prop_value;
+                        else if (prop_name == "abs_change")
+                            (*dev_attr_config)[k].events.ch_event.abs_change = prop_value;
+                        else if (prop_name == "rel_change")
+                            (*dev_attr_config)[k].events.ch_event.rel_change = prop_value;
+                        else if (prop_name == "period")
+                            (*dev_attr_config)[k].events.per_event.period = prop_value;
+                        else if (prop_name == "archive_abs_change")
+                            (*dev_attr_config)[k].events.arch_event.archive_abs_change = prop_value;
+                        else if (prop_name == "archive_rel_change")
+                            (*dev_attr_config)[k].events.arch_event.archive_rel_change = prop_value;
+                        else if (prop_name == "archive_period")
+                            (*dev_attr_config)[k].events.arch_event.archive_period = prop_value;
+                    }
+                }
+            }
+        }
 
 //
 // Init remaining parameters from them retrieve at device level
 //
 
-		for (i = 0;i < db_data_device.size();i++)
-		{
-			long nb_prop;
+        for (i = 0; i < db_data_device.size(); i++)
+        {
+            long nb_prop;
 
-			string &att_name = db_data_device[i].name;
-			db_data_device[i] >> nb_prop;
-			i++;
+            string &att_name = db_data_device[i].name;
+            db_data_device[i] >> nb_prop;
+            i++;
 
-			for (j = 0;j < nb_prop;j++)
-			{
+            for (j = 0; j < nb_prop; j++)
+            {
 
 //
 // Extract prop value
 //
 
-				string prop_value;
-				string &prop_name = db_data_device[i].name;
-				if (db_data_device[i].size() != 1)
-				{
-					vector<string> tmp;
-					db_data_device[i] >> tmp;
-					prop_value = tmp[0] + ", " + tmp[1];
-				}
-				else
-					db_data_device[i] >> prop_value;
-				i++;
+                string prop_value;
+                string &prop_name = db_data_device[i].name;
+                if (db_data_device[i].size() != 1)
+                {
+                    vector<string> tmp;
+                    db_data_device[i] >> tmp;
+                    prop_value = tmp[0] + ", " + tmp[1];
+                }
+                else
+                    db_data_device[i] >> prop_value;
+                i++;
 
 //
 // Store prop value in attribute config vector
 //
 
-				for (k = 0;k < dev_attr_config->size();k++)
-				{
-					if ((*dev_attr_config)[k].name == att_name)
-					{
-						if (prop_name == "min_warning")
-							(*dev_attr_config)[k].alarms.min_warning = prop_value;
-						else if (prop_name == "max_warning")
-							(*dev_attr_config)[k].alarms.max_warning = prop_value;
-						else if (prop_name == "delta_t")
-							(*dev_attr_config)[k].alarms.delta_t = prop_value;
-						else if (prop_name == "delta_val")
-							(*dev_attr_config)[k].alarms.delta_val = prop_value;
-						else if (prop_name == "abs_change")
-							(*dev_attr_config)[k].events.ch_event.abs_change = prop_value;
-						else if (prop_name == "rel_change")
-							(*dev_attr_config)[k].events.ch_event.rel_change = prop_value;
-						else if (prop_name == "period")
-							(*dev_attr_config)[k].events.per_event.period = prop_value;
-						else if (prop_name == "archive_abs_change")
-							(*dev_attr_config)[k].events.arch_event.archive_abs_change = prop_value;
-						else if (prop_name == "archive_rel_change")
-							(*dev_attr_config)[k].events.arch_event.archive_rel_change = prop_value;
-						else if (prop_name == "archive_period")
-							(*dev_attr_config)[k].events.arch_event.archive_period = prop_value;
-					}
-				}
-			}
-		}
+                for (k = 0; k < dev_attr_config->size(); k++)
+                {
+                    if ((*dev_attr_config)[k].name == att_name)
+                    {
+                        if (prop_name == "min_warning")
+                            (*dev_attr_config)[k].alarms.min_warning = prop_value;
+                        else if (prop_name == "max_warning")
+                            (*dev_attr_config)[k].alarms.max_warning = prop_value;
+                        else if (prop_name == "delta_t")
+                            (*dev_attr_config)[k].alarms.delta_t = prop_value;
+                        else if (prop_name == "delta_val")
+                            (*dev_attr_config)[k].alarms.delta_val = prop_value;
+                        else if (prop_name == "abs_change")
+                            (*dev_attr_config)[k].events.ch_event.abs_change = prop_value;
+                        else if (prop_name == "rel_change")
+                            (*dev_attr_config)[k].events.ch_event.rel_change = prop_value;
+                        else if (prop_name == "period")
+                            (*dev_attr_config)[k].events.per_event.period = prop_value;
+                        else if (prop_name == "archive_abs_change")
+                            (*dev_attr_config)[k].events.arch_event.archive_abs_change = prop_value;
+                        else if (prop_name == "archive_rel_change")
+                            (*dev_attr_config)[k].events.arch_event.archive_rel_change = prop_value;
+                        else if (prop_name == "archive_period")
+                            (*dev_attr_config)[k].events.arch_event.archive_period = prop_value;
+                    }
+                }
+            }
+        }
 
-	}
+    }
 
 }
 
@@ -4352,19 +4367,19 @@ void DeviceProxy::get_remaining_param(AttributeInfoListEx *dev_attr_config)
 //
 //-----------------------------------------------------------------------------
 
-AttributeInfoEx DeviceProxy::get_attribute_config(const string& attr_string)
+AttributeInfoEx DeviceProxy::get_attribute_config(const string &attr_string)
 {
-	vector<string> attr_string_list;
-	AttributeInfoListEx *dev_attr_config_list;
-	AttributeInfoEx dev_attr_config;
+    vector<string> attr_string_list;
+    AttributeInfoListEx *dev_attr_config_list;
+    AttributeInfoEx dev_attr_config;
 
-	attr_string_list.push_back(attr_string);
-	dev_attr_config_list = get_attribute_config_ex(attr_string_list);
+    attr_string_list.push_back(attr_string);
+    dev_attr_config_list = get_attribute_config_ex(attr_string_list);
 
-	dev_attr_config = (*dev_attr_config_list)[0];
-	delete(dev_attr_config_list);
+    dev_attr_config = (*dev_attr_config_list)[0];
+    delete (dev_attr_config_list);
 
-	return(dev_attr_config);
+    return (dev_attr_config);
 }
 
 //-----------------------------------------------------------------------------
@@ -4375,334 +4390,344 @@ AttributeInfoEx DeviceProxy::get_attribute_config(const string& attr_string)
 
 void DeviceProxy::set_attribute_config(AttributeInfoList &dev_attr_list)
 {
-	AttributeConfigList attr_config_list;
-	DevVarStringArray attr_list;
-	int ctr = 0;
+    AttributeConfigList attr_config_list;
+    DevVarStringArray attr_list;
+    int ctr = 0;
 
-	attr_config_list.length(dev_attr_list.size());
+    attr_config_list.length(dev_attr_list.size());
 
-	for (unsigned int i=0; i<attr_config_list.length(); i++)
-	{
-		attr_config_list[i].name = dev_attr_list[i].name.c_str();
-		attr_config_list[i].writable = dev_attr_list[i].writable;
-		attr_config_list[i].data_format = dev_attr_list[i].data_format;
-		attr_config_list[i].data_type = dev_attr_list[i].data_type;
-		attr_config_list[i].max_dim_x = dev_attr_list[i].max_dim_x;
-		attr_config_list[i].max_dim_y = dev_attr_list[i].max_dim_y;
-		attr_config_list[i].description = dev_attr_list[i].description.c_str();
-		attr_config_list[i].label = dev_attr_list[i].label.c_str();
-		attr_config_list[i].unit = dev_attr_list[i].unit.c_str();
-		attr_config_list[i].standard_unit = dev_attr_list[i].standard_unit.c_str();
-		attr_config_list[i].display_unit = dev_attr_list[i].display_unit.c_str();
-		attr_config_list[i].format = dev_attr_list[i].format.c_str();
-		attr_config_list[i].min_value = dev_attr_list[i].min_value.c_str();
-		attr_config_list[i].max_value = dev_attr_list[i].max_value.c_str();
-		attr_config_list[i].min_alarm = dev_attr_list[i].min_alarm.c_str();
-		attr_config_list[i].max_alarm = dev_attr_list[i].max_alarm.c_str();
-		attr_config_list[i].writable_attr_name = dev_attr_list[i].writable_attr_name.c_str();
-		attr_config_list[i].extensions.length(dev_attr_list[i].extensions.size());
-		for (unsigned int j=0; j<dev_attr_list[i].extensions.size(); j++)
-		{
-			attr_config_list[i].extensions[j] = string_dup(dev_attr_list[i].extensions[j].c_str());
-		}
-	}
+    for (unsigned int i = 0; i < attr_config_list.length(); i++)
+    {
+        attr_config_list[i].name = dev_attr_list[i].name.c_str();
+        attr_config_list[i].writable = dev_attr_list[i].writable;
+        attr_config_list[i].data_format = dev_attr_list[i].data_format;
+        attr_config_list[i].data_type = dev_attr_list[i].data_type;
+        attr_config_list[i].max_dim_x = dev_attr_list[i].max_dim_x;
+        attr_config_list[i].max_dim_y = dev_attr_list[i].max_dim_y;
+        attr_config_list[i].description = dev_attr_list[i].description.c_str();
+        attr_config_list[i].label = dev_attr_list[i].label.c_str();
+        attr_config_list[i].unit = dev_attr_list[i].unit.c_str();
+        attr_config_list[i].standard_unit = dev_attr_list[i].standard_unit.c_str();
+        attr_config_list[i].display_unit = dev_attr_list[i].display_unit.c_str();
+        attr_config_list[i].format = dev_attr_list[i].format.c_str();
+        attr_config_list[i].min_value = dev_attr_list[i].min_value.c_str();
+        attr_config_list[i].max_value = dev_attr_list[i].max_value.c_str();
+        attr_config_list[i].min_alarm = dev_attr_list[i].min_alarm.c_str();
+        attr_config_list[i].max_alarm = dev_attr_list[i].max_alarm.c_str();
+        attr_config_list[i].writable_attr_name = dev_attr_list[i].writable_attr_name.c_str();
+        attr_config_list[i].extensions.length(dev_attr_list[i].extensions.size());
+        for (unsigned int j = 0; j < dev_attr_list[i].extensions.size(); j++)
+        {
+            attr_config_list[i].extensions[j] = string_dup(dev_attr_list[i].extensions[j].c_str());
+        }
+    }
 
-	while (ctr < 2)
-	{
-		try
-		{
-			check_and_reconnect();
+    while (ctr < 2)
+    {
+        try
+        {
+            check_and_reconnect();
 
-			Device_var dev = Device::_duplicate(device);
-			dev->set_attribute_config(attr_config_list);
-			ctr = 2;
+            Device_var dev = Device::_duplicate(device);
+            dev->set_attribute_config(attr_config_list);
+            ctr = 2;
 
-		}
-		catch (Tango::DevFailed &e)
-		{
-			if (::strcmp(e.errors[0].reason,DEVICE_UNLOCKED_REASON) == 0)
-			{
-				TangoSys_OMemStream desc;
-				desc << "Failed to execute set_attribute_config on device " << device_name << ends;
+        }
+        catch (Tango::DevFailed &e)
+        {
+            if (::strcmp(e.errors[0].reason, DEVICE_UNLOCKED_REASON) == 0)
+            {
+                TangoSys_OMemStream desc;
+                desc << "Failed to execute set_attribute_config on device " << device_name << ends;
 
-				DeviceUnlockedExcept::re_throw_exception(e,(const char*)DEVICE_UNLOCKED_REASON,
-							desc.str(), (const char*)"DeviceProxy::set_attribute_config()");
-			}
-			else
-				throw;
-		}
-		catch (CORBA::TRANSIENT &trans)
-		{
-			TRANSIENT_NOT_EXIST_EXCEPT(trans,"DeviceProxy","set_attribute_config",this);
-		}
-		catch (CORBA::OBJECT_NOT_EXIST &one)
-		{
-			if (one.minor() == omni::OBJECT_NOT_EXIST_NoMatch || one.minor() == 0)
-			{
-				TRANSIENT_NOT_EXIST_EXCEPT(one,"DeviceProxy","set_attribute_config",this);
-			}
-			else
-			{
-				set_connection_state(CONNECTION_NOTOK);
-				TangoSys_OMemStream desc;
-				desc << "Failed to execute set_attribute_config on device " << device_name << ends;
-				ApiCommExcept::re_throw_exception(one,
-							      (const char*)"API_CommunicationFailed",
-                        				      desc.str(),
-							      (const char*)"DeviceProxy::set_attribute_config()");
-			}
-		}
-		catch (CORBA::COMM_FAILURE &comm)
-		{
-			if (comm.minor() == omni::COMM_FAILURE_WaitingForReply)
-			{
-				TRANSIENT_NOT_EXIST_EXCEPT(comm,"DeviceProxy","set_attribute_config",this);
-			}
-			else
-			{
-				set_connection_state(CONNECTION_NOTOK);
-				TangoSys_OMemStream desc;
-				desc << "Failed to execute set_attribute_config on device " << device_name << ends;
-				ApiCommExcept::re_throw_exception(comm,
-							      (const char*)"API_CommunicationFailed",
-                        				      desc.str(),
-							      (const char*)"DeviceProxy::set_attribute_config()");
-			}
-		}
+                DeviceUnlockedExcept::re_throw_exception(e,
+                                                         (const char *) DEVICE_UNLOCKED_REASON,
+                                                         desc.str(),
+                                                         (const char *) "DeviceProxy::set_attribute_config()");
+            }
+            else
+                throw;
+        }
+        catch (CORBA::TRANSIENT &trans)
+        {
+            TRANSIENT_NOT_EXIST_EXCEPT(trans, "DeviceProxy", "set_attribute_config", this);
+        }
+        catch (CORBA::OBJECT_NOT_EXIST &one)
+        {
+            if (one.minor() == omni::OBJECT_NOT_EXIST_NoMatch || one.minor() == 0)
+            {
+                TRANSIENT_NOT_EXIST_EXCEPT(one, "DeviceProxy", "set_attribute_config", this);
+            }
+            else
+            {
+                set_connection_state(CONNECTION_NOTOK);
+                TangoSys_OMemStream desc;
+                desc << "Failed to execute set_attribute_config on device " << device_name << ends;
+                ApiCommExcept::re_throw_exception(one,
+                                                  (const char *) "API_CommunicationFailed",
+                                                  desc.str(),
+                                                  (const char *) "DeviceProxy::set_attribute_config()");
+            }
+        }
+        catch (CORBA::COMM_FAILURE &comm)
+        {
+            if (comm.minor() == omni::COMM_FAILURE_WaitingForReply)
+            {
+                TRANSIENT_NOT_EXIST_EXCEPT(comm, "DeviceProxy", "set_attribute_config", this);
+            }
+            else
+            {
+                set_connection_state(CONNECTION_NOTOK);
+                TangoSys_OMemStream desc;
+                desc << "Failed to execute set_attribute_config on device " << device_name << ends;
+                ApiCommExcept::re_throw_exception(comm,
+                                                  (const char *) "API_CommunicationFailed",
+                                                  desc.str(),
+                                                  (const char *) "DeviceProxy::set_attribute_config()");
+            }
+        }
         catch (CORBA::SystemException &ce)
         {
-			set_connection_state(CONNECTION_NOTOK);
+            set_connection_state(CONNECTION_NOTOK);
 
-			TangoSys_OMemStream desc;
-			desc << "Failed to execute set_attribute_config on device " << device_name << ends;
-			ApiCommExcept::re_throw_exception(ce,
-						      (const char*)"API_CommunicationFailed",
-                        			      desc.str(),
-						      (const char*)"DeviceProxy::set_attribute_config()");
-		}
-	}
+            TangoSys_OMemStream desc;
+            desc << "Failed to execute set_attribute_config on device " << device_name << ends;
+            ApiCommExcept::re_throw_exception(ce,
+                                              (const char *) "API_CommunicationFailed",
+                                              desc.str(),
+                                              (const char *) "DeviceProxy::set_attribute_config()");
+        }
+    }
 
 
-	return;
+    return;
 }
-
 
 void DeviceProxy::set_attribute_config(AttributeInfoListEx &dev_attr_list)
 {
-	AttributeConfigList attr_config_list;
-	AttributeConfigList_3 attr_config_list_3;
-	AttributeConfigList_5 attr_config_list_5;
-	DevVarStringArray attr_list;
-	int ctr = 0;
-	unsigned int i,j;
+    AttributeConfigList attr_config_list;
+    AttributeConfigList_3 attr_config_list_3;
+    AttributeConfigList_5 attr_config_list_5;
+    DevVarStringArray attr_list;
+    int ctr = 0;
+    unsigned int i, j;
 
 
-	if (version >= 5)
-	{
-		attr_config_list_5.length(dev_attr_list.size());
+    if (version >= 5)
+    {
+        attr_config_list_5.length(dev_attr_list.size());
 
-		for (i=0; i<attr_config_list_5.length(); i++)
-		{
-			ApiUtil::AttributeInfoEx_to_AttributeConfig(&dev_attr_list[i],&attr_config_list_5[i]);
-		}
-	}
-	else if (version >= 3)
-	{
-		attr_config_list_3.length(dev_attr_list.size());
+        for (i = 0; i < attr_config_list_5.length(); i++)
+        {
+            ApiUtil::AttributeInfoEx_to_AttributeConfig(&dev_attr_list[i], &attr_config_list_5[i]);
+        }
+    }
+    else if (version >= 3)
+    {
+        attr_config_list_3.length(dev_attr_list.size());
 
-		for (i=0; i<attr_config_list_3.length(); i++)
-		{
-			attr_config_list_3[i].name = dev_attr_list[i].name.c_str();
-			attr_config_list_3[i].writable = dev_attr_list[i].writable;
-			attr_config_list_3[i].data_format = dev_attr_list[i].data_format;
-			attr_config_list_3[i].data_type = dev_attr_list[i].data_type;
-			attr_config_list_3[i].max_dim_x = dev_attr_list[i].max_dim_x;
-			attr_config_list_3[i].max_dim_y = dev_attr_list[i].max_dim_y;
-			attr_config_list_3[i].description = dev_attr_list[i].description.c_str();
-			attr_config_list_3[i].label = dev_attr_list[i].label.c_str();
-			attr_config_list_3[i].unit = dev_attr_list[i].unit.c_str();
-			attr_config_list_3[i].standard_unit = dev_attr_list[i].standard_unit.c_str();
-			attr_config_list_3[i].display_unit = dev_attr_list[i].display_unit.c_str();
-			attr_config_list_3[i].format = dev_attr_list[i].format.c_str();
-			attr_config_list_3[i].min_value = dev_attr_list[i].min_value.c_str();
-			attr_config_list_3[i].max_value = dev_attr_list[i].max_value.c_str();
-			attr_config_list_3[i].writable_attr_name = dev_attr_list[i].writable_attr_name.c_str();
-			attr_config_list_3[i].level = dev_attr_list[i].disp_level;
-			attr_config_list_3[i].extensions.length(dev_attr_list[i].extensions.size());
-			for (j=0; j<dev_attr_list[i].extensions.size(); j++)
-			{
-				attr_config_list_3[i].extensions[j] = string_dup(dev_attr_list[i].extensions[j].c_str());
-			}
-			for (j=0; j<dev_attr_list[i].sys_extensions.size(); j++)
-			{
-				attr_config_list_3[i].sys_extensions[j] = string_dup(dev_attr_list[i].sys_extensions[j].c_str());
-			}
+        for (i = 0; i < attr_config_list_3.length(); i++)
+        {
+            attr_config_list_3[i].name = dev_attr_list[i].name.c_str();
+            attr_config_list_3[i].writable = dev_attr_list[i].writable;
+            attr_config_list_3[i].data_format = dev_attr_list[i].data_format;
+            attr_config_list_3[i].data_type = dev_attr_list[i].data_type;
+            attr_config_list_3[i].max_dim_x = dev_attr_list[i].max_dim_x;
+            attr_config_list_3[i].max_dim_y = dev_attr_list[i].max_dim_y;
+            attr_config_list_3[i].description = dev_attr_list[i].description.c_str();
+            attr_config_list_3[i].label = dev_attr_list[i].label.c_str();
+            attr_config_list_3[i].unit = dev_attr_list[i].unit.c_str();
+            attr_config_list_3[i].standard_unit = dev_attr_list[i].standard_unit.c_str();
+            attr_config_list_3[i].display_unit = dev_attr_list[i].display_unit.c_str();
+            attr_config_list_3[i].format = dev_attr_list[i].format.c_str();
+            attr_config_list_3[i].min_value = dev_attr_list[i].min_value.c_str();
+            attr_config_list_3[i].max_value = dev_attr_list[i].max_value.c_str();
+            attr_config_list_3[i].writable_attr_name = dev_attr_list[i].writable_attr_name.c_str();
+            attr_config_list_3[i].level = dev_attr_list[i].disp_level;
+            attr_config_list_3[i].extensions.length(dev_attr_list[i].extensions.size());
+            for (j = 0; j < dev_attr_list[i].extensions.size(); j++)
+            {
+                attr_config_list_3[i].extensions[j] = string_dup(dev_attr_list[i].extensions[j].c_str());
+            }
+            for (j = 0; j < dev_attr_list[i].sys_extensions.size(); j++)
+            {
+                attr_config_list_3[i].sys_extensions[j] = string_dup(dev_attr_list[i].sys_extensions[j].c_str());
+            }
 
-			attr_config_list_3[i].att_alarm.min_alarm = dev_attr_list[i].alarms.min_alarm.c_str();
-			attr_config_list_3[i].att_alarm.max_alarm = dev_attr_list[i].alarms.max_alarm.c_str();
-			attr_config_list_3[i].att_alarm.min_warning = dev_attr_list[i].alarms.min_warning.c_str();
-			attr_config_list_3[i].att_alarm.max_warning = dev_attr_list[i].alarms.max_warning.c_str();
-			attr_config_list_3[i].att_alarm.delta_t = dev_attr_list[i].alarms.delta_t.c_str();
-			attr_config_list_3[i].att_alarm.delta_val = dev_attr_list[i].alarms.delta_val.c_str();
-			for (j=0; j<dev_attr_list[i].alarms.extensions.size(); j++)
-			{
-				attr_config_list_3[i].att_alarm.extensions[j] = string_dup(dev_attr_list[i].alarms.extensions[j].c_str());
-			}
+            attr_config_list_3[i].att_alarm.min_alarm = dev_attr_list[i].alarms.min_alarm.c_str();
+            attr_config_list_3[i].att_alarm.max_alarm = dev_attr_list[i].alarms.max_alarm.c_str();
+            attr_config_list_3[i].att_alarm.min_warning = dev_attr_list[i].alarms.min_warning.c_str();
+            attr_config_list_3[i].att_alarm.max_warning = dev_attr_list[i].alarms.max_warning.c_str();
+            attr_config_list_3[i].att_alarm.delta_t = dev_attr_list[i].alarms.delta_t.c_str();
+            attr_config_list_3[i].att_alarm.delta_val = dev_attr_list[i].alarms.delta_val.c_str();
+            for (j = 0; j < dev_attr_list[i].alarms.extensions.size(); j++)
+            {
+                attr_config_list_3[i].att_alarm.extensions[j] =
+                    string_dup(dev_attr_list[i].alarms.extensions[j].c_str());
+            }
 
-			attr_config_list_3[i].event_prop.ch_event.rel_change = dev_attr_list[i].events.ch_event.rel_change.c_str();
-			attr_config_list_3[i].event_prop.ch_event.abs_change = dev_attr_list[i].events.ch_event.abs_change.c_str();
-			for (j=0; j<dev_attr_list[i].events.ch_event.extensions.size(); j++)
-			{
-				attr_config_list_3[i].event_prop.ch_event.extensions[j] = string_dup(dev_attr_list[i].events.ch_event.extensions[j].c_str());
-			}
+            attr_config_list_3[i].event_prop.ch_event.rel_change = dev_attr_list[i].events.ch_event.rel_change.c_str();
+            attr_config_list_3[i].event_prop.ch_event.abs_change = dev_attr_list[i].events.ch_event.abs_change.c_str();
+            for (j = 0; j < dev_attr_list[i].events.ch_event.extensions.size(); j++)
+            {
+                attr_config_list_3[i].event_prop.ch_event.extensions[j] =
+                    string_dup(dev_attr_list[i].events.ch_event.extensions[j].c_str());
+            }
 
-			attr_config_list_3[i].event_prop.per_event.period = dev_attr_list[i].events.per_event.period.c_str();
-			for (j=0; j<dev_attr_list[i].events.per_event.extensions.size(); j++)
-			{
-				attr_config_list_3[i].event_prop.per_event.extensions[j] = string_dup(dev_attr_list[i].events.per_event.extensions[j].c_str());
-			}
+            attr_config_list_3[i].event_prop.per_event.period = dev_attr_list[i].events.per_event.period.c_str();
+            for (j = 0; j < dev_attr_list[i].events.per_event.extensions.size(); j++)
+            {
+                attr_config_list_3[i].event_prop.per_event.extensions[j] =
+                    string_dup(dev_attr_list[i].events.per_event.extensions[j].c_str());
+            }
 
-			attr_config_list_3[i].event_prop.arch_event.rel_change = dev_attr_list[i].events.arch_event.archive_rel_change.c_str();
-			attr_config_list_3[i].event_prop.arch_event.abs_change = dev_attr_list[i].events.arch_event.archive_abs_change.c_str();
-			attr_config_list_3[i].event_prop.arch_event.period = dev_attr_list[i].events.arch_event.archive_period.c_str();
-			for (j=0; j<dev_attr_list[i].events.ch_event.extensions.size(); j++)
-			{
-				attr_config_list_3[i].event_prop.arch_event.extensions[j] = string_dup(dev_attr_list[i].events.arch_event.extensions[j].c_str());
-			}
-		}
-	}
-	else
-	{
-		attr_config_list.length(dev_attr_list.size());
+            attr_config_list_3[i].event_prop.arch_event.rel_change =
+                dev_attr_list[i].events.arch_event.archive_rel_change.c_str();
+            attr_config_list_3[i].event_prop.arch_event.abs_change =
+                dev_attr_list[i].events.arch_event.archive_abs_change.c_str();
+            attr_config_list_3[i].event_prop.arch_event.period =
+                dev_attr_list[i].events.arch_event.archive_period.c_str();
+            for (j = 0; j < dev_attr_list[i].events.ch_event.extensions.size(); j++)
+            {
+                attr_config_list_3[i].event_prop.arch_event.extensions[j] =
+                    string_dup(dev_attr_list[i].events.arch_event.extensions[j].c_str());
+            }
+        }
+    }
+    else
+    {
+        attr_config_list.length(dev_attr_list.size());
 
-		for (i=0; i<attr_config_list.length(); i++)
-		{
-			attr_config_list[i].name = dev_attr_list[i].name.c_str();
-			attr_config_list[i].writable = dev_attr_list[i].writable;
-			attr_config_list[i].data_format = dev_attr_list[i].data_format;
-			attr_config_list[i].data_type = dev_attr_list[i].data_type;
-			attr_config_list[i].max_dim_x = dev_attr_list[i].max_dim_x;
-			attr_config_list[i].max_dim_y = dev_attr_list[i].max_dim_y;
-			attr_config_list[i].description = dev_attr_list[i].description.c_str();
-			attr_config_list[i].label = dev_attr_list[i].label.c_str();
-			attr_config_list[i].unit = dev_attr_list[i].unit.c_str();
-			attr_config_list[i].standard_unit = dev_attr_list[i].standard_unit.c_str();
-			attr_config_list[i].display_unit = dev_attr_list[i].display_unit.c_str();
-			attr_config_list[i].format = dev_attr_list[i].format.c_str();
-			attr_config_list[i].min_value = dev_attr_list[i].min_value.c_str();
-			attr_config_list[i].max_value = dev_attr_list[i].max_value.c_str();
-			attr_config_list[i].min_alarm = dev_attr_list[i].min_alarm.c_str();
-			attr_config_list[i].max_alarm = dev_attr_list[i].max_alarm.c_str();
-			attr_config_list[i].writable_attr_name = dev_attr_list[i].writable_attr_name.c_str();
-			attr_config_list[i].extensions.length(dev_attr_list[i].extensions.size());
-			for (j=0; j<dev_attr_list[i].extensions.size(); j++)
-			{
-				attr_config_list_3[i].extensions[j] = string_dup(dev_attr_list[i].extensions[j].c_str());
-			}
-		}
-	}
+        for (i = 0; i < attr_config_list.length(); i++)
+        {
+            attr_config_list[i].name = dev_attr_list[i].name.c_str();
+            attr_config_list[i].writable = dev_attr_list[i].writable;
+            attr_config_list[i].data_format = dev_attr_list[i].data_format;
+            attr_config_list[i].data_type = dev_attr_list[i].data_type;
+            attr_config_list[i].max_dim_x = dev_attr_list[i].max_dim_x;
+            attr_config_list[i].max_dim_y = dev_attr_list[i].max_dim_y;
+            attr_config_list[i].description = dev_attr_list[i].description.c_str();
+            attr_config_list[i].label = dev_attr_list[i].label.c_str();
+            attr_config_list[i].unit = dev_attr_list[i].unit.c_str();
+            attr_config_list[i].standard_unit = dev_attr_list[i].standard_unit.c_str();
+            attr_config_list[i].display_unit = dev_attr_list[i].display_unit.c_str();
+            attr_config_list[i].format = dev_attr_list[i].format.c_str();
+            attr_config_list[i].min_value = dev_attr_list[i].min_value.c_str();
+            attr_config_list[i].max_value = dev_attr_list[i].max_value.c_str();
+            attr_config_list[i].min_alarm = dev_attr_list[i].min_alarm.c_str();
+            attr_config_list[i].max_alarm = dev_attr_list[i].max_alarm.c_str();
+            attr_config_list[i].writable_attr_name = dev_attr_list[i].writable_attr_name.c_str();
+            attr_config_list[i].extensions.length(dev_attr_list[i].extensions.size());
+            for (j = 0; j < dev_attr_list[i].extensions.size(); j++)
+            {
+                attr_config_list_3[i].extensions[j] = string_dup(dev_attr_list[i].extensions[j].c_str());
+            }
+        }
+    }
 
-	while (ctr < 2)
-	{
-		try
-		{
-			check_and_reconnect();
+    while (ctr < 2)
+    {
+        try
+        {
+            check_and_reconnect();
 
-			if (version >= 4)
-			{
-				ClntIdent ci;
-				ApiUtil *au = ApiUtil::instance();
-				ci.cpp_clnt(au->get_client_pid());
+            if (version >= 4)
+            {
+                ClntIdent ci;
+                ApiUtil *au = ApiUtil::instance();
+                ci.cpp_clnt(au->get_client_pid());
 
-				if (version == 5)
-				{
-					Device_5_var dev = Device_5::_duplicate(device_5);
-					dev->set_attribute_config_5(attr_config_list_5,ci);
-				}
-				else
-				{
-					Device_4_var dev = Device_4::_duplicate(device_4);
-					dev->set_attribute_config_4(attr_config_list_3,ci);
-				}
-			}
-			else if (version == 3)
-			{
-				Device_3_var dev = Device_3::_duplicate(device_3);
-				dev->set_attribute_config_3(attr_config_list_3);
-			}
-			else
-			{
-				Device_var dev = Device::_duplicate(device);
-				device->set_attribute_config(attr_config_list);
-			}
-			ctr = 2;
+                if (version == 5)
+                {
+                    Device_5_var dev = Device_5::_duplicate(device_5);
+                    dev->set_attribute_config_5(attr_config_list_5, ci);
+                }
+                else
+                {
+                    Device_4_var dev = Device_4::_duplicate(device_4);
+                    dev->set_attribute_config_4(attr_config_list_3, ci);
+                }
+            }
+            else if (version == 3)
+            {
+                Device_3_var dev = Device_3::_duplicate(device_3);
+                dev->set_attribute_config_3(attr_config_list_3);
+            }
+            else
+            {
+                Device_var dev = Device::_duplicate(device);
+                device->set_attribute_config(attr_config_list);
+            }
+            ctr = 2;
 
-		}
-		catch (Tango::DevFailed &e)
-		{
-			if (::strcmp(e.errors[0].reason,DEVICE_UNLOCKED_REASON) == 0)
-			{
-				TangoSys_OMemStream desc;
-				desc << "Failed to execute set_attribute_config on device " << device_name << ends;
+        }
+        catch (Tango::DevFailed &e)
+        {
+            if (::strcmp(e.errors[0].reason, DEVICE_UNLOCKED_REASON) == 0)
+            {
+                TangoSys_OMemStream desc;
+                desc << "Failed to execute set_attribute_config on device " << device_name << ends;
 
-				DeviceUnlockedExcept::re_throw_exception(e,(const char*)DEVICE_UNLOCKED_REASON,
-							desc.str(), (const char*)"DeviceProxy::set_attribute_config()");
-			}
-			else
-				throw;
-		}
-		catch (CORBA::TRANSIENT &trans)
-		{
-			TRANSIENT_NOT_EXIST_EXCEPT(trans,"DeviceProxy","set_attribute_config",this);
-		}
-		catch (CORBA::OBJECT_NOT_EXIST &one)
-		{
-			if (one.minor() == omni::OBJECT_NOT_EXIST_NoMatch || one.minor() == 0)
-			{
-				TRANSIENT_NOT_EXIST_EXCEPT(one,"DeviceProxy","set_attribute_config",this);
-			}
-			else
-			{
-				set_connection_state(CONNECTION_NOTOK);
-				TangoSys_OMemStream desc;
-				desc << "Failed to execute set_attribute_config on device " << device_name << ends;
-				ApiCommExcept::re_throw_exception(one,
-							      (const char*)"API_CommunicationFailed",
-                        				      desc.str(),
-							      (const char*)"DeviceProxy::set_attribute_config()");
-			}
-		}
-		catch (CORBA::COMM_FAILURE &comm)
-		{
-			if (comm.minor() == omni::COMM_FAILURE_WaitingForReply)
-			{
-				TRANSIENT_NOT_EXIST_EXCEPT(comm,"DeviceProxy","set_attribute_config",this);
-			}
-			else
-			{
-				set_connection_state(CONNECTION_NOTOK);
-				TangoSys_OMemStream desc;
-				desc << "Failed to execute set_attribute_config on device " << device_name << ends;
-				ApiCommExcept::re_throw_exception(comm,
-							      (const char*)"API_CommunicationFailed",
-                        				      desc.str(),
-							      (const char*)"DeviceProxy::set_attribute_config()");
-			}
-		}
+                DeviceUnlockedExcept::re_throw_exception(e,
+                                                         (const char *) DEVICE_UNLOCKED_REASON,
+                                                         desc.str(),
+                                                         (const char *) "DeviceProxy::set_attribute_config()");
+            }
+            else
+                throw;
+        }
+        catch (CORBA::TRANSIENT &trans)
+        {
+            TRANSIENT_NOT_EXIST_EXCEPT(trans, "DeviceProxy", "set_attribute_config", this);
+        }
+        catch (CORBA::OBJECT_NOT_EXIST &one)
+        {
+            if (one.minor() == omni::OBJECT_NOT_EXIST_NoMatch || one.minor() == 0)
+            {
+                TRANSIENT_NOT_EXIST_EXCEPT(one, "DeviceProxy", "set_attribute_config", this);
+            }
+            else
+            {
+                set_connection_state(CONNECTION_NOTOK);
+                TangoSys_OMemStream desc;
+                desc << "Failed to execute set_attribute_config on device " << device_name << ends;
+                ApiCommExcept::re_throw_exception(one,
+                                                  (const char *) "API_CommunicationFailed",
+                                                  desc.str(),
+                                                  (const char *) "DeviceProxy::set_attribute_config()");
+            }
+        }
+        catch (CORBA::COMM_FAILURE &comm)
+        {
+            if (comm.minor() == omni::COMM_FAILURE_WaitingForReply)
+            {
+                TRANSIENT_NOT_EXIST_EXCEPT(comm, "DeviceProxy", "set_attribute_config", this);
+            }
+            else
+            {
+                set_connection_state(CONNECTION_NOTOK);
+                TangoSys_OMemStream desc;
+                desc << "Failed to execute set_attribute_config on device " << device_name << ends;
+                ApiCommExcept::re_throw_exception(comm,
+                                                  (const char *) "API_CommunicationFailed",
+                                                  desc.str(),
+                                                  (const char *) "DeviceProxy::set_attribute_config()");
+            }
+        }
         catch (CORBA::SystemException &ce)
         {
-			set_connection_state(CONNECTION_NOTOK);
+            set_connection_state(CONNECTION_NOTOK);
 
-			TangoSys_OMemStream desc;
-			desc << "Failed to execute set_attribute_config on device " << device_name << ends;
-			ApiCommExcept::re_throw_exception(ce,
-						      (const char*)"API_CommunicationFailed",
-                        			      desc.str(),
-						      (const char*)"DeviceProxy::set_attribute_config()");
-		}
-	}
+            TangoSys_OMemStream desc;
+            desc << "Failed to execute set_attribute_config on device " << device_name << ends;
+            ApiCommExcept::re_throw_exception(ce,
+                                              (const char *) "API_CommunicationFailed",
+                                              desc.str(),
+                                              (const char *) "DeviceProxy::set_attribute_config()");
+        }
+    }
 
-	return;
+    return;
 }
 
 
@@ -4712,119 +4737,119 @@ void DeviceProxy::set_attribute_config(AttributeInfoListEx &dev_attr_list)
 //
 //-----------------------------------------------------------------------------
 
-PipeInfoList *DeviceProxy::get_pipe_config(vector<string>& pipe_string_list)
+PipeInfoList *DeviceProxy::get_pipe_config(vector<string> &pipe_string_list)
 {
-	PipeConfigList_var pipe_config_list_5;
-	PipeInfoList *dev_pipe_config = new PipeInfoList();
-	DevVarStringArray pipe_list;
-	int ctr = 0;
+    PipeConfigList_var pipe_config_list_5;
+    PipeInfoList *dev_pipe_config = new PipeInfoList();
+    DevVarStringArray pipe_list;
+    int ctr = 0;
 
 //
 // Error if device does not support IDL 5
 //
 
-	if (version > 0 && version < 5)
-	{
-		stringstream ss;
-		ss << "Device " << device_name << " too old to use get_pipe_config() call. Please upgrade to Tango 9/IDL5";
+    if (version > 0 && version < 5)
+    {
+        stringstream ss;
+        ss << "Device " << device_name << " too old to use get_pipe_config() call. Please upgrade to Tango 9/IDL5";
 
-		ApiNonSuppExcept::throw_exception(API_UnsupportedFeature,
-									  ss.str(),"DeviceProxy::get_pipe_config()");
-	}
+        ApiNonSuppExcept::throw_exception(API_UnsupportedFeature,
+                                          ss.str(), "DeviceProxy::get_pipe_config()");
+    }
 
 //
 // Prepare sent parameters
 //
 
-	pipe_list.length(pipe_string_list.size());
-	for (unsigned int i=0; i<pipe_string_list.size(); i++)
-	{
-		if (pipe_string_list[i] == AllPipe)
-			pipe_list[i] = string_dup(AllPipe);
-		else
-			pipe_list[i] = string_dup(pipe_string_list[i].c_str());
-	}
+    pipe_list.length(pipe_string_list.size());
+    for (unsigned int i = 0; i < pipe_string_list.size(); i++)
+    {
+        if (pipe_string_list[i] == AllPipe)
+            pipe_list[i] = string_dup(AllPipe);
+        else
+            pipe_list[i] = string_dup(pipe_string_list[i].c_str());
+    }
 
 //
 // Call device
 //
 
-	while (ctr < 2)
-	{
-		try
-		{
-			check_and_reconnect();
+    while (ctr < 2)
+    {
+        try
+        {
+            check_and_reconnect();
 
-			Device_5_var dev = Device_5::_duplicate(device_5);
-			pipe_config_list_5 = dev->get_pipe_config_5(pipe_list);
-			dev_pipe_config->resize(pipe_config_list_5->length());
+            Device_5_var dev = Device_5::_duplicate(device_5);
+            pipe_config_list_5 = dev->get_pipe_config_5(pipe_list);
+            dev_pipe_config->resize(pipe_config_list_5->length());
 
-			for (size_t i=0; i<pipe_config_list_5->length(); i++)
-			{
-				(*dev_pipe_config)[i].disp_level = pipe_config_list_5[i].level;
-				(*dev_pipe_config)[i].name = pipe_config_list_5[i].name;
-				(*dev_pipe_config)[i].description = pipe_config_list_5[i].description;
-				(*dev_pipe_config)[i].label = pipe_config_list_5[i].label;
-				(*dev_pipe_config)[i].writable = pipe_config_list_5[i].writable;
-				for (size_t j=0; j<pipe_config_list_5[i].extensions.length(); j++)
-				{
-					(*dev_pipe_config)[i].extensions[j] = pipe_config_list_5[i].extensions[j];
-				}
-			}
+            for (size_t i = 0; i < pipe_config_list_5->length(); i++)
+            {
+                (*dev_pipe_config)[i].disp_level = pipe_config_list_5[i].level;
+                (*dev_pipe_config)[i].name = pipe_config_list_5[i].name;
+                (*dev_pipe_config)[i].description = pipe_config_list_5[i].description;
+                (*dev_pipe_config)[i].label = pipe_config_list_5[i].label;
+                (*dev_pipe_config)[i].writable = pipe_config_list_5[i].writable;
+                for (size_t j = 0; j < pipe_config_list_5[i].extensions.length(); j++)
+                {
+                    (*dev_pipe_config)[i].extensions[j] = pipe_config_list_5[i].extensions[j];
+                }
+            }
 
-			ctr = 2;
-		}
-		catch (CORBA::TRANSIENT &trans)
-		{
-			TRANSIENT_NOT_EXIST_EXCEPT(trans,"DeviceProxy","get_pipe_config",this);
-		}
-		catch (CORBA::OBJECT_NOT_EXIST &one)
-		{
-			if (one.minor() == omni::OBJECT_NOT_EXIST_NoMatch || one.minor() == 0)
-			{
-				TRANSIENT_NOT_EXIST_EXCEPT(one,"DeviceProxy","get_pipe_config",this);
-			}
-			else
-			{
-				set_connection_state(CONNECTION_NOTOK);
-				TangoSys_OMemStream desc;
-				desc << "Failed to execute get_pipe_config on device " << device_name << ends;
-				ApiCommExcept::re_throw_exception(one,"API_CommunicationFailed",
-                        				      desc.str(),"DeviceProxy::get_pipe_config()");
-			}
-		}
-		catch (CORBA::COMM_FAILURE &comm)
-		{
-			if (comm.minor() == omni::COMM_FAILURE_WaitingForReply)
-			{
-				TRANSIENT_NOT_EXIST_EXCEPT(comm,"DeviceProxy","get_pipe_config",this);
-			}
-			else
-			{
-				set_connection_state(CONNECTION_NOTOK);
-				TangoSys_OMemStream desc;
-				desc << "Failed to execute get_pipe_config on device " << device_name << ends;
-				ApiCommExcept::re_throw_exception(comm,"API_CommunicationFailed",
-                        				      desc.str(),"DeviceProxy::get_pipe_config()");
-			}
-		}
+            ctr = 2;
+        }
+        catch (CORBA::TRANSIENT &trans)
+        {
+            TRANSIENT_NOT_EXIST_EXCEPT(trans, "DeviceProxy", "get_pipe_config", this);
+        }
+        catch (CORBA::OBJECT_NOT_EXIST &one)
+        {
+            if (one.minor() == omni::OBJECT_NOT_EXIST_NoMatch || one.minor() == 0)
+            {
+                TRANSIENT_NOT_EXIST_EXCEPT(one, "DeviceProxy", "get_pipe_config", this);
+            }
+            else
+            {
+                set_connection_state(CONNECTION_NOTOK);
+                TangoSys_OMemStream desc;
+                desc << "Failed to execute get_pipe_config on device " << device_name << ends;
+                ApiCommExcept::re_throw_exception(one, "API_CommunicationFailed",
+                                                  desc.str(), "DeviceProxy::get_pipe_config()");
+            }
+        }
+        catch (CORBA::COMM_FAILURE &comm)
+        {
+            if (comm.minor() == omni::COMM_FAILURE_WaitingForReply)
+            {
+                TRANSIENT_NOT_EXIST_EXCEPT(comm, "DeviceProxy", "get_pipe_config", this);
+            }
+            else
+            {
+                set_connection_state(CONNECTION_NOTOK);
+                TangoSys_OMemStream desc;
+                desc << "Failed to execute get_pipe_config on device " << device_name << ends;
+                ApiCommExcept::re_throw_exception(comm, "API_CommunicationFailed",
+                                                  desc.str(), "DeviceProxy::get_pipe_config()");
+            }
+        }
         catch (CORBA::SystemException &ce)
         {
-			set_connection_state(CONNECTION_NOTOK);
+            set_connection_state(CONNECTION_NOTOK);
 
-			TangoSys_OMemStream desc;
-			desc << "Failed to execute get_pipe_config on device " << device_name << ends;
-			ApiCommExcept::re_throw_exception(ce,"API_CommunicationFailed",
-                       				   desc.str(),"DeviceProxy::get_pipe_config()");
-		}
-		catch (Tango::DevFailed)
-		{
-			delete dev_pipe_config;
-			throw;
-		}
-	}
+            TangoSys_OMemStream desc;
+            desc << "Failed to execute get_pipe_config on device " << device_name << ends;
+            ApiCommExcept::re_throw_exception(ce, "API_CommunicationFailed",
+                                              desc.str(), "DeviceProxy::get_pipe_config()");
+        }
+        catch (Tango::DevFailed)
+        {
+            delete dev_pipe_config;
+            throw;
+        }
+    }
 
-	return(dev_pipe_config);
+    return (dev_pipe_config);
 }
 
 //-----------------------------------------------------------------------------
@@ -4835,17 +4860,17 @@ PipeInfoList *DeviceProxy::get_pipe_config(vector<string>& pipe_string_list)
 
 PipeInfo DeviceProxy::get_pipe_config(const string &pipe_name)
 {
-	vector<string> pipe_string_list;
-	PipeInfoList *dev_pipe_config_list;
-	PipeInfo dev_pipe_config;
+    vector<string> pipe_string_list;
+    PipeInfoList *dev_pipe_config_list;
+    PipeInfo dev_pipe_config;
 
-	pipe_string_list.push_back(pipe_name);
-	dev_pipe_config_list = get_pipe_config(pipe_string_list);
+    pipe_string_list.push_back(pipe_name);
+    dev_pipe_config_list = get_pipe_config(pipe_string_list);
 
-	dev_pipe_config = (*dev_pipe_config_list)[0];
-	delete(dev_pipe_config_list);
+    dev_pipe_config = (*dev_pipe_config_list)[0];
+    delete (dev_pipe_config_list);
 
-	return(dev_pipe_config);
+    return (dev_pipe_config);
 }
 
 //-----------------------------------------------------------------------------
@@ -4860,114 +4885,114 @@ void DeviceProxy::set_pipe_config(PipeInfoList &dev_pipe_list)
 // Error if device does not support IDL 5
 //
 
-	if (version > 0 && version < 5)
-	{
-		stringstream ss;
-		ss << "Device " << device_name << " too old to use set_pipe_config() call. Please upgrade to Tango 9/IDL5";
+    if (version > 0 && version < 5)
+    {
+        stringstream ss;
+        ss << "Device " << device_name << " too old to use set_pipe_config() call. Please upgrade to Tango 9/IDL5";
 
-		ApiNonSuppExcept::throw_exception(API_UnsupportedFeature,ss.str(),"DeviceProxy::set_pipe_config()");
-	}
+        ApiNonSuppExcept::throw_exception(API_UnsupportedFeature, ss.str(), "DeviceProxy::set_pipe_config()");
+    }
 
-	PipeConfigList pipe_config_list;
-	int ctr = 0;
+    PipeConfigList pipe_config_list;
+    int ctr = 0;
 
-	pipe_config_list.length(dev_pipe_list.size());
+    pipe_config_list.length(dev_pipe_list.size());
 
-	for (unsigned int i=0; i<pipe_config_list.length(); i++)
-	{
-		pipe_config_list[i].name = dev_pipe_list[i].name.c_str();
-		pipe_config_list[i].writable = dev_pipe_list[i].writable;
-		pipe_config_list[i].description = dev_pipe_list[i].description.c_str();
-		pipe_config_list[i].label = dev_pipe_list[i].label.c_str();
-		pipe_config_list[i].level = dev_pipe_list[i].disp_level;
-		pipe_config_list[i].extensions.length(dev_pipe_list[i].extensions.size());
-		for (unsigned int j=0; j<dev_pipe_list[i].extensions.size(); j++)
-		{
-			pipe_config_list[i].extensions[j] = string_dup(dev_pipe_list[i].extensions[j].c_str());
-		}
-	}
+    for (unsigned int i = 0; i < pipe_config_list.length(); i++)
+    {
+        pipe_config_list[i].name = dev_pipe_list[i].name.c_str();
+        pipe_config_list[i].writable = dev_pipe_list[i].writable;
+        pipe_config_list[i].description = dev_pipe_list[i].description.c_str();
+        pipe_config_list[i].label = dev_pipe_list[i].label.c_str();
+        pipe_config_list[i].level = dev_pipe_list[i].disp_level;
+        pipe_config_list[i].extensions.length(dev_pipe_list[i].extensions.size());
+        for (unsigned int j = 0; j < dev_pipe_list[i].extensions.size(); j++)
+        {
+            pipe_config_list[i].extensions[j] = string_dup(dev_pipe_list[i].extensions[j].c_str());
+        }
+    }
 
-	while (ctr < 2)
-	{
-		try
-		{
-			check_and_reconnect();
+    while (ctr < 2)
+    {
+        try
+        {
+            check_and_reconnect();
 
-			ClntIdent ci;
-			ApiUtil *au = ApiUtil::instance();
-			ci.cpp_clnt(au->get_client_pid());
-			Device_5_var dev = Device_5::_duplicate(device_5);
-			dev->set_pipe_config_5(pipe_config_list,ci);
+            ClntIdent ci;
+            ApiUtil *au = ApiUtil::instance();
+            ci.cpp_clnt(au->get_client_pid());
+            Device_5_var dev = Device_5::_duplicate(device_5);
+            dev->set_pipe_config_5(pipe_config_list, ci);
 
-			ctr = 2;
+            ctr = 2;
 
-		}
-		catch (Tango::DevFailed &e)
-		{
-			if (::strcmp(e.errors[0].reason,DEVICE_UNLOCKED_REASON) == 0)
-			{
-				TangoSys_OMemStream desc;
-				desc << "Failed to execute set_pipe_config on device " << device_name << ends;
+        }
+        catch (Tango::DevFailed &e)
+        {
+            if (::strcmp(e.errors[0].reason, DEVICE_UNLOCKED_REASON) == 0)
+            {
+                TangoSys_OMemStream desc;
+                desc << "Failed to execute set_pipe_config on device " << device_name << ends;
 
-				DeviceUnlockedExcept::re_throw_exception(e,DEVICE_UNLOCKED_REASON,
-							desc.str(), "DeviceProxy::set_pipe_config()");
-			}
-			else
-				throw;
-		}
-		catch (CORBA::TRANSIENT &trans)
-		{
-			TRANSIENT_NOT_EXIST_EXCEPT(trans,"DeviceProxy","set_pipe_config",this);
-		}
-		catch (CORBA::OBJECT_NOT_EXIST &one)
-		{
-			if (one.minor() == omni::OBJECT_NOT_EXIST_NoMatch || one.minor() == 0)
-			{
-				TRANSIENT_NOT_EXIST_EXCEPT(one,"DeviceProxy","set_pipe_config",this);
-			}
-			else
-			{
-				set_connection_state(CONNECTION_NOTOK);
-				TangoSys_OMemStream desc;
-				desc << "Failed to execute set_pipe_config on device " << device_name << ends;
-				ApiCommExcept::re_throw_exception(one,
-							      (const char*)"API_CommunicationFailed",
-                        				      desc.str(),
-							      (const char*)"DeviceProxy::set_pipe_config()");
-			}
-		}
-		catch (CORBA::COMM_FAILURE &comm)
-		{
-			if (comm.minor() == omni::COMM_FAILURE_WaitingForReply)
-			{
-				TRANSIENT_NOT_EXIST_EXCEPT(comm,"DeviceProxy","set_pipe_config",this);
-			}
-			else
-			{
-				set_connection_state(CONNECTION_NOTOK);
-				TangoSys_OMemStream desc;
-				desc << "Failed to execute set_pipe_config on device " << device_name << ends;
-				ApiCommExcept::re_throw_exception(comm,
-							      (const char*)"API_CommunicationFailed",
-                        				      desc.str(),
-							      (const char*)"DeviceProxy::set_pipe_config()");
-			}
-		}
+                DeviceUnlockedExcept::re_throw_exception(e, DEVICE_UNLOCKED_REASON,
+                                                         desc.str(), "DeviceProxy::set_pipe_config()");
+            }
+            else
+                throw;
+        }
+        catch (CORBA::TRANSIENT &trans)
+        {
+            TRANSIENT_NOT_EXIST_EXCEPT(trans, "DeviceProxy", "set_pipe_config", this);
+        }
+        catch (CORBA::OBJECT_NOT_EXIST &one)
+        {
+            if (one.minor() == omni::OBJECT_NOT_EXIST_NoMatch || one.minor() == 0)
+            {
+                TRANSIENT_NOT_EXIST_EXCEPT(one, "DeviceProxy", "set_pipe_config", this);
+            }
+            else
+            {
+                set_connection_state(CONNECTION_NOTOK);
+                TangoSys_OMemStream desc;
+                desc << "Failed to execute set_pipe_config on device " << device_name << ends;
+                ApiCommExcept::re_throw_exception(one,
+                                                  (const char *) "API_CommunicationFailed",
+                                                  desc.str(),
+                                                  (const char *) "DeviceProxy::set_pipe_config()");
+            }
+        }
+        catch (CORBA::COMM_FAILURE &comm)
+        {
+            if (comm.minor() == omni::COMM_FAILURE_WaitingForReply)
+            {
+                TRANSIENT_NOT_EXIST_EXCEPT(comm, "DeviceProxy", "set_pipe_config", this);
+            }
+            else
+            {
+                set_connection_state(CONNECTION_NOTOK);
+                TangoSys_OMemStream desc;
+                desc << "Failed to execute set_pipe_config on device " << device_name << ends;
+                ApiCommExcept::re_throw_exception(comm,
+                                                  (const char *) "API_CommunicationFailed",
+                                                  desc.str(),
+                                                  (const char *) "DeviceProxy::set_pipe_config()");
+            }
+        }
         catch (CORBA::SystemException &ce)
         {
-			set_connection_state(CONNECTION_NOTOK);
+            set_connection_state(CONNECTION_NOTOK);
 
-			TangoSys_OMemStream desc;
-			desc << "Failed to execute set_pipe_config on device " << device_name << ends;
-			ApiCommExcept::re_throw_exception(ce,
-						      (const char*)"API_CommunicationFailed",
-                        			      desc.str(),
-						      (const char*)"DeviceProxy::set_pipe_config()");
-		}
-	}
+            TangoSys_OMemStream desc;
+            desc << "Failed to execute set_pipe_config on device " << device_name << ends;
+            ApiCommExcept::re_throw_exception(ce,
+                                              (const char *) "API_CommunicationFailed",
+                                              desc.str(),
+                                              (const char *) "DeviceProxy::set_pipe_config()");
+        }
+    }
 
 
-	return;
+    return;
 }
 
 //-----------------------------------------------------------------------------
@@ -4978,21 +5003,21 @@ void DeviceProxy::set_pipe_config(PipeInfoList &dev_pipe_list)
 
 vector<string> *DeviceProxy::get_pipe_list()
 {
-	vector<string> all_pipe;
-	PipeInfoList *all_pipe_config;
+    vector<string> all_pipe;
+    PipeInfoList *all_pipe_config;
 
-	all_pipe.push_back(AllPipe);
-	all_pipe_config = get_pipe_config(all_pipe);
+    all_pipe.push_back(AllPipe);
+    all_pipe_config = get_pipe_config(all_pipe);
 
-	vector<string> *pipe_list = new vector<string>;
-	pipe_list->resize(all_pipe_config->size());
-	for (unsigned int i=0; i<all_pipe_config->size(); i++)
-	{
-		(*pipe_list)[i] = (*all_pipe_config)[i].name;
-	}
-	delete all_pipe_config;
+    vector<string> *pipe_list = new vector<string>;
+    pipe_list->resize(all_pipe_config->size());
+    for (unsigned int i = 0; i < all_pipe_config->size(); i++)
+    {
+        (*pipe_list)[i] = (*all_pipe_config)[i].name;
+    }
+    delete all_pipe_config;
 
-	return pipe_list;
+    return pipe_list;
 }
 
 //-----------------------------------------------------------------------------
@@ -5002,90 +5027,96 @@ vector<string> *DeviceProxy::get_pipe_list()
 //-----------------------------------------------------------------------------
 
 
-DevicePipe DeviceProxy::read_pipe(const string& pipe_name)
+DevicePipe DeviceProxy::read_pipe(const string &pipe_name)
 {
-	DevPipeData_var pipe_value_5;
-	DevicePipe dev_pipe;
-	int ctr = 0;
+    DevPipeData_var pipe_value_5;
+    DevicePipe dev_pipe;
+    int ctr = 0;
 
 //
 // Error if device does not support IDL 5
 //
 
-	if (version > 0 && version < 5)
-	{
-		stringstream ss;
-		ss << "Device " << device_name << " too old to use read_pipe() call. Please upgrade to Tango 9/IDL5";
+    if (version > 0 && version < 5)
+    {
+        stringstream ss;
+        ss << "Device " << device_name << " too old to use read_pipe() call. Please upgrade to Tango 9/IDL5";
 
-		ApiNonSuppExcept::throw_exception(API_UnsupportedFeature,ss.str(),"DeviceProxy::read_pipe()");
-	}
+        ApiNonSuppExcept::throw_exception(API_UnsupportedFeature, ss.str(), "DeviceProxy::read_pipe()");
+    }
 
-	while (ctr < 2)
-	{
-		try
-		{
-			check_and_reconnect();
-
-			ClntIdent ci;
-			ApiUtil *au = ApiUtil::instance();
-			ci.cpp_clnt(au->get_client_pid());
-			Device_5_var dev = Device_5::_duplicate(device_5);
-			pipe_value_5 = dev->read_pipe_5(pipe_name.c_str(),ci);
-
-			ctr = 2;
-		}
-		catch (Tango::ConnectionFailed &e)
-		{
-			stringstream desc;
-			desc << "Failed to read_pipe on device " << device_name << ", pipe " << pipe_name;
-			ApiConnExcept::re_throw_exception(e,API_PipeFailed,desc.str(),"DeviceProxy::read_pipe()");
-		}
-		catch (Tango::DevFailed &e)
-		{
-			stringstream desc;
-			desc << "Failed to read_pipe on device " << device_name << ", pipe " << pipe_name;
-			Except::re_throw_exception(e,API_PipeFailed,desc.str(),"DeviceProxy::read_pipe()");
-		}
-		catch (CORBA::TRANSIENT &trans)
-		{
-			TRANSIENT_NOT_EXIST_EXCEPT(trans,"DeviceProxy","read_pipe",this);
-		}
-		catch (CORBA::OBJECT_NOT_EXIST &one)
-		{
-			if (one.minor() == omni::OBJECT_NOT_EXIST_NoMatch || one.minor() == 0)
-			{
-				TRANSIENT_NOT_EXIST_EXCEPT(one,"DeviceProxy","read_pipe",this);
-			}
-			else
-			{
-				set_connection_state(CONNECTION_NOTOK);
-				stringstream desc;
-				desc << "Failed to read_pipe on device " << device_name;
-				ApiCommExcept::re_throw_exception(one,"API_CommunicationFailed",desc.str(),"DeviceProxy::read_pipe()");
-			}
-		}
-		catch (CORBA::COMM_FAILURE &comm)
-		{
-			if (comm.minor() == omni::COMM_FAILURE_WaitingForReply)
-			{
-				TRANSIENT_NOT_EXIST_EXCEPT(comm,"DeviceProxy","read_pipe",this);
-			}
-			else
-			{
-				set_connection_state(CONNECTION_NOTOK);
-				stringstream desc;
-				desc << "Failed to read_pipe on device " << device_name;
-				ApiCommExcept::re_throw_exception(comm,"API_CommunicationFailed",desc.str(),"DeviceProxy::read_pipe()");
-			}
-		}
-		catch (CORBA::SystemException &ce)
+    while (ctr < 2)
+    {
+        try
         {
-			set_connection_state(CONNECTION_NOTOK);
-			stringstream desc;
-			desc << "Failed to read_pipe on device " << device_name;
-			ApiCommExcept::re_throw_exception(ce,"API_CommunicationFailed",desc.str(),"DeviceProxy::read_pipe()");
-		}
-	}
+            check_and_reconnect();
+
+            ClntIdent ci;
+            ApiUtil *au = ApiUtil::instance();
+            ci.cpp_clnt(au->get_client_pid());
+            Device_5_var dev = Device_5::_duplicate(device_5);
+            pipe_value_5 = dev->read_pipe_5(pipe_name.c_str(), ci);
+
+            ctr = 2;
+        }
+        catch (Tango::ConnectionFailed &e)
+        {
+            stringstream desc;
+            desc << "Failed to read_pipe on device " << device_name << ", pipe " << pipe_name;
+            ApiConnExcept::re_throw_exception(e, API_PipeFailed, desc.str(), "DeviceProxy::read_pipe()");
+        }
+        catch (Tango::DevFailed &e)
+        {
+            stringstream desc;
+            desc << "Failed to read_pipe on device " << device_name << ", pipe " << pipe_name;
+            Except::re_throw_exception(e, API_PipeFailed, desc.str(), "DeviceProxy::read_pipe()");
+        }
+        catch (CORBA::TRANSIENT &trans)
+        {
+            TRANSIENT_NOT_EXIST_EXCEPT(trans, "DeviceProxy", "read_pipe", this);
+        }
+        catch (CORBA::OBJECT_NOT_EXIST &one)
+        {
+            if (one.minor() == omni::OBJECT_NOT_EXIST_NoMatch || one.minor() == 0)
+            {
+                TRANSIENT_NOT_EXIST_EXCEPT(one, "DeviceProxy", "read_pipe", this);
+            }
+            else
+            {
+                set_connection_state(CONNECTION_NOTOK);
+                stringstream desc;
+                desc << "Failed to read_pipe on device " << device_name;
+                ApiCommExcept::re_throw_exception(one,
+                                                  "API_CommunicationFailed",
+                                                  desc.str(),
+                                                  "DeviceProxy::read_pipe()");
+            }
+        }
+        catch (CORBA::COMM_FAILURE &comm)
+        {
+            if (comm.minor() == omni::COMM_FAILURE_WaitingForReply)
+            {
+                TRANSIENT_NOT_EXIST_EXCEPT(comm, "DeviceProxy", "read_pipe", this);
+            }
+            else
+            {
+                set_connection_state(CONNECTION_NOTOK);
+                stringstream desc;
+                desc << "Failed to read_pipe on device " << device_name;
+                ApiCommExcept::re_throw_exception(comm,
+                                                  "API_CommunicationFailed",
+                                                  desc.str(),
+                                                  "DeviceProxy::read_pipe()");
+            }
+        }
+        catch (CORBA::SystemException &ce)
+        {
+            set_connection_state(CONNECTION_NOTOK);
+            stringstream desc;
+            desc << "Failed to read_pipe on device " << device_name;
+            ApiCommExcept::re_throw_exception(ce, "API_CommunicationFailed", desc.str(), "DeviceProxy::read_pipe()");
+        }
+    }
 
 //
 // Pass received data to the caller.
@@ -5093,23 +5124,23 @@ DevicePipe DeviceProxy::read_pipe(const string& pipe_name)
 // This is required because the whole object received by the call will be deleted at the end of this method
 //
 
-	dev_pipe.set_name(pipe_value_5->name.in());
-	dev_pipe.set_time(pipe_value_5->time);
+    dev_pipe.set_name(pipe_value_5->name.in());
+    dev_pipe.set_time(pipe_value_5->time);
 
-	CORBA::ULong max,len;
-	max = pipe_value_5->data_blob.blob_data.maximum();
-	len = pipe_value_5->data_blob.blob_data.length();
-	DevPipeDataElt *buf = pipe_value_5->data_blob.blob_data.get_buffer((CORBA::Boolean)true);
-	DevVarPipeDataEltArray *dvpdea = new DevVarPipeDataEltArray(max,len,buf,true);
+    CORBA::ULong max, len;
+    max = pipe_value_5->data_blob.blob_data.maximum();
+    len = pipe_value_5->data_blob.blob_data.length();
+    DevPipeDataElt *buf = pipe_value_5->data_blob.blob_data.get_buffer((CORBA::Boolean) true);
+    DevVarPipeDataEltArray *dvpdea = new DevVarPipeDataEltArray(max, len, buf, true);
 
-	dev_pipe.get_root_blob().reset_extract_ctr();
-	dev_pipe.get_root_blob().reset_insert_ctr();
-	dev_pipe.get_root_blob().set_name(pipe_value_5->data_blob.name.in());
-	delete dev_pipe.get_root_blob().get_extract_data();
-	dev_pipe.get_root_blob().set_extract_data(dvpdea);
-	dev_pipe.get_root_blob().set_extract_delete(true);
+    dev_pipe.get_root_blob().reset_extract_ctr();
+    dev_pipe.get_root_blob().reset_insert_ctr();
+    dev_pipe.get_root_blob().set_name(pipe_value_5->data_blob.name.in());
+    delete dev_pipe.get_root_blob().get_extract_data();
+    dev_pipe.get_root_blob().set_extract_data(dvpdea);
+    dev_pipe.get_root_blob().set_extract_delete(true);
 
-	return dev_pipe;
+    return dev_pipe;
 }
 
 //-----------------------------------------------------------------------------
@@ -5119,127 +5150,133 @@ DevicePipe DeviceProxy::read_pipe(const string& pipe_name)
 //-----------------------------------------------------------------------------
 
 
-void DeviceProxy::write_pipe(DevicePipe& dev_pipe)
+void DeviceProxy::write_pipe(DevicePipe &dev_pipe)
 {
-	DevPipeData pipe_value_5;
-	int ctr = 0;
+    DevPipeData pipe_value_5;
+    int ctr = 0;
 
 //
 // Error if device does not support IDL 5
 //
 
-	if (version > 0 && version < 5)
-	{
-		stringstream ss;
-		ss << "Device " << device_name << " too old to use write_pipe() call. Please upgrade to Tango 9/IDL5";
+    if (version > 0 && version < 5)
+    {
+        stringstream ss;
+        ss << "Device " << device_name << " too old to use write_pipe() call. Please upgrade to Tango 9/IDL5";
 
-		ApiNonSuppExcept::throw_exception(API_UnsupportedFeature,ss.str(),"DeviceProxy::write_pipe()");
-	}
+        ApiNonSuppExcept::throw_exception(API_UnsupportedFeature, ss.str(), "DeviceProxy::write_pipe()");
+    }
 
 //
 // Prepare data sent to device
 //
 
-	pipe_value_5.name = dev_pipe.get_name().c_str();
-	const string &bl_name = dev_pipe.get_root_blob().get_name();
-	if (bl_name.size() != 0)
-		pipe_value_5.data_blob.name = bl_name.c_str();
+    pipe_value_5.name = dev_pipe.get_name().c_str();
+    const string &bl_name = dev_pipe.get_root_blob().get_name();
+    if (bl_name.size() != 0)
+        pipe_value_5.data_blob.name = bl_name.c_str();
 
-	DevVarPipeDataEltArray *tmp_ptr = dev_pipe.get_root_blob().get_insert_data();
-	if (tmp_ptr == Tango_nullptr)
-	{
-		Except::throw_exception(API_PipeNoDataElement,"No data in pipe!","DeviceProxy::write_pipe()");
-	}
+    DevVarPipeDataEltArray *tmp_ptr = dev_pipe.get_root_blob().get_insert_data();
+    if (tmp_ptr == Tango_nullptr)
+    {
+        Except::throw_exception(API_PipeNoDataElement, "No data in pipe!", "DeviceProxy::write_pipe()");
+    }
 
-	CORBA::ULong max,len;
-	max = tmp_ptr->maximum();
-	len = tmp_ptr->length();
-	pipe_value_5.data_blob.blob_data.replace(max,len,tmp_ptr->get_buffer((CORBA::Boolean)true),true);
+    CORBA::ULong max, len;
+    max = tmp_ptr->maximum();
+    len = tmp_ptr->length();
+    pipe_value_5.data_blob.blob_data.replace(max, len, tmp_ptr->get_buffer((CORBA::Boolean) true), true);
 
-	while (ctr < 2)
-	{
-		try
-		{
-			check_and_reconnect();
-
-			ClntIdent ci;
-			ApiUtil *au = ApiUtil::instance();
-			ci.cpp_clnt(au->get_client_pid());
-			Device_5_var dev = Device_5::_duplicate(device_5);
-			dev->write_pipe_5(pipe_value_5,ci);
-
-			ctr = 2;
-		}
-		catch (Tango::ConnectionFailed &e)
-		{
-			dev_pipe.get_root_blob().reset_insert_ctr();
-			delete tmp_ptr;
-
-			stringstream desc;
-			desc << "Failed to write_pipe on device " << device_name << ", pipe " << dev_pipe.get_name();
-			ApiConnExcept::re_throw_exception(e,API_PipeFailed,desc.str(),"DeviceProxy::write_pipe()");
-		}
-		catch (Tango::DevFailed &e)
-		{
-			dev_pipe.get_root_blob().reset_insert_ctr();
-			delete tmp_ptr;
-
-			stringstream desc;
-			desc << "Failed to write_pipe on device " << device_name << ", pipe " << dev_pipe.get_name();
-			Except::re_throw_exception(e,API_PipeFailed,desc.str(),"DeviceProxy::write_pipe()");
-		}
-		catch (CORBA::TRANSIENT &trans)
-		{
-			TRANSIENT_NOT_EXIST_EXCEPT(trans,"DeviceProxy","write_pipe",this);
-		}
-		catch (CORBA::OBJECT_NOT_EXIST &one)
-		{
-			if (one.minor() == omni::OBJECT_NOT_EXIST_NoMatch || one.minor() == 0)
-			{
-				TRANSIENT_NOT_EXIST_EXCEPT(one,"DeviceProxy","write_pipe",this);
-			}
-			else
-			{
-				dev_pipe.get_root_blob().reset_insert_ctr();
-				delete tmp_ptr;
-
-				set_connection_state(CONNECTION_NOTOK);
-				stringstream desc;
-				desc << "Failed to write_pipe on device " << device_name;
-				ApiCommExcept::re_throw_exception(one,"API_CommunicationFailed",desc.str(),"DeviceProxy::write_pipe()");
-			}
-		}
-		catch (CORBA::COMM_FAILURE &comm)
-		{
-			if (comm.minor() == omni::COMM_FAILURE_WaitingForReply)
-			{
-				TRANSIENT_NOT_EXIST_EXCEPT(comm,"DeviceProxy","write_pipe",this);
-			}
-			else
-			{
-				dev_pipe.get_root_blob().reset_insert_ctr();
-				delete tmp_ptr;
-
-				set_connection_state(CONNECTION_NOTOK);
-				stringstream desc;
-				desc << "Failed to write_pipe on device " << device_name;
-				ApiCommExcept::re_throw_exception(comm,"API_CommunicationFailed",desc.str(),"DeviceProxy::write_pipe()");
-			}
-		}
-		catch (CORBA::SystemException &ce)
+    while (ctr < 2)
+    {
+        try
         {
-			dev_pipe.get_root_blob().reset_insert_ctr();
-			delete tmp_ptr;
+            check_and_reconnect();
 
-			set_connection_state(CONNECTION_NOTOK);
-			stringstream desc;
-			desc << "Failed to write_pipe on device " << device_name;
-			ApiCommExcept::re_throw_exception(ce,"API_CommunicationFailed",desc.str(),"DeviceProxy::write_pipe()");
-		}
-	}
+            ClntIdent ci;
+            ApiUtil *au = ApiUtil::instance();
+            ci.cpp_clnt(au->get_client_pid());
+            Device_5_var dev = Device_5::_duplicate(device_5);
+            dev->write_pipe_5(pipe_value_5, ci);
 
-	dev_pipe.get_root_blob().reset_insert_ctr();
-	delete tmp_ptr;
+            ctr = 2;
+        }
+        catch (Tango::ConnectionFailed &e)
+        {
+            dev_pipe.get_root_blob().reset_insert_ctr();
+            delete tmp_ptr;
+
+            stringstream desc;
+            desc << "Failed to write_pipe on device " << device_name << ", pipe " << dev_pipe.get_name();
+            ApiConnExcept::re_throw_exception(e, API_PipeFailed, desc.str(), "DeviceProxy::write_pipe()");
+        }
+        catch (Tango::DevFailed &e)
+        {
+            dev_pipe.get_root_blob().reset_insert_ctr();
+            delete tmp_ptr;
+
+            stringstream desc;
+            desc << "Failed to write_pipe on device " << device_name << ", pipe " << dev_pipe.get_name();
+            Except::re_throw_exception(e, API_PipeFailed, desc.str(), "DeviceProxy::write_pipe()");
+        }
+        catch (CORBA::TRANSIENT &trans)
+        {
+            TRANSIENT_NOT_EXIST_EXCEPT(trans, "DeviceProxy", "write_pipe", this);
+        }
+        catch (CORBA::OBJECT_NOT_EXIST &one)
+        {
+            if (one.minor() == omni::OBJECT_NOT_EXIST_NoMatch || one.minor() == 0)
+            {
+                TRANSIENT_NOT_EXIST_EXCEPT(one, "DeviceProxy", "write_pipe", this);
+            }
+            else
+            {
+                dev_pipe.get_root_blob().reset_insert_ctr();
+                delete tmp_ptr;
+
+                set_connection_state(CONNECTION_NOTOK);
+                stringstream desc;
+                desc << "Failed to write_pipe on device " << device_name;
+                ApiCommExcept::re_throw_exception(one,
+                                                  "API_CommunicationFailed",
+                                                  desc.str(),
+                                                  "DeviceProxy::write_pipe()");
+            }
+        }
+        catch (CORBA::COMM_FAILURE &comm)
+        {
+            if (comm.minor() == omni::COMM_FAILURE_WaitingForReply)
+            {
+                TRANSIENT_NOT_EXIST_EXCEPT(comm, "DeviceProxy", "write_pipe", this);
+            }
+            else
+            {
+                dev_pipe.get_root_blob().reset_insert_ctr();
+                delete tmp_ptr;
+
+                set_connection_state(CONNECTION_NOTOK);
+                stringstream desc;
+                desc << "Failed to write_pipe on device " << device_name;
+                ApiCommExcept::re_throw_exception(comm,
+                                                  "API_CommunicationFailed",
+                                                  desc.str(),
+                                                  "DeviceProxy::write_pipe()");
+            }
+        }
+        catch (CORBA::SystemException &ce)
+        {
+            dev_pipe.get_root_blob().reset_insert_ctr();
+            delete tmp_ptr;
+
+            set_connection_state(CONNECTION_NOTOK);
+            stringstream desc;
+            desc << "Failed to write_pipe on device " << device_name;
+            ApiCommExcept::re_throw_exception(ce, "API_CommunicationFailed", desc.str(), "DeviceProxy::write_pipe()");
+        }
+    }
+
+    dev_pipe.get_root_blob().reset_insert_ctr();
+    delete tmp_ptr;
 }
 
 //-----------------------------------------------------------------------------
@@ -5250,106 +5287,115 @@ void DeviceProxy::write_pipe(DevicePipe& dev_pipe)
 
 DevicePipe DeviceProxy::write_read_pipe(DevicePipe &pipe_data)
 {
-	DevPipeData pipe_value_5;
-	DevPipeData_var r_pipe_value_5;
-	DevicePipe r_dev_pipe;
-	int ctr = 0;
+    DevPipeData pipe_value_5;
+    DevPipeData_var r_pipe_value_5;
+    DevicePipe r_dev_pipe;
+    int ctr = 0;
 
 //
 // Error if device does not support IDL 5
 //
 
-	if (version > 0 && version < 5)
-	{
-		stringstream ss;
-		ss << "Device " << device_name << " too old to use write_read_pipe() call. Please upgrade to Tango 9/IDL5";
+    if (version > 0 && version < 5)
+    {
+        stringstream ss;
+        ss << "Device " << device_name << " too old to use write_read_pipe() call. Please upgrade to Tango 9/IDL5";
 
-		ApiNonSuppExcept::throw_exception(API_UnsupportedFeature,ss.str(),"DeviceProxy::write_read_pipe()");
-	}
+        ApiNonSuppExcept::throw_exception(API_UnsupportedFeature, ss.str(), "DeviceProxy::write_read_pipe()");
+    }
 
 //
 // Prepare data sent to device
 //
 
-	pipe_value_5.name = pipe_data.get_name().c_str();
-	const string &bl_name = pipe_data.get_root_blob().get_name();
-	if (bl_name.size() != 0)
-		pipe_value_5.data_blob.name = bl_name.c_str();
+    pipe_value_5.name = pipe_data.get_name().c_str();
+    const string &bl_name = pipe_data.get_root_blob().get_name();
+    if (bl_name.size() != 0)
+        pipe_value_5.data_blob.name = bl_name.c_str();
 
-	DevVarPipeDataEltArray *tmp_ptr = pipe_data.get_root_blob().get_insert_data();
-	CORBA::ULong max,len;
-	max = tmp_ptr->maximum();
-	len = tmp_ptr->length();
-	pipe_value_5.data_blob.blob_data.replace(max,len,tmp_ptr->get_buffer((CORBA::Boolean)true),true);
+    DevVarPipeDataEltArray *tmp_ptr = pipe_data.get_root_blob().get_insert_data();
+    CORBA::ULong max, len;
+    max = tmp_ptr->maximum();
+    len = tmp_ptr->length();
+    pipe_value_5.data_blob.blob_data.replace(max, len, tmp_ptr->get_buffer((CORBA::Boolean) true), true);
 
-	delete tmp_ptr;
+    delete tmp_ptr;
 
-	while (ctr < 2)
-	{
-		try
-		{
-			check_and_reconnect();
-
-			ClntIdent ci;
-			ApiUtil *au = ApiUtil::instance();
-			ci.cpp_clnt(au->get_client_pid());
-			Device_5_var dev = Device_5::_duplicate(device_5);
-			r_pipe_value_5 = dev->write_read_pipe_5(pipe_value_5,ci);
-
-			ctr = 2;
-		}
-		catch (Tango::ConnectionFailed &e)
-		{
-			stringstream desc;
-			desc << "Failed to write_read_pipe on device " << device_name << ", pipe " << pipe_data.get_name();
-			ApiConnExcept::re_throw_exception(e,API_PipeFailed,desc.str(),"DeviceProxy::write_read_pipe()");
-		}
-		catch (Tango::DevFailed &e)
-		{
-			stringstream desc;
-			desc << "Failed to write_pipe on device " << device_name << ", pipe " << pipe_data.get_name();
-			Except::re_throw_exception(e,API_PipeFailed,desc.str(),"DeviceProxy::write_read_pipe()");
-		}
-		catch (CORBA::TRANSIENT &trans)
-		{
-			TRANSIENT_NOT_EXIST_EXCEPT(trans,"DeviceProxy","write_read_pipe",this);
-		}
-		catch (CORBA::OBJECT_NOT_EXIST &one)
-		{
-			if (one.minor() == omni::OBJECT_NOT_EXIST_NoMatch || one.minor() == 0)
-			{
-				TRANSIENT_NOT_EXIST_EXCEPT(one,"DeviceProxy","write_read_pipe",this);
-			}
-			else
-			{
-				set_connection_state(CONNECTION_NOTOK);
-				stringstream desc;
-				desc << "Failed to write_read_pipe on device " << device_name;
-				ApiCommExcept::re_throw_exception(one,"API_CommunicationFailed",desc.str(),"DeviceProxy::write_read_pipe()");
-			}
-		}
-		catch (CORBA::COMM_FAILURE &comm)
-		{
-			if (comm.minor() == omni::COMM_FAILURE_WaitingForReply)
-			{
-				TRANSIENT_NOT_EXIST_EXCEPT(comm,"DeviceProxy","write_read_pipe",this);
-			}
-			else
-			{
-				set_connection_state(CONNECTION_NOTOK);
-				stringstream desc;
-				desc << "Failed to write_read_pipe on device " << device_name;
-				ApiCommExcept::re_throw_exception(comm,"API_CommunicationFailed",desc.str(),"DeviceProxy::write_read_pipe()");
-			}
-		}
-		catch (CORBA::SystemException &ce)
+    while (ctr < 2)
+    {
+        try
         {
-			set_connection_state(CONNECTION_NOTOK);
-			stringstream desc;
-			desc << "Failed to write_read_pipe on device " << device_name;
-			ApiCommExcept::re_throw_exception(ce,"API_CommunicationFailed",desc.str(),"DeviceProxy::write_read_pipe()");
-		}
-	}
+            check_and_reconnect();
+
+            ClntIdent ci;
+            ApiUtil *au = ApiUtil::instance();
+            ci.cpp_clnt(au->get_client_pid());
+            Device_5_var dev = Device_5::_duplicate(device_5);
+            r_pipe_value_5 = dev->write_read_pipe_5(pipe_value_5, ci);
+
+            ctr = 2;
+        }
+        catch (Tango::ConnectionFailed &e)
+        {
+            stringstream desc;
+            desc << "Failed to write_read_pipe on device " << device_name << ", pipe " << pipe_data.get_name();
+            ApiConnExcept::re_throw_exception(e, API_PipeFailed, desc.str(), "DeviceProxy::write_read_pipe()");
+        }
+        catch (Tango::DevFailed &e)
+        {
+            stringstream desc;
+            desc << "Failed to write_pipe on device " << device_name << ", pipe " << pipe_data.get_name();
+            Except::re_throw_exception(e, API_PipeFailed, desc.str(), "DeviceProxy::write_read_pipe()");
+        }
+        catch (CORBA::TRANSIENT &trans)
+        {
+            TRANSIENT_NOT_EXIST_EXCEPT(trans, "DeviceProxy", "write_read_pipe", this);
+        }
+        catch (CORBA::OBJECT_NOT_EXIST &one)
+        {
+            if (one.minor() == omni::OBJECT_NOT_EXIST_NoMatch || one.minor() == 0)
+            {
+                TRANSIENT_NOT_EXIST_EXCEPT(one, "DeviceProxy", "write_read_pipe", this);
+            }
+            else
+            {
+                set_connection_state(CONNECTION_NOTOK);
+                stringstream desc;
+                desc << "Failed to write_read_pipe on device " << device_name;
+                ApiCommExcept::re_throw_exception(one,
+                                                  "API_CommunicationFailed",
+                                                  desc.str(),
+                                                  "DeviceProxy::write_read_pipe()");
+            }
+        }
+        catch (CORBA::COMM_FAILURE &comm)
+        {
+            if (comm.minor() == omni::COMM_FAILURE_WaitingForReply)
+            {
+                TRANSIENT_NOT_EXIST_EXCEPT(comm, "DeviceProxy", "write_read_pipe", this);
+            }
+            else
+            {
+                set_connection_state(CONNECTION_NOTOK);
+                stringstream desc;
+                desc << "Failed to write_read_pipe on device " << device_name;
+                ApiCommExcept::re_throw_exception(comm,
+                                                  "API_CommunicationFailed",
+                                                  desc.str(),
+                                                  "DeviceProxy::write_read_pipe()");
+            }
+        }
+        catch (CORBA::SystemException &ce)
+        {
+            set_connection_state(CONNECTION_NOTOK);
+            stringstream desc;
+            desc << "Failed to write_read_pipe on device " << device_name;
+            ApiCommExcept::re_throw_exception(ce,
+                                              "API_CommunicationFailed",
+                                              desc.str(),
+                                              "DeviceProxy::write_read_pipe()");
+        }
+    }
 
 //
 // Pass received data to the caller.
@@ -5357,21 +5403,21 @@ DevicePipe DeviceProxy::write_read_pipe(DevicePipe &pipe_data)
 // This is required because the whole object received by the call will be deleted at the end of this method
 //
 
-	r_dev_pipe.set_name(r_pipe_value_5->name.in());
-	r_dev_pipe.set_time(r_pipe_value_5->time);
+    r_dev_pipe.set_name(r_pipe_value_5->name.in());
+    r_dev_pipe.set_time(r_pipe_value_5->time);
 
-	max = r_pipe_value_5->data_blob.blob_data.maximum();
-	len = r_pipe_value_5->data_blob.blob_data.length();
-	DevPipeDataElt *buf = r_pipe_value_5->data_blob.blob_data.get_buffer((CORBA::Boolean)true);
-	DevVarPipeDataEltArray *dvpdea = new DevVarPipeDataEltArray(max,len,buf,true);
+    max = r_pipe_value_5->data_blob.blob_data.maximum();
+    len = r_pipe_value_5->data_blob.blob_data.length();
+    DevPipeDataElt *buf = r_pipe_value_5->data_blob.blob_data.get_buffer((CORBA::Boolean) true);
+    DevVarPipeDataEltArray *dvpdea = new DevVarPipeDataEltArray(max, len, buf, true);
 
-	r_dev_pipe.get_root_blob().reset_extract_ctr();
-	r_dev_pipe.get_root_blob().reset_insert_ctr();
-	r_dev_pipe.get_root_blob().set_name(r_pipe_value_5->data_blob.name.in());
-	r_dev_pipe.get_root_blob().set_extract_data(dvpdea);
-	r_dev_pipe.get_root_blob().set_extract_delete(true);
+    r_dev_pipe.get_root_blob().reset_extract_ctr();
+    r_dev_pipe.get_root_blob().reset_insert_ctr();
+    r_dev_pipe.get_root_blob().set_name(r_pipe_value_5->data_blob.name.in());
+    r_dev_pipe.get_root_blob().set_extract_data(dvpdea);
+    r_dev_pipe.get_root_blob().set_extract_delete(true);
 
-	return r_dev_pipe;
+    return r_dev_pipe;
 
 }
 
@@ -5382,202 +5428,202 @@ DevicePipe DeviceProxy::write_read_pipe(DevicePipe &pipe_data)
 //
 //-----------------------------------------------------------------------------
 
-vector<DeviceAttribute> *DeviceProxy::read_attributes(vector<string>& attr_string_list)
+vector<DeviceAttribute> *DeviceProxy::read_attributes(vector<string> &attr_string_list)
 {
-	AttributeValueList_var attr_value_list;
-	AttributeValueList_3_var attr_value_list_3;
-	AttributeValueList_4_var attr_value_list_4;
-	AttributeValueList_5_var attr_value_list_5;
-	DevVarStringArray attr_list;
+    AttributeValueList_var attr_value_list;
+    AttributeValueList_3_var attr_value_list_3;
+    AttributeValueList_4_var attr_value_list_4;
+    AttributeValueList_5_var attr_value_list_5;
+    DevVarStringArray attr_list;
 
 //
 // Check that the caller did not give two times the same attribute
 //
 
-	same_att_name(attr_string_list,"Deviceproxy::read_attributes()");
-	unsigned long i;
+    same_att_name(attr_string_list, "Deviceproxy::read_attributes()");
+    unsigned long i;
 
-	attr_list.length(attr_string_list.size());
-	for (i = 0;i < attr_string_list.size();i++)
-	{
-		attr_list[i] = string_dup(attr_string_list[i].c_str());
-	}
+    attr_list.length(attr_string_list.size());
+    for (i = 0; i < attr_string_list.size(); i++)
+    {
+        attr_list[i] = string_dup(attr_string_list[i].c_str());
+    }
 
-	int ctr = 0;
-	Tango::DevSource local_source;
+    int ctr = 0;
+    Tango::DevSource local_source;
 
-	while (ctr < 2)
-	{
-		try
-		{
-			check_and_reconnect(local_source);
+    while (ctr < 2)
+    {
+        try
+        {
+            check_and_reconnect(local_source);
 
-			ClntIdent ci;
-			ApiUtil *au = ApiUtil::instance();
-			ci.cpp_clnt(au->get_client_pid());
+            ClntIdent ci;
+            ApiUtil *au = ApiUtil::instance();
+            ci.cpp_clnt(au->get_client_pid());
 
-			if (version == 5)
-			{
-				Device_5_var dev = Device_5::_duplicate(device_5);
-				attr_value_list_5 = dev->read_attributes_5(attr_list,local_source,ci);
-			}
-			else if (version == 4)
-			{
-				Device_4_var dev = Device_4::_duplicate(device_4);
-				attr_value_list_4 = dev->read_attributes_4(attr_list,local_source,ci);
-			}
-			else if (version == 3)
-			{
-				Device_3_var dev = Device_3::_duplicate(device_3);
-				attr_value_list_3 = dev->read_attributes_3(attr_list,local_source);
-			}
-			else if (version == 2)
-			{
-				Device_2_var dev = Device_2::_duplicate(device_2);
-				attr_value_list = dev->read_attributes_2(attr_list,local_source);
-			}
-			else
-			{
-				Device_var dev = Device::_duplicate(device);
-				attr_value_list = dev->read_attributes(attr_list);
-			}
+            if (version == 5)
+            {
+                Device_5_var dev = Device_5::_duplicate(device_5);
+                attr_value_list_5 = dev->read_attributes_5(attr_list, local_source, ci);
+            }
+            else if (version == 4)
+            {
+                Device_4_var dev = Device_4::_duplicate(device_4);
+                attr_value_list_4 = dev->read_attributes_4(attr_list, local_source, ci);
+            }
+            else if (version == 3)
+            {
+                Device_3_var dev = Device_3::_duplicate(device_3);
+                attr_value_list_3 = dev->read_attributes_3(attr_list, local_source);
+            }
+            else if (version == 2)
+            {
+                Device_2_var dev = Device_2::_duplicate(device_2);
+                attr_value_list = dev->read_attributes_2(attr_list, local_source);
+            }
+            else
+            {
+                Device_var dev = Device::_duplicate(device);
+                attr_value_list = dev->read_attributes(attr_list);
+            }
 
-			ctr = 2;
-		}
-		catch (Tango::ConnectionFailed &e)
-		{
-			TangoSys_OMemStream desc;
-			desc << "Failed to read_attributes on device " << device_name;
-			desc << ", attributes ";
-			int nb_attr = attr_string_list.size();
-			for (int i = 0;i < nb_attr;i++)
-			{
-				desc << attr_string_list[i];
-				if (i != nb_attr - 1)
-					desc << ", ";
-			}
-			desc << ends;
-            ApiConnExcept::re_throw_exception(e,(const char*)API_AttributeFailed,
-                        	desc.str(), (const char*)"DeviceProxy::read_attributes()");
-		}
-		catch (Tango::DevFailed &e)
-		{
-			TangoSys_OMemStream desc;
-			desc << "Failed to read_attributes on device " << device_name;
-			desc << ", attributes ";
-			int nb_attr = attr_string_list.size();
-			for (int i = 0;i < nb_attr;i++)
-			{
-				desc << attr_string_list[i];
-				if (i != nb_attr - 1)
-					desc << ", ";
-			}
-			desc << ends;
-        	Except::re_throw_exception(e,(const char*)API_AttributeFailed,
-                        	desc.str(), (const char*)"DeviceProxy::read_attributes()");
-		}
-		catch (CORBA::TRANSIENT &trans)
-		{
-			TRANSIENT_NOT_EXIST_EXCEPT(trans,"DeviceProxy","read_attributes",this);
-		}
-		catch (CORBA::OBJECT_NOT_EXIST &one)
-		{
-			if (one.minor() == omni::OBJECT_NOT_EXIST_NoMatch || one.minor() == 0)
-			{
-				TRANSIENT_NOT_EXIST_EXCEPT(one,"DeviceProxy","read_attributes",this);
-			}
-			else
-			{
-				set_connection_state(CONNECTION_NOTOK);
-				TangoSys_OMemStream desc;
-				desc << "Failed to execute read_attributes on device " << device_name << ends;
-				ApiCommExcept::re_throw_exception(one,
-							      (const char*)"API_CommunicationFailed",
-                        				      desc.str(),
-							      (const char*)"DeviceProxy::read_attributes()");
-			}
-		}
-		catch (CORBA::COMM_FAILURE &comm)
-		{
-			if (comm.minor() == omni::COMM_FAILURE_WaitingForReply)
-			{
-				TRANSIENT_NOT_EXIST_EXCEPT(comm,"DeviceProxy","read_attributes",this);
-			}
-			else
-			{
-				set_connection_state(CONNECTION_NOTOK);
-				TangoSys_OMemStream desc;
-				desc << "Failed to execute read_attributes on device " << device_name << ends;
-				ApiCommExcept::re_throw_exception(comm,
-							      (const char*)"API_CommunicationFailed",
-                        				      desc.str(),
-							      (const char*)"DeviceProxy::read_attributes()");
-			}
-		}
+            ctr = 2;
+        }
+        catch (Tango::ConnectionFailed &e)
+        {
+            TangoSys_OMemStream desc;
+            desc << "Failed to read_attributes on device " << device_name;
+            desc << ", attributes ";
+            int nb_attr = attr_string_list.size();
+            for (int i = 0; i < nb_attr; i++)
+            {
+                desc << attr_string_list[i];
+                if (i != nb_attr - 1)
+                    desc << ", ";
+            }
+            desc << ends;
+            ApiConnExcept::re_throw_exception(e, (const char *) API_AttributeFailed,
+                                              desc.str(), (const char *) "DeviceProxy::read_attributes()");
+        }
+        catch (Tango::DevFailed &e)
+        {
+            TangoSys_OMemStream desc;
+            desc << "Failed to read_attributes on device " << device_name;
+            desc << ", attributes ";
+            int nb_attr = attr_string_list.size();
+            for (int i = 0; i < nb_attr; i++)
+            {
+                desc << attr_string_list[i];
+                if (i != nb_attr - 1)
+                    desc << ", ";
+            }
+            desc << ends;
+            Except::re_throw_exception(e, (const char *) API_AttributeFailed,
+                                       desc.str(), (const char *) "DeviceProxy::read_attributes()");
+        }
+        catch (CORBA::TRANSIENT &trans)
+        {
+            TRANSIENT_NOT_EXIST_EXCEPT(trans, "DeviceProxy", "read_attributes", this);
+        }
+        catch (CORBA::OBJECT_NOT_EXIST &one)
+        {
+            if (one.minor() == omni::OBJECT_NOT_EXIST_NoMatch || one.minor() == 0)
+            {
+                TRANSIENT_NOT_EXIST_EXCEPT(one, "DeviceProxy", "read_attributes", this);
+            }
+            else
+            {
+                set_connection_state(CONNECTION_NOTOK);
+                TangoSys_OMemStream desc;
+                desc << "Failed to execute read_attributes on device " << device_name << ends;
+                ApiCommExcept::re_throw_exception(one,
+                                                  (const char *) "API_CommunicationFailed",
+                                                  desc.str(),
+                                                  (const char *) "DeviceProxy::read_attributes()");
+            }
+        }
+        catch (CORBA::COMM_FAILURE &comm)
+        {
+            if (comm.minor() == omni::COMM_FAILURE_WaitingForReply)
+            {
+                TRANSIENT_NOT_EXIST_EXCEPT(comm, "DeviceProxy", "read_attributes", this);
+            }
+            else
+            {
+                set_connection_state(CONNECTION_NOTOK);
+                TangoSys_OMemStream desc;
+                desc << "Failed to execute read_attributes on device " << device_name << ends;
+                ApiCommExcept::re_throw_exception(comm,
+                                                  (const char *) "API_CommunicationFailed",
+                                                  desc.str(),
+                                                  (const char *) "DeviceProxy::read_attributes()");
+            }
+        }
         catch (CORBA::SystemException &ce)
         {
-			set_connection_state(CONNECTION_NOTOK);
-			TangoSys_OMemStream desc;
-			desc << "Failed to execute read_attributes on device " << device_name << ends;
-			ApiCommExcept::re_throw_exception(ce,
-						      (const char*)"API_CommunicationFailed",
-                        			      desc.str(),
-						      (const char*)"DeviceProxy::read_attributes()");
-		}
-	}
+            set_connection_state(CONNECTION_NOTOK);
+            TangoSys_OMemStream desc;
+            desc << "Failed to execute read_attributes on device " << device_name << ends;
+            ApiCommExcept::re_throw_exception(ce,
+                                              (const char *) "API_CommunicationFailed",
+                                              desc.str(),
+                                              (const char *) "DeviceProxy::read_attributes()");
+        }
+    }
 
-	unsigned long nb_received;
-	if (version >= 5)
+    unsigned long nb_received;
+    if (version >= 5)
         nb_received = attr_value_list_5->length();
     else if (version == 4)
-		nb_received = attr_value_list_4->length();
+        nb_received = attr_value_list_4->length();
     else if (version == 3)
         nb_received = attr_value_list_3->length();
     else
         nb_received = attr_value_list->length();
 
-	vector<DeviceAttribute> *dev_attr = new(vector<DeviceAttribute>);
-	dev_attr->resize(nb_received);
+    vector<DeviceAttribute> *dev_attr = new(vector<DeviceAttribute>);
+    dev_attr->resize(nb_received);
 
-	for (i=0; i < nb_received; i++)
-	{
-		if (version >= 3)
-		{
-			if (version == 5)
-				ApiUtil::attr_to_device(&(attr_value_list_5[i]),version,&(*dev_attr)[i]);
-			else if (version == 4)
-				ApiUtil::attr_to_device(&(attr_value_list_4[i]),version,&(*dev_attr)[i]);
-			else
-				ApiUtil::attr_to_device(NULL,&(attr_value_list_3[i]),version,&(*dev_attr)[i]);
+    for (i = 0; i < nb_received; i++)
+    {
+        if (version >= 3)
+        {
+            if (version == 5)
+                ApiUtil::attr_to_device(&(attr_value_list_5[i]), version, &(*dev_attr)[i]);
+            else if (version == 4)
+                ApiUtil::attr_to_device(&(attr_value_list_4[i]), version, &(*dev_attr)[i]);
+            else
+                ApiUtil::attr_to_device(NULL, &(attr_value_list_3[i]), version, &(*dev_attr)[i]);
 
 //
 // Add an error in the error stack in case there is one
 //
 
             DevErrorList_var &err_list = (*dev_attr)[i].get_error_list();
-			long nb_except = err_list.in().length();
-			if (nb_except != 0)
-			{
-				TangoSys_OMemStream desc;
-				desc << "Failed to read_attributes on device " << device_name;
-				desc << ", attribute " << (*dev_attr)[i].name << ends;
+            long nb_except = err_list.in().length();
+            if (nb_except != 0)
+            {
+                TangoSys_OMemStream desc;
+                desc << "Failed to read_attributes on device " << device_name;
+                desc << ", attribute " << (*dev_attr)[i].name << ends;
 
-				err_list.inout().length(nb_except + 1);
-				err_list[nb_except].reason = CORBA::string_dup(API_AttributeFailed);
-				err_list[nb_except].origin = CORBA::string_dup("DeviceProxy::read_attributes()");
+                err_list.inout().length(nb_except + 1);
+                err_list[nb_except].reason = CORBA::string_dup(API_AttributeFailed);
+                err_list[nb_except].origin = CORBA::string_dup("DeviceProxy::read_attributes()");
 
-				string st = desc.str();
-				err_list[nb_except].desc = CORBA::string_dup(st.c_str());
-				err_list[nb_except].severity = Tango::ERR;
-			}
-		}
-		else
-		{
-			ApiUtil::attr_to_device(&(attr_value_list[i]),NULL,version,&(*dev_attr)[i]);
-		}
-	}
+                string st = desc.str();
+                err_list[nb_except].desc = CORBA::string_dup(st.c_str());
+                err_list[nb_except].severity = Tango::ERR;
+            }
+        }
+        else
+        {
+            ApiUtil::attr_to_device(&(attr_value_list[i]), NULL, version, &(*dev_attr)[i]);
+        }
+    }
 
-	return(dev_attr);
+    return (dev_attr);
 }
 
 //-----------------------------------------------------------------------------
@@ -5587,314 +5633,315 @@ vector<DeviceAttribute> *DeviceProxy::read_attributes(vector<string>& attr_strin
 //-----------------------------------------------------------------------------
 
 
-DeviceAttribute DeviceProxy::read_attribute(string& attr_string)
+DeviceAttribute DeviceProxy::read_attribute(string &attr_string)
 {
-	AttributeValueList_var attr_value_list;
-	AttributeValueList_3_var attr_value_list_3;
-	AttributeValueList_4_var attr_value_list_4;
-	AttributeValueList_5_var attr_value_list_5;
-	DeviceAttribute dev_attr;
-	DevVarStringArray attr_list;
-	int ctr = 0;
-	Tango::DevSource local_source;
+    AttributeValueList_var attr_value_list;
+    AttributeValueList_3_var attr_value_list_3;
+    AttributeValueList_4_var attr_value_list_4;
+    AttributeValueList_5_var attr_value_list_5;
+    DeviceAttribute dev_attr;
+    DevVarStringArray attr_list;
+    int ctr = 0;
+    Tango::DevSource local_source;
 
-	attr_list.length(1);
-	attr_list[0] = CORBA::string_dup(attr_string.c_str());
+    attr_list.length(1);
+    attr_list[0] = CORBA::string_dup(attr_string.c_str());
 
-	while (ctr < 2)
-	{
-		try
-		{
-			check_and_reconnect(local_source);
+    while (ctr < 2)
+    {
+        try
+        {
+            check_and_reconnect(local_source);
 
-			if (version >= 5)
-			{
-				ClntIdent ci;
-				ApiUtil *au = ApiUtil::instance();
-				ci.cpp_clnt(au->get_client_pid());
-				Device_5_var dev = Device_5::_duplicate(device_5);
-				attr_value_list_5 = dev->read_attributes_5(attr_list,local_source,ci);
-			}
-			else if (version == 4)
-			{
-				ClntIdent ci;
-				ApiUtil *au = ApiUtil::instance();
-				ci.cpp_clnt(au->get_client_pid());
-				Device_4_var dev = Device_4::_duplicate(device_4);
-				attr_value_list_4 = dev->read_attributes_4(attr_list,local_source,ci);
-			}
-			else if (version == 3)
-			{
-				Device_3_var dev = Device_3::_duplicate(device_3);
-				attr_value_list_3 = dev->read_attributes_3(attr_list,local_source);
-			}
-			else if (version == 2)
-			{
-				Device_2_var dev = Device_2::_duplicate(device_2);
-				attr_value_list = dev->read_attributes_2(attr_list,local_source);
-			}
-			else
-			{
-				Device_var dev = Device::_duplicate(device);
-				attr_value_list = dev->read_attributes(attr_list);
-			}
-			ctr = 2;
-		}
-		READ_ATT_EXCEPT(attr_string,this)
-	}
+            if (version >= 5)
+            {
+                ClntIdent ci;
+                ApiUtil *au = ApiUtil::instance();
+                ci.cpp_clnt(au->get_client_pid());
+                Device_5_var dev = Device_5::_duplicate(device_5);
+                attr_value_list_5 = dev->read_attributes_5(attr_list, local_source, ci);
+            }
+            else if (version == 4)
+            {
+                ClntIdent ci;
+                ApiUtil *au = ApiUtil::instance();
+                ci.cpp_clnt(au->get_client_pid());
+                Device_4_var dev = Device_4::_duplicate(device_4);
+                attr_value_list_4 = dev->read_attributes_4(attr_list, local_source, ci);
+            }
+            else if (version == 3)
+            {
+                Device_3_var dev = Device_3::_duplicate(device_3);
+                attr_value_list_3 = dev->read_attributes_3(attr_list, local_source);
+            }
+            else if (version == 2)
+            {
+                Device_2_var dev = Device_2::_duplicate(device_2);
+                attr_value_list = dev->read_attributes_2(attr_list, local_source);
+            }
+            else
+            {
+                Device_var dev = Device::_duplicate(device);
+                attr_value_list = dev->read_attributes(attr_list);
+            }
+            ctr = 2;
+        }
+        READ_ATT_EXCEPT(attr_string, this)
+    }
 
-	if (version >= 3)
-	{
-		if (version >= 5)
-			ApiUtil::attr_to_device(&(attr_value_list_5[0]),version,&dev_attr);
-		else if (version == 4)
-			ApiUtil::attr_to_device(&(attr_value_list_4[0]),version,&dev_attr);
-		else
-			ApiUtil::attr_to_device(NULL,&(attr_value_list_3[0]),version,&dev_attr);
+    if (version >= 3)
+    {
+        if (version >= 5)
+            ApiUtil::attr_to_device(&(attr_value_list_5[0]), version, &dev_attr);
+        else if (version == 4)
+            ApiUtil::attr_to_device(&(attr_value_list_4[0]), version, &dev_attr);
+        else
+            ApiUtil::attr_to_device(NULL, &(attr_value_list_3[0]), version, &dev_attr);
 
 //
 // Add an error in the error stack in case there is one
 //
 
         DevErrorList_var &err_list = dev_attr.get_error_list();
-		long nb_except = err_list.in().length();
-		if (nb_except != 0)
-		{
-			TangoSys_OMemStream desc;
-			desc << "Failed to read_attribute on device " << device_name;
-			desc << ", attribute " << dev_attr.name << ends;
+        long nb_except = err_list.in().length();
+        if (nb_except != 0)
+        {
+            TangoSys_OMemStream desc;
+            desc << "Failed to read_attribute on device " << device_name;
+            desc << ", attribute " << dev_attr.name << ends;
 
-			err_list.inout().length(nb_except + 1);
-			err_list[nb_except].reason = CORBA::string_dup(API_AttributeFailed);
-			err_list[nb_except].origin = CORBA::string_dup("DeviceProxy::read_attribute()");
+            err_list.inout().length(nb_except + 1);
+            err_list[nb_except].reason = CORBA::string_dup(API_AttributeFailed);
+            err_list[nb_except].origin = CORBA::string_dup("DeviceProxy::read_attribute()");
 
-			string st = desc.str();
-			err_list[nb_except].desc = CORBA::string_dup(st.c_str());
-			err_list[nb_except].severity = Tango::ERR;
-		}
-	}
-	else
-	{
-		ApiUtil::attr_to_device(&(attr_value_list[0]),NULL,version,&dev_attr);
-	}
+            string st = desc.str();
+            err_list[nb_except].desc = CORBA::string_dup(st.c_str());
+            err_list[nb_except].severity = Tango::ERR;
+        }
+    }
+    else
+    {
+        ApiUtil::attr_to_device(&(attr_value_list[0]), NULL, version, &dev_attr);
+    }
 
-	return(dev_attr);
+    return (dev_attr);
 }
 
-
-void DeviceProxy::read_attribute(const char *attr_str,DeviceAttribute &dev_attr)
+void DeviceProxy::read_attribute(const char *attr_str, DeviceAttribute &dev_attr)
 {
-	AttributeValueList *attr_value_list = NULL;
-	AttributeValueList_3 *attr_value_list_3 = NULL;
-	AttributeValueList_4 *attr_value_list_4 = NULL;
-	AttributeValueList_5 *attr_value_list_5 = NULL;
-	DevVarStringArray attr_list;
-	int ctr = 0;
-	Tango::DevSource local_source;
+    AttributeValueList *attr_value_list = NULL;
+    AttributeValueList_3 *attr_value_list_3 = NULL;
+    AttributeValueList_4 *attr_value_list_4 = NULL;
+    AttributeValueList_5 *attr_value_list_5 = NULL;
+    DevVarStringArray attr_list;
+    int ctr = 0;
+    Tango::DevSource local_source;
 
-	attr_list.length(1);
-	attr_list[0] = CORBA::string_dup(attr_str);
+    attr_list.length(1);
+    attr_list[0] = CORBA::string_dup(attr_str);
 
-	while (ctr < 2)
-	{
-		try
-		{
-			check_and_reconnect(local_source);
+    while (ctr < 2)
+    {
+        try
+        {
+            check_and_reconnect(local_source);
 
-			ClntIdent ci;
-			ApiUtil *au = ApiUtil::instance();
-			ci.cpp_clnt(au->get_client_pid());
+            ClntIdent ci;
+            ApiUtil *au = ApiUtil::instance();
+            ci.cpp_clnt(au->get_client_pid());
 
-			if (version >= 5)
-			{
-				Device_5_var dev = Device_5::_duplicate(device_5);
-				attr_value_list_5 = dev->read_attributes_5(attr_list,local_source,ci);
-			}
-			else if (version == 4)
-			{
-				Device_4_var dev = Device_4::_duplicate(device_4);
-				attr_value_list_4 = dev->read_attributes_4(attr_list,local_source,ci);
-			}
-			else if (version == 3)
-			{
-				Device_3_var dev = Device_3::_duplicate(device_3);
-				attr_value_list_3 = dev->read_attributes_3(attr_list,local_source);
-			}
-			else if (version == 2)
-			{
-				Device_2_var dev = Device_2::_duplicate(device_2);
-				attr_value_list = dev->read_attributes_2(attr_list,local_source);
-			}
-			else
-			{
-				Device_var dev = Device::_duplicate(device);
-				attr_value_list = dev->read_attributes(attr_list);
-			}
-			ctr = 2;
-		}
-		READ_ATT_EXCEPT(attr_str,this)
-	}
+            if (version >= 5)
+            {
+                Device_5_var dev = Device_5::_duplicate(device_5);
+                attr_value_list_5 = dev->read_attributes_5(attr_list, local_source, ci);
+            }
+            else if (version == 4)
+            {
+                Device_4_var dev = Device_4::_duplicate(device_4);
+                attr_value_list_4 = dev->read_attributes_4(attr_list, local_source, ci);
+            }
+            else if (version == 3)
+            {
+                Device_3_var dev = Device_3::_duplicate(device_3);
+                attr_value_list_3 = dev->read_attributes_3(attr_list, local_source);
+            }
+            else if (version == 2)
+            {
+                Device_2_var dev = Device_2::_duplicate(device_2);
+                attr_value_list = dev->read_attributes_2(attr_list, local_source);
+            }
+            else
+            {
+                Device_var dev = Device::_duplicate(device);
+                attr_value_list = dev->read_attributes(attr_list);
+            }
+            ctr = 2;
+        }
+        READ_ATT_EXCEPT(attr_str, this)
+    }
 
-	if (version >= 3)
-	{
+    if (version >= 3)
+    {
 
-		if (version >= 5)
-		{
-			ApiUtil::attr_to_device(&((*attr_value_list_5)[0]),version,&dev_attr);
-			delete attr_value_list_5;
-		}
-		else if (version == 4)
-		{
-			ApiUtil::attr_to_device(&((*attr_value_list_4)[0]),version,&dev_attr);
-			delete attr_value_list_4;
-		}
-		else
-		{
-			ApiUtil::attr_to_device(NULL,&((*attr_value_list_3)[0]),version,&dev_attr);
-			delete attr_value_list_3;
-		}
+        if (version >= 5)
+        {
+            ApiUtil::attr_to_device(&((*attr_value_list_5)[0]), version, &dev_attr);
+            delete attr_value_list_5;
+        }
+        else if (version == 4)
+        {
+            ApiUtil::attr_to_device(&((*attr_value_list_4)[0]), version, &dev_attr);
+            delete attr_value_list_4;
+        }
+        else
+        {
+            ApiUtil::attr_to_device(NULL, &((*attr_value_list_3)[0]), version, &dev_attr);
+            delete attr_value_list_3;
+        }
 
 //
 // Add an error in the error stack in case there is one
 //
 
         DevErrorList_var &err_list = dev_attr.get_error_list();
-		long nb_except = err_list.in().length();
-		if (nb_except != 0)
-		{
-			TangoSys_OMemStream desc;
-			desc << "Failed to read_attribute on device " << device_name;
-			desc << ", attribute " << dev_attr.name << ends;
+        long nb_except = err_list.in().length();
+        if (nb_except != 0)
+        {
+            TangoSys_OMemStream desc;
+            desc << "Failed to read_attribute on device " << device_name;
+            desc << ", attribute " << dev_attr.name << ends;
 
-			err_list.inout().length(nb_except + 1);
-			err_list[nb_except].reason = CORBA::string_dup(API_AttributeFailed);
-			err_list[nb_except].origin = CORBA::string_dup("DeviceProxy::read_attribute()");
+            err_list.inout().length(nb_except + 1);
+            err_list[nb_except].reason = CORBA::string_dup(API_AttributeFailed);
+            err_list[nb_except].origin = CORBA::string_dup("DeviceProxy::read_attribute()");
 
-			string st = desc.str();
-			err_list[nb_except].desc = CORBA::string_dup(st.c_str());
-			err_list[nb_except].severity = Tango::ERR;
-		}
-	}
-	else
-	{
-		ApiUtil::attr_to_device(&((*attr_value_list)[0]),NULL,version,&dev_attr);
-		delete attr_value_list;
-	}
+            string st = desc.str();
+            err_list[nb_except].desc = CORBA::string_dup(st.c_str());
+            err_list[nb_except].severity = Tango::ERR;
+        }
+    }
+    else
+    {
+        ApiUtil::attr_to_device(&((*attr_value_list)[0]), NULL, version, &dev_attr);
+        delete attr_value_list;
+    }
 
 }
 
-void DeviceProxy::read_attribute(const string &attr_str,AttributeValue_4 *&av_4)
+void DeviceProxy::read_attribute(const string &attr_str, AttributeValue_4 *&av_4)
 {
-	DevVarStringArray attr_list;
-	int ctr = 0;
-	Tango::DevSource local_source;
+    DevVarStringArray attr_list;
+    int ctr = 0;
+    Tango::DevSource local_source;
 
-	if (version < 4)
-	{
-		stringstream ss;
-		ss << "Device " << dev_name() << " is too old to support this call. Please, update to IDL 4 (Tango 7.x or more)";
-		Except::throw_exception(API_NotSupported,ss.str(),"DeviceProxy::read_attribute");
-	}
+    if (version < 4)
+    {
+        stringstream ss;
+        ss << "Device " << dev_name()
+           << " is too old to support this call. Please, update to IDL 4 (Tango 7.x or more)";
+        Except::throw_exception(API_NotSupported, ss.str(), "DeviceProxy::read_attribute");
+    }
 
-	attr_list.length(1);
-	attr_list[0] = CORBA::string_dup(attr_str.c_str());
+    attr_list.length(1);
+    attr_list[0] = CORBA::string_dup(attr_str.c_str());
 
-	while (ctr < 2)
-	{
-		try
-		{
-			check_and_reconnect(local_source);
+    while (ctr < 2)
+    {
+        try
+        {
+            check_and_reconnect(local_source);
 
-			ClntIdent ci;
-			ApiUtil *au = ApiUtil::instance();
-			ci.cpp_clnt(au->get_client_pid());
+            ClntIdent ci;
+            ApiUtil *au = ApiUtil::instance();
+            ci.cpp_clnt(au->get_client_pid());
 
-			Device_4_var dev = Device_4::_duplicate(device_4);
-			AttributeValueList_4 *attr_value_list_4 = dev->read_attributes_4(attr_list,local_source,ci);
-			av_4 = attr_value_list_4->get_buffer(true);
-			delete attr_value_list_4;
+            Device_4_var dev = Device_4::_duplicate(device_4);
+            AttributeValueList_4 *attr_value_list_4 = dev->read_attributes_4(attr_list, local_source, ci);
+            av_4 = attr_value_list_4->get_buffer(true);
+            delete attr_value_list_4;
 
-			ctr = 2;
-		}
-		READ_ATT_EXCEPT(attr_str,this)
-	}
+            ctr = 2;
+        }
+        READ_ATT_EXCEPT(attr_str, this)
+    }
 
 //
 // Add an error in the error stack in case there is one
 //
 
-	long nb_except = av_4->err_list.length();
-	if (nb_except != 0)
-	{
-		TangoSys_OMemStream desc;
-		desc << "Failed to read_attribute on device " << device_name;
-		desc << ", attribute " << attr_str << ends;
+    long nb_except = av_4->err_list.length();
+    if (nb_except != 0)
+    {
+        TangoSys_OMemStream desc;
+        desc << "Failed to read_attribute on device " << device_name;
+        desc << ", attribute " << attr_str << ends;
 
-		av_4->err_list.length(nb_except + 1);
-		av_4->err_list[nb_except].reason = CORBA::string_dup(API_AttributeFailed);
-		av_4->err_list[nb_except].origin = CORBA::string_dup("DeviceProxy::read_attribute()");
+        av_4->err_list.length(nb_except + 1);
+        av_4->err_list[nb_except].reason = CORBA::string_dup(API_AttributeFailed);
+        av_4->err_list[nb_except].origin = CORBA::string_dup("DeviceProxy::read_attribute()");
 
-		string st = desc.str();
-		av_4->err_list[nb_except].desc = CORBA::string_dup(st.c_str());
-		av_4->err_list[nb_except].severity = Tango::ERR;
-	}
+        string st = desc.str();
+        av_4->err_list[nb_except].desc = CORBA::string_dup(st.c_str());
+        av_4->err_list[nb_except].severity = Tango::ERR;
+    }
 }
 
-void DeviceProxy::read_attribute(const string &attr_str,AttributeValue_5 *&av_5)
+void DeviceProxy::read_attribute(const string &attr_str, AttributeValue_5 *&av_5)
 {
-	DevVarStringArray attr_list;
-	int ctr = 0;
-	Tango::DevSource local_source;
+    DevVarStringArray attr_list;
+    int ctr = 0;
+    Tango::DevSource local_source;
 
-	if (version < 5)
-	{
-		stringstream ss;
-		ss << "Device " << dev_name() << " is too old to support this call. Please, update to IDL 5 (Tango 9.x or more)";
-		Except::throw_exception(API_NotSupported,ss.str(),"DeviceProxy::read_attribute");
-	}
+    if (version < 5)
+    {
+        stringstream ss;
+        ss << "Device " << dev_name()
+           << " is too old to support this call. Please, update to IDL 5 (Tango 9.x or more)";
+        Except::throw_exception(API_NotSupported, ss.str(), "DeviceProxy::read_attribute");
+    }
 
-	attr_list.length(1);
-	attr_list[0] = CORBA::string_dup(attr_str.c_str());
+    attr_list.length(1);
+    attr_list[0] = CORBA::string_dup(attr_str.c_str());
 
-	while (ctr < 2)
-	{
-		try
-		{
-			check_and_reconnect(local_source);
+    while (ctr < 2)
+    {
+        try
+        {
+            check_and_reconnect(local_source);
 
-			ClntIdent ci;
-			ApiUtil *au = ApiUtil::instance();
-			ci.cpp_clnt(au->get_client_pid());
+            ClntIdent ci;
+            ApiUtil *au = ApiUtil::instance();
+            ci.cpp_clnt(au->get_client_pid());
 
-			Device_5_var dev = Device_5::_duplicate(device_5);
-			AttributeValueList_5 *attr_value_list_5 = dev->read_attributes_5(attr_list,local_source,ci);
-			av_5 = attr_value_list_5->get_buffer(true);
-			delete attr_value_list_5;
+            Device_5_var dev = Device_5::_duplicate(device_5);
+            AttributeValueList_5 *attr_value_list_5 = dev->read_attributes_5(attr_list, local_source, ci);
+            av_5 = attr_value_list_5->get_buffer(true);
+            delete attr_value_list_5;
 
-			ctr = 2;
-		}
-		READ_ATT_EXCEPT(attr_str,this)
-	}
+            ctr = 2;
+        }
+        READ_ATT_EXCEPT(attr_str, this)
+    }
 
 //
 // Add an error in the error stack in case there is one
 //
 
-	long nb_except = av_5->err_list.length();
-	if (nb_except != 0)
-	{
-		TangoSys_OMemStream desc;
-		desc << "Failed to read_attribute on device " << device_name;
-		desc << ", attribute " << attr_str << ends;
+    long nb_except = av_5->err_list.length();
+    if (nb_except != 0)
+    {
+        TangoSys_OMemStream desc;
+        desc << "Failed to read_attribute on device " << device_name;
+        desc << ", attribute " << attr_str << ends;
 
-		av_5->err_list.length(nb_except + 1);
-		av_5->err_list[nb_except].reason = CORBA::string_dup(API_AttributeFailed);
-		av_5->err_list[nb_except].origin = CORBA::string_dup("DeviceProxy::read_attribute()");
+        av_5->err_list.length(nb_except + 1);
+        av_5->err_list[nb_except].reason = CORBA::string_dup(API_AttributeFailed);
+        av_5->err_list[nb_except].origin = CORBA::string_dup("DeviceProxy::read_attribute()");
 
-		string st = desc.str();
-		av_5->err_list[nb_except].desc = CORBA::string_dup(st.c_str());
-		av_5->err_list[nb_except].severity = Tango::ERR;
-	}
+        string st = desc.str();
+        av_5->err_list[nb_except].desc = CORBA::string_dup(st.c_str());
+        av_5->err_list[nb_except].severity = Tango::ERR;
+    }
 }
 
 //-----------------------------------------------------------------------------
@@ -5903,276 +5950,276 @@ void DeviceProxy::read_attribute(const string &attr_str,AttributeValue_5 *&av_5)
 //
 //-----------------------------------------------------------------------------
 
-void DeviceProxy::write_attributes(vector<DeviceAttribute>& attr_list)
+void DeviceProxy::write_attributes(vector<DeviceAttribute> &attr_list)
 {
-	AttributeValueList attr_value_list;
-	AttributeValueList_4 attr_value_list_4;
+    AttributeValueList attr_value_list;
+    AttributeValueList_4 attr_value_list_4;
 
-	Tango::AccessControlType local_act;
+    Tango::AccessControlType local_act;
 
-	if (version == 0)
+    if (version == 0)
         check_and_reconnect(local_act);
 
-	if (version >= 4)
-		attr_value_list_4.length(attr_list.size());
-	else
-		attr_value_list.length(attr_list.size());
+    if (version >= 4)
+        attr_value_list_4.length(attr_list.size());
+    else
+        attr_value_list.length(attr_list.size());
 
-	for (unsigned int i=0; i<attr_list.size(); i++)
-	{
-		if (version >= 4)
-		{
-			attr_value_list_4[i].name = attr_list[i].name.c_str();
-			attr_value_list_4[i].quality = attr_list[i].quality;
-			attr_value_list_4[i].data_format = attr_list[i].data_format;
-			attr_value_list_4[i].time = attr_list[i].time;
-			attr_value_list_4[i].w_dim.dim_x = attr_list[i].dim_x;
-			attr_value_list_4[i].w_dim.dim_y = attr_list[i].dim_y;
-		}
-		else
-		{
-			attr_value_list[i].name = attr_list[i].name.c_str();
-			attr_value_list[i].quality = attr_list[i].quality;
-			attr_value_list[i].time = attr_list[i].time;
-			attr_value_list[i].dim_x = attr_list[i].dim_x;
-			attr_value_list[i].dim_y = attr_list[i].dim_y;
-		}
+    for (unsigned int i = 0; i < attr_list.size(); i++)
+    {
+        if (version >= 4)
+        {
+            attr_value_list_4[i].name = attr_list[i].name.c_str();
+            attr_value_list_4[i].quality = attr_list[i].quality;
+            attr_value_list_4[i].data_format = attr_list[i].data_format;
+            attr_value_list_4[i].time = attr_list[i].time;
+            attr_value_list_4[i].w_dim.dim_x = attr_list[i].dim_x;
+            attr_value_list_4[i].w_dim.dim_y = attr_list[i].dim_y;
+        }
+        else
+        {
+            attr_value_list[i].name = attr_list[i].name.c_str();
+            attr_value_list[i].quality = attr_list[i].quality;
+            attr_value_list[i].time = attr_list[i].time;
+            attr_value_list[i].dim_x = attr_list[i].dim_x;
+            attr_value_list[i].dim_y = attr_list[i].dim_y;
+        }
 
-		if (attr_list[i].LongSeq.operator->() != NULL)
-		{
-			if (version >= 4)
-				attr_value_list_4[i].value.long_att_value(attr_list[i].LongSeq.in());
-			else
-				attr_value_list[i].value <<= attr_list[i].LongSeq.in();
-			continue;
-		}
-		if (attr_list[i].Long64Seq.operator->() != NULL)
-		{
-			if (version >= 4)
-				attr_value_list_4[i].value.long64_att_value(attr_list[i].Long64Seq.in());
-			else
-				attr_value_list[i].value <<= attr_list[i].Long64Seq.in();
-			continue;
-		}
-		if (attr_list[i].ShortSeq.operator->() != NULL)
-		{
-			if (version >= 4)
-				attr_value_list_4[i].value.short_att_value(attr_list[i].ShortSeq.in());
-			else
-				attr_value_list[i].value <<= attr_list[i].ShortSeq.in();
-			continue;
-		}
-		if (attr_list[i].DoubleSeq.operator->() != NULL)
-		{
-			if (version >= 4)
-				attr_value_list_4[i].value.double_att_value(attr_list[i].DoubleSeq.in());
-			else
-				attr_value_list[i].value <<= attr_list[i].DoubleSeq.in();
-			continue;
-		}
-		if (attr_list[i].StringSeq.operator->() != NULL)
-		{
-			if (version >= 4)
-				attr_value_list_4[i].value.string_att_value(attr_list[i].StringSeq.in());
-			else
-				attr_value_list[i].value  <<= attr_list[i].StringSeq.in();
-			continue;
-		}
-		if (attr_list[i].FloatSeq.operator->() != NULL)
-		{
-			if (version >= 4)
-				attr_value_list_4[i].value.float_att_value(attr_list[i].FloatSeq.in());
-			else
-				attr_value_list[i].value <<= attr_list[i].FloatSeq.in();
-			continue;
-		}
-		if (attr_list[i].BooleanSeq.operator->() != NULL)
-		{
-			if (version >= 4)
-				attr_value_list_4[i].value.bool_att_value(attr_list[i].BooleanSeq.in());
-			else
-				attr_value_list[i].value <<= attr_list[i].BooleanSeq.in();
-			continue;
-		}
-		if (attr_list[i].UShortSeq.operator->() != NULL)
-		{
-			if (version >= 4)
-				attr_value_list_4[i].value.ushort_att_value(attr_list[i].UShortSeq.in());
-			else
-				attr_value_list[i].value <<= attr_list[i].UShortSeq.in();
-			continue;
-		}
-		if (attr_list[i].UCharSeq.operator->() != NULL)
-		{
-			if (version >= 4)
-				attr_value_list_4[i].value.uchar_att_value(attr_list[i].UCharSeq.in());
-			else
-				attr_value_list[i].value  <<= attr_list[i].UCharSeq.in();
-			continue;
-		}
-		if (attr_list[i].ULongSeq.operator->() != NULL)
-		{
-			if (version >= 4)
-				attr_value_list_4[i].value.ulong_att_value(attr_list[i].ULongSeq.in());
-			else
-				attr_value_list[i].value <<= attr_list[i].ULongSeq.in();
-			continue;
-		}
-		if (attr_list[i].ULong64Seq.operator->() != NULL)
-		{
-			if (version >= 4)
-				attr_value_list_4[i].value.ulong64_att_value(attr_list[i].ULong64Seq.in());
-			else
-				attr_value_list[i].value <<= attr_list[i].ULong64Seq.in();
-			continue;
-		}
-		if (attr_list[i].StateSeq.operator->() != NULL)
-		{
-			if (version >= 4)
-				attr_value_list_4[i].value.state_att_value(attr_list[i].StateSeq.in());
-			else
-				attr_value_list[i].value <<= attr_list[i].StateSeq.in();
-			continue;
-		}
-	}
+        if (attr_list[i].LongSeq.operator->() != NULL)
+        {
+            if (version >= 4)
+                attr_value_list_4[i].value.long_att_value(attr_list[i].LongSeq.in());
+            else
+                attr_value_list[i].value <<= attr_list[i].LongSeq.in();
+            continue;
+        }
+        if (attr_list[i].Long64Seq.operator->() != NULL)
+        {
+            if (version >= 4)
+                attr_value_list_4[i].value.long64_att_value(attr_list[i].Long64Seq.in());
+            else
+                attr_value_list[i].value <<= attr_list[i].Long64Seq.in();
+            continue;
+        }
+        if (attr_list[i].ShortSeq.operator->() != NULL)
+        {
+            if (version >= 4)
+                attr_value_list_4[i].value.short_att_value(attr_list[i].ShortSeq.in());
+            else
+                attr_value_list[i].value <<= attr_list[i].ShortSeq.in();
+            continue;
+        }
+        if (attr_list[i].DoubleSeq.operator->() != NULL)
+        {
+            if (version >= 4)
+                attr_value_list_4[i].value.double_att_value(attr_list[i].DoubleSeq.in());
+            else
+                attr_value_list[i].value <<= attr_list[i].DoubleSeq.in();
+            continue;
+        }
+        if (attr_list[i].StringSeq.operator->() != NULL)
+        {
+            if (version >= 4)
+                attr_value_list_4[i].value.string_att_value(attr_list[i].StringSeq.in());
+            else
+                attr_value_list[i].value <<= attr_list[i].StringSeq.in();
+            continue;
+        }
+        if (attr_list[i].FloatSeq.operator->() != NULL)
+        {
+            if (version >= 4)
+                attr_value_list_4[i].value.float_att_value(attr_list[i].FloatSeq.in());
+            else
+                attr_value_list[i].value <<= attr_list[i].FloatSeq.in();
+            continue;
+        }
+        if (attr_list[i].BooleanSeq.operator->() != NULL)
+        {
+            if (version >= 4)
+                attr_value_list_4[i].value.bool_att_value(attr_list[i].BooleanSeq.in());
+            else
+                attr_value_list[i].value <<= attr_list[i].BooleanSeq.in();
+            continue;
+        }
+        if (attr_list[i].UShortSeq.operator->() != NULL)
+        {
+            if (version >= 4)
+                attr_value_list_4[i].value.ushort_att_value(attr_list[i].UShortSeq.in());
+            else
+                attr_value_list[i].value <<= attr_list[i].UShortSeq.in();
+            continue;
+        }
+        if (attr_list[i].UCharSeq.operator->() != NULL)
+        {
+            if (version >= 4)
+                attr_value_list_4[i].value.uchar_att_value(attr_list[i].UCharSeq.in());
+            else
+                attr_value_list[i].value <<= attr_list[i].UCharSeq.in();
+            continue;
+        }
+        if (attr_list[i].ULongSeq.operator->() != NULL)
+        {
+            if (version >= 4)
+                attr_value_list_4[i].value.ulong_att_value(attr_list[i].ULongSeq.in());
+            else
+                attr_value_list[i].value <<= attr_list[i].ULongSeq.in();
+            continue;
+        }
+        if (attr_list[i].ULong64Seq.operator->() != NULL)
+        {
+            if (version >= 4)
+                attr_value_list_4[i].value.ulong64_att_value(attr_list[i].ULong64Seq.in());
+            else
+                attr_value_list[i].value <<= attr_list[i].ULong64Seq.in();
+            continue;
+        }
+        if (attr_list[i].StateSeq.operator->() != NULL)
+        {
+            if (version >= 4)
+                attr_value_list_4[i].value.state_att_value(attr_list[i].StateSeq.in());
+            else
+                attr_value_list[i].value <<= attr_list[i].StateSeq.in();
+            continue;
+        }
+    }
 
-	int ctr = 0;
+    int ctr = 0;
 
-	while (ctr < 2)
-	{
-		try
-		{
-			check_and_reconnect(local_act);
+    while (ctr < 2)
+    {
+        try
+        {
+            check_and_reconnect(local_act);
 
 //
 // Throw exception if caller not allowed to write_attribute
 //
 
-			if (local_act == ACCESS_READ)
-			{
-				try
-				{
-					Device_var dev = Device::_duplicate(device);
-					dev->ping();
-				}
-				catch(...)
-				{
-					set_connection_state(CONNECTION_NOTOK);
-					throw;
-				}
+            if (local_act == ACCESS_READ)
+            {
+                try
+                {
+                    Device_var dev = Device::_duplicate(device);
+                    dev->ping();
+                }
+                catch (...)
+                {
+                    set_connection_state(CONNECTION_NOTOK);
+                    throw;
+                }
 
-				TangoSys_OMemStream desc;
-				desc << "Writing attribute(s) on device " << dev_name() << " is not authorized" << ends;
+                TangoSys_OMemStream desc;
+                desc << "Writing attribute(s) on device " << dev_name() << " is not authorized" << ends;
 
-				NotAllowedExcept::throw_exception((const char *)API_ReadOnlyMode,desc.str(),
-											  	  (const char *)"DeviceProxy::write_attributes()");
-			}
+                NotAllowedExcept::throw_exception((const char *) API_ReadOnlyMode, desc.str(),
+                                                  (const char *) "DeviceProxy::write_attributes()");
+            }
 
 //
 // Now, write the attribute(s)
 //
 
-			if (version >= 4)
-			{
-				ClntIdent ci;
-				ApiUtil *au = ApiUtil::instance();
-				ci.cpp_clnt(au->get_client_pid());
+            if (version >= 4)
+            {
+                ClntIdent ci;
+                ApiUtil *au = ApiUtil::instance();
+                ci.cpp_clnt(au->get_client_pid());
 
-				Device_4_var dev = Device_4::_duplicate(device_4);
-				dev->write_attributes_4(attr_value_list_4,ci);
-			}
-			else if (version == 3)
-			{
-				Device_3_var dev = Device_3::_duplicate(device_3);
-				dev->write_attributes_3(attr_value_list);
-			}
-			else
-			{
-				Device_var dev = Device::_duplicate(device);
-				dev->write_attributes(attr_value_list);
-			}
-			ctr = 2;
-		}
-		catch (Tango::MultiDevFailed &e)
-		{
-			throw Tango::NamedDevFailedList(e,
-						       device_name,
-						       (const char *)"DeviceProxy::write_attributes",
-						       (const char *)API_AttributeFailed);
-		}
-		catch (Tango::DevFailed &e)
-		{
-			TangoSys_OMemStream desc;
-			desc << "Failed to write_attributes on device " << device_name;
-			desc << ", attributes ";
-			int nb_attr = attr_value_list.length();
-			for (int i = 0;i < nb_attr;i++)
-			{
-				desc << attr_value_list[i].name.in();
-				if (i != nb_attr - 1)
-					desc << ", ";
-			}
-			desc << ends;
+                Device_4_var dev = Device_4::_duplicate(device_4);
+                dev->write_attributes_4(attr_value_list_4, ci);
+            }
+            else if (version == 3)
+            {
+                Device_3_var dev = Device_3::_duplicate(device_3);
+                dev->write_attributes_3(attr_value_list);
+            }
+            else
+            {
+                Device_var dev = Device::_duplicate(device);
+                dev->write_attributes(attr_value_list);
+            }
+            ctr = 2;
+        }
+        catch (Tango::MultiDevFailed &e)
+        {
+            throw Tango::NamedDevFailedList(e,
+                                            device_name,
+                                            (const char *) "DeviceProxy::write_attributes",
+                                            (const char *) API_AttributeFailed);
+        }
+        catch (Tango::DevFailed &e)
+        {
+            TangoSys_OMemStream desc;
+            desc << "Failed to write_attributes on device " << device_name;
+            desc << ", attributes ";
+            int nb_attr = attr_value_list.length();
+            for (int i = 0; i < nb_attr; i++)
+            {
+                desc << attr_value_list[i].name.in();
+                if (i != nb_attr - 1)
+                    desc << ", ";
+            }
+            desc << ends;
 
-			if (::strcmp(e.errors[0].reason,DEVICE_UNLOCKED_REASON) == 0)
-				DeviceUnlockedExcept::re_throw_exception(e,(const char*)DEVICE_UNLOCKED_REASON,
-							desc.str(), (const char*)"DeviceProxy::write_attribute()");
-			else
-                Except::re_throw_exception(e,(const char*)API_AttributeFailed,
-                        	desc.str(), (const char*)"DeviceProxy::write_attribute()");
-		}
-		catch (CORBA::TRANSIENT &trans)
-		{
-			TRANSIENT_NOT_EXIST_EXCEPT(trans,"DeviceProxy","write_attributes",this);
-		}
-		catch (CORBA::OBJECT_NOT_EXIST &one)
-		{
-			if (one.minor() == omni::OBJECT_NOT_EXIST_NoMatch || one.minor() == 0)
-			{
-				TRANSIENT_NOT_EXIST_EXCEPT(one,"DeviceProxy","write_attributes",this);
-			}
-			else
-			{
-				set_connection_state(CONNECTION_NOTOK);
-				TangoSys_OMemStream desc;
-				desc << "Failed to execute write_attribute on device " << device_name << ends;
-				ApiCommExcept::re_throw_exception(one,
-							      (const char*)"API_CommunicationFailed",
-                        				      desc.str(),
-							      (const char*)"DeviceProxy::write_attributes()");
-			}
-		}
-		catch (CORBA::COMM_FAILURE &comm)
-		{
-			if (comm.minor() == omni::COMM_FAILURE_WaitingForReply)
-			{
-				TRANSIENT_NOT_EXIST_EXCEPT(comm,"DeviceProxy","write_attributes",this);
-			}
-			else
-			{
-				set_connection_state(CONNECTION_NOTOK);
-				TangoSys_OMemStream desc;
-				desc << "Failed to execute write_attribute on device " << device_name << ends;
-				ApiCommExcept::re_throw_exception(comm,
-							      (const char*)"API_CommunicationFailed",
-                        				      desc.str(),
-							      (const char*)"DeviceProxy::write_attributes()");
-			}
-		}
+            if (::strcmp(e.errors[0].reason, DEVICE_UNLOCKED_REASON) == 0)
+                DeviceUnlockedExcept::re_throw_exception(e, (const char *) DEVICE_UNLOCKED_REASON,
+                                                         desc.str(), (const char *) "DeviceProxy::write_attribute()");
+            else
+                Except::re_throw_exception(e, (const char *) API_AttributeFailed,
+                                           desc.str(), (const char *) "DeviceProxy::write_attribute()");
+        }
+        catch (CORBA::TRANSIENT &trans)
+        {
+            TRANSIENT_NOT_EXIST_EXCEPT(trans, "DeviceProxy", "write_attributes", this);
+        }
+        catch (CORBA::OBJECT_NOT_EXIST &one)
+        {
+            if (one.minor() == omni::OBJECT_NOT_EXIST_NoMatch || one.minor() == 0)
+            {
+                TRANSIENT_NOT_EXIST_EXCEPT(one, "DeviceProxy", "write_attributes", this);
+            }
+            else
+            {
+                set_connection_state(CONNECTION_NOTOK);
+                TangoSys_OMemStream desc;
+                desc << "Failed to execute write_attribute on device " << device_name << ends;
+                ApiCommExcept::re_throw_exception(one,
+                                                  (const char *) "API_CommunicationFailed",
+                                                  desc.str(),
+                                                  (const char *) "DeviceProxy::write_attributes()");
+            }
+        }
+        catch (CORBA::COMM_FAILURE &comm)
+        {
+            if (comm.minor() == omni::COMM_FAILURE_WaitingForReply)
+            {
+                TRANSIENT_NOT_EXIST_EXCEPT(comm, "DeviceProxy", "write_attributes", this);
+            }
+            else
+            {
+                set_connection_state(CONNECTION_NOTOK);
+                TangoSys_OMemStream desc;
+                desc << "Failed to execute write_attribute on device " << device_name << ends;
+                ApiCommExcept::re_throw_exception(comm,
+                                                  (const char *) "API_CommunicationFailed",
+                                                  desc.str(),
+                                                  (const char *) "DeviceProxy::write_attributes()");
+            }
+        }
         catch (CORBA::SystemException &ce)
         {
-			set_connection_state(CONNECTION_NOTOK);
+            set_connection_state(CONNECTION_NOTOK);
 
-			TangoSys_OMemStream desc;
-			desc << "Failed to execute write_attributes on device " << device_name << ends;
-			ApiCommExcept::re_throw_exception(ce,
-						      (const char*)"API_CommunicationFailed",
-                        			      desc.str(),
-						      (const char*)"DeviceProxy::write_attributes()");
-		}
-	}
+            TangoSys_OMemStream desc;
+            desc << "Failed to execute write_attributes on device " << device_name << ends;
+            ApiCommExcept::re_throw_exception(ce,
+                                              (const char *) "API_CommunicationFailed",
+                                              desc.str(),
+                                              (const char *) "DeviceProxy::write_attributes()");
+        }
+    }
 
-	return;
+    return;
 }
 
 //-----------------------------------------------------------------------------
@@ -6183,229 +6230,229 @@ void DeviceProxy::write_attributes(vector<DeviceAttribute>& attr_list)
 
 void DeviceProxy::write_attribute(DeviceAttribute &dev_attr)
 {
-	AttributeValueList attr_value_list;
-	AttributeValueList_4 attr_value_list_4;
-	Tango::AccessControlType local_act;
+    AttributeValueList attr_value_list;
+    AttributeValueList_4 attr_value_list_4;
+    Tango::AccessControlType local_act;
 
     if (version == 0)
         check_and_reconnect(local_act);
 
-	if (version >= 4)
-	{
-		attr_value_list_4.length(1);
+    if (version >= 4)
+    {
+        attr_value_list_4.length(1);
 
-		attr_value_list_4[0].name = dev_attr.name.c_str();
-		attr_value_list_4[0].quality = dev_attr.quality;
-		attr_value_list_4[0].data_format = dev_attr.data_format;
-		attr_value_list_4[0].time = dev_attr.time;
-		attr_value_list_4[0].w_dim.dim_x = dev_attr.dim_x;
-		attr_value_list_4[0].w_dim.dim_y = dev_attr.dim_y;
+        attr_value_list_4[0].name = dev_attr.name.c_str();
+        attr_value_list_4[0].quality = dev_attr.quality;
+        attr_value_list_4[0].data_format = dev_attr.data_format;
+        attr_value_list_4[0].time = dev_attr.time;
+        attr_value_list_4[0].w_dim.dim_x = dev_attr.dim_x;
+        attr_value_list_4[0].w_dim.dim_y = dev_attr.dim_y;
 
-		if (dev_attr.LongSeq.operator->() != NULL)
-			attr_value_list_4[0].value.long_att_value(dev_attr.LongSeq.in());
-		else if (dev_attr.Long64Seq.operator->() != NULL)
-			attr_value_list_4[0].value.long64_att_value(dev_attr.Long64Seq.in());
-		else if (dev_attr.ShortSeq.operator->() != NULL)
-			attr_value_list_4[0].value.short_att_value(dev_attr.ShortSeq.in());
-		else if (dev_attr.DoubleSeq.operator->() != NULL)
-			attr_value_list_4[0].value.double_att_value(dev_attr.DoubleSeq.in());
-		else if (dev_attr.StringSeq.operator->() != NULL)
-			attr_value_list_4[0].value.string_att_value(dev_attr.StringSeq.in());
-		else if (dev_attr.FloatSeq.operator->() != NULL)
-			attr_value_list_4[0].value.float_att_value(dev_attr.FloatSeq.in());
-		else if (dev_attr.BooleanSeq.operator->() != NULL)
-			attr_value_list_4[0].value.bool_att_value(dev_attr.BooleanSeq.in());
-		else if (dev_attr.UShortSeq.operator->() != NULL)
-			attr_value_list_4[0].value.ushort_att_value(dev_attr.UShortSeq.in());
-		else if (dev_attr.UCharSeq.operator->() != NULL)
-			attr_value_list_4[0].value.uchar_att_value(dev_attr.UCharSeq.in());
-		else if (dev_attr.ULongSeq.operator->() != NULL)
-			attr_value_list_4[0].value.ulong_att_value(dev_attr.ULongSeq.in());
-		else if (dev_attr.ULong64Seq.operator->() != NULL)
-			attr_value_list_4[0].value.ulong64_att_value(dev_attr.ULong64Seq.in());
-		else if (dev_attr.StateSeq.operator->() != NULL)
-			attr_value_list_4[0].value.state_att_value(dev_attr.StateSeq.in());
-		else if (dev_attr.EncodedSeq.operator->() != NULL)
-			attr_value_list_4[0].value.encoded_att_value(dev_attr.EncodedSeq.in());
-	}
-	else
-	{
-		attr_value_list.length(1);
+        if (dev_attr.LongSeq.operator->() != NULL)
+            attr_value_list_4[0].value.long_att_value(dev_attr.LongSeq.in());
+        else if (dev_attr.Long64Seq.operator->() != NULL)
+            attr_value_list_4[0].value.long64_att_value(dev_attr.Long64Seq.in());
+        else if (dev_attr.ShortSeq.operator->() != NULL)
+            attr_value_list_4[0].value.short_att_value(dev_attr.ShortSeq.in());
+        else if (dev_attr.DoubleSeq.operator->() != NULL)
+            attr_value_list_4[0].value.double_att_value(dev_attr.DoubleSeq.in());
+        else if (dev_attr.StringSeq.operator->() != NULL)
+            attr_value_list_4[0].value.string_att_value(dev_attr.StringSeq.in());
+        else if (dev_attr.FloatSeq.operator->() != NULL)
+            attr_value_list_4[0].value.float_att_value(dev_attr.FloatSeq.in());
+        else if (dev_attr.BooleanSeq.operator->() != NULL)
+            attr_value_list_4[0].value.bool_att_value(dev_attr.BooleanSeq.in());
+        else if (dev_attr.UShortSeq.operator->() != NULL)
+            attr_value_list_4[0].value.ushort_att_value(dev_attr.UShortSeq.in());
+        else if (dev_attr.UCharSeq.operator->() != NULL)
+            attr_value_list_4[0].value.uchar_att_value(dev_attr.UCharSeq.in());
+        else if (dev_attr.ULongSeq.operator->() != NULL)
+            attr_value_list_4[0].value.ulong_att_value(dev_attr.ULongSeq.in());
+        else if (dev_attr.ULong64Seq.operator->() != NULL)
+            attr_value_list_4[0].value.ulong64_att_value(dev_attr.ULong64Seq.in());
+        else if (dev_attr.StateSeq.operator->() != NULL)
+            attr_value_list_4[0].value.state_att_value(dev_attr.StateSeq.in());
+        else if (dev_attr.EncodedSeq.operator->() != NULL)
+            attr_value_list_4[0].value.encoded_att_value(dev_attr.EncodedSeq.in());
+    }
+    else
+    {
+        attr_value_list.length(1);
 
-		attr_value_list[0].name = dev_attr.name.c_str();
-		attr_value_list[0].quality = dev_attr.quality;
-		attr_value_list[0].time = dev_attr.time;
-		attr_value_list[0].dim_x = dev_attr.dim_x;
-		attr_value_list[0].dim_y = dev_attr.dim_y;
+        attr_value_list[0].name = dev_attr.name.c_str();
+        attr_value_list[0].quality = dev_attr.quality;
+        attr_value_list[0].time = dev_attr.time;
+        attr_value_list[0].dim_x = dev_attr.dim_x;
+        attr_value_list[0].dim_y = dev_attr.dim_y;
 
-		if (dev_attr.LongSeq.operator->() != NULL)
-			attr_value_list[0].value <<= dev_attr.LongSeq.in();
-		else if (dev_attr.Long64Seq.operator->() != NULL)
-			 attr_value_list[0].value <<= dev_attr.Long64Seq.in();
-		else if (dev_attr.ShortSeq.operator->() != NULL)
-			attr_value_list[0].value <<= dev_attr.ShortSeq.in();
-		else if (dev_attr.DoubleSeq.operator->() != NULL)
-			attr_value_list[0].value <<= dev_attr.DoubleSeq.in();
-		else if (dev_attr.StringSeq.operator->() != NULL)
-			attr_value_list[0].value  <<= dev_attr.StringSeq.in();
-		else if (dev_attr.FloatSeq.operator->() != NULL)
-			attr_value_list[0].value <<= dev_attr.FloatSeq.in();
-		else if (dev_attr.BooleanSeq.operator->() != NULL)
-			attr_value_list[0].value <<= dev_attr.BooleanSeq.in();
-		else if (dev_attr.UShortSeq.operator->() != NULL)
-			attr_value_list[0].value  <<= dev_attr.UShortSeq.in();
-		else if (dev_attr.UCharSeq.operator->() != NULL)
-			attr_value_list[0].value  <<= dev_attr.UCharSeq.in();
-		else if (dev_attr.ULongSeq.operator->() != NULL)
-			attr_value_list[0].value <<= dev_attr.ULongSeq.in();
-		else if (dev_attr.ULong64Seq.operator->() != NULL)
-			attr_value_list[0].value <<= dev_attr.ULong64Seq.in();
-		else if (dev_attr.StateSeq.operator->() != NULL)
-			attr_value_list[0].value <<= dev_attr.StateSeq.in();
-	}
+        if (dev_attr.LongSeq.operator->() != NULL)
+            attr_value_list[0].value <<= dev_attr.LongSeq.in();
+        else if (dev_attr.Long64Seq.operator->() != NULL)
+            attr_value_list[0].value <<= dev_attr.Long64Seq.in();
+        else if (dev_attr.ShortSeq.operator->() != NULL)
+            attr_value_list[0].value <<= dev_attr.ShortSeq.in();
+        else if (dev_attr.DoubleSeq.operator->() != NULL)
+            attr_value_list[0].value <<= dev_attr.DoubleSeq.in();
+        else if (dev_attr.StringSeq.operator->() != NULL)
+            attr_value_list[0].value <<= dev_attr.StringSeq.in();
+        else if (dev_attr.FloatSeq.operator->() != NULL)
+            attr_value_list[0].value <<= dev_attr.FloatSeq.in();
+        else if (dev_attr.BooleanSeq.operator->() != NULL)
+            attr_value_list[0].value <<= dev_attr.BooleanSeq.in();
+        else if (dev_attr.UShortSeq.operator->() != NULL)
+            attr_value_list[0].value <<= dev_attr.UShortSeq.in();
+        else if (dev_attr.UCharSeq.operator->() != NULL)
+            attr_value_list[0].value <<= dev_attr.UCharSeq.in();
+        else if (dev_attr.ULongSeq.operator->() != NULL)
+            attr_value_list[0].value <<= dev_attr.ULongSeq.in();
+        else if (dev_attr.ULong64Seq.operator->() != NULL)
+            attr_value_list[0].value <<= dev_attr.ULong64Seq.in();
+        else if (dev_attr.StateSeq.operator->() != NULL)
+            attr_value_list[0].value <<= dev_attr.StateSeq.in();
+    }
 
-	int ctr = 0;
+    int ctr = 0;
 
-	while (ctr < 2)
-	{
-		try
-		{
-			check_and_reconnect(local_act);
+    while (ctr < 2)
+    {
+        try
+        {
+            check_and_reconnect(local_act);
 
 //
 // Throw exception if caller not allowed to write_attribute
 //
 
-			if (local_act == ACCESS_READ)
-			{
-				try
-				{
-					Device_var dev = Device::_duplicate(device);
-					dev->ping();
-				}
-				catch(...)
-				{
-					set_connection_state(CONNECTION_NOTOK);
-					throw;
-				}
+            if (local_act == ACCESS_READ)
+            {
+                try
+                {
+                    Device_var dev = Device::_duplicate(device);
+                    dev->ping();
+                }
+                catch (...)
+                {
+                    set_connection_state(CONNECTION_NOTOK);
+                    throw;
+                }
 
-				TangoSys_OMemStream desc;
-				desc << "Writing attribute(s) on device " << dev_name() << " is not authorized" << ends;
+                TangoSys_OMemStream desc;
+                desc << "Writing attribute(s) on device " << dev_name() << " is not authorized" << ends;
 
-				NotAllowedExcept::throw_exception((const char *)API_ReadOnlyMode,desc.str(),
-											  	  (const char *)"DeviceProxy::write_attribute()");
-			}
+                NotAllowedExcept::throw_exception((const char *) API_ReadOnlyMode, desc.str(),
+                                                  (const char *) "DeviceProxy::write_attribute()");
+            }
 
 //
 // Now, write the attribute(s)
 //
 
-			if (version >= 4)
-			{
-				ClntIdent ci;
-				ApiUtil *au = ApiUtil::instance();
-				ci.cpp_clnt(au->get_client_pid());
+            if (version >= 4)
+            {
+                ClntIdent ci;
+                ApiUtil *au = ApiUtil::instance();
+                ci.cpp_clnt(au->get_client_pid());
 
-				Device_4_var dev = Device_4::_duplicate(device_4);
-				dev->write_attributes_4(attr_value_list_4,ci);
-			}
-			else if (version == 3)
-			{
-				Device_3_var dev = Device_3::_duplicate(device_3);
-				dev->write_attributes_3(attr_value_list);
-			}
-			else
-			{
-				Device_var dev = Device::_duplicate(device);
-				dev->write_attributes(attr_value_list);
-			}
-			ctr = 2;
+                Device_4_var dev = Device_4::_duplicate(device_4);
+                dev->write_attributes_4(attr_value_list_4, ci);
+            }
+            else if (version == 3)
+            {
+                Device_3_var dev = Device_3::_duplicate(device_3);
+                dev->write_attributes_3(attr_value_list);
+            }
+            else
+            {
+                Device_var dev = Device::_duplicate(device);
+                dev->write_attributes(attr_value_list);
+            }
+            ctr = 2;
 
-		}
-		catch (Tango::MultiDevFailed &e)
-		{
+        }
+        catch (Tango::MultiDevFailed &e)
+        {
 
 //
 // Transfer this exception into a DevFailed exception
 //
 
-			Tango::DevFailed ex(e.errors[0].err_list);
-			TangoSys_OMemStream desc;
-			desc << "Failed to write_attribute on device " << device_name;
-			desc << ", attribute ";
-			desc << dev_attr.name;
-			desc << ends;
-                	Except::re_throw_exception(ex,(const char*)API_AttributeFailed,
-                        	desc.str(), (const char*)"DeviceProxy::write_attribute()");
+            Tango::DevFailed ex(e.errors[0].err_list);
+            TangoSys_OMemStream desc;
+            desc << "Failed to write_attribute on device " << device_name;
+            desc << ", attribute ";
+            desc << dev_attr.name;
+            desc << ends;
+            Except::re_throw_exception(ex, (const char *) API_AttributeFailed,
+                                       desc.str(), (const char *) "DeviceProxy::write_attribute()");
 
-		}
-		catch (Tango::DevFailed &e)
-		{
-			TangoSys_OMemStream desc;
-			desc << "Failed to write_attribute on device " << device_name;
-			desc << ", attribute ";
-			desc << dev_attr.name;
-			desc << ends;
+        }
+        catch (Tango::DevFailed &e)
+        {
+            TangoSys_OMemStream desc;
+            desc << "Failed to write_attribute on device " << device_name;
+            desc << ", attribute ";
+            desc << dev_attr.name;
+            desc << ends;
 
-			if (::strcmp(e.errors[0].reason,DEVICE_UNLOCKED_REASON) == 0)
-				DeviceUnlockedExcept::re_throw_exception(e,(const char*)DEVICE_UNLOCKED_REASON,
-							desc.str(), (const char*)"DeviceProxy::write_attribute()");
-			else
-            	Except::re_throw_exception(e,(const char*)API_AttributeFailed,
-                        	desc.str(), (const char*)"DeviceProxy::write_attribute()");
-		}
-		catch (CORBA::TRANSIENT &trans)
-		{
-			TRANSIENT_NOT_EXIST_EXCEPT(trans,"DeviceProxy","write_attribute()",this);
-		}
-		catch (CORBA::OBJECT_NOT_EXIST &one)
-		{
-			if (one.minor() == omni::OBJECT_NOT_EXIST_NoMatch || one.minor() == 0)
-			{
-				TRANSIENT_NOT_EXIST_EXCEPT(one,"DeviceProxy","write_attribute",this);
-			}
-			else
-			{
-				set_connection_state(CONNECTION_NOTOK);
-				TangoSys_OMemStream desc;
-				desc << "Failed to execute write_attribute on device " << device_name << ends;
-				ApiCommExcept::re_throw_exception(one,
-							      (const char*)"API_CommunicationFailed",
-                        				      desc.str(),
-							      (const char*)"DeviceProxy::write_attribute()");
-			}
-		}
-		catch (CORBA::COMM_FAILURE &comm)
-		{
-			if (comm.minor() == omni::COMM_FAILURE_WaitingForReply)
-			{
-				TRANSIENT_NOT_EXIST_EXCEPT(comm,"DeviceProxy","write_attribute",this);
-			}
-			else
-			{
-				set_connection_state(CONNECTION_NOTOK);
-				TangoSys_OMemStream desc;
-				desc << "Failed to execute write_attribute on device " << device_name << ends;
-				ApiCommExcept::re_throw_exception(comm,
-							      (const char*)"API_CommunicationFailed",
-                        				      desc.str(),
-							      (const char*)"DeviceProxy::write_attribute()");
-			}
-		}
+            if (::strcmp(e.errors[0].reason, DEVICE_UNLOCKED_REASON) == 0)
+                DeviceUnlockedExcept::re_throw_exception(e, (const char *) DEVICE_UNLOCKED_REASON,
+                                                         desc.str(), (const char *) "DeviceProxy::write_attribute()");
+            else
+                Except::re_throw_exception(e, (const char *) API_AttributeFailed,
+                                           desc.str(), (const char *) "DeviceProxy::write_attribute()");
+        }
+        catch (CORBA::TRANSIENT &trans)
+        {
+            TRANSIENT_NOT_EXIST_EXCEPT(trans, "DeviceProxy", "write_attribute()", this);
+        }
+        catch (CORBA::OBJECT_NOT_EXIST &one)
+        {
+            if (one.minor() == omni::OBJECT_NOT_EXIST_NoMatch || one.minor() == 0)
+            {
+                TRANSIENT_NOT_EXIST_EXCEPT(one, "DeviceProxy", "write_attribute", this);
+            }
+            else
+            {
+                set_connection_state(CONNECTION_NOTOK);
+                TangoSys_OMemStream desc;
+                desc << "Failed to execute write_attribute on device " << device_name << ends;
+                ApiCommExcept::re_throw_exception(one,
+                                                  (const char *) "API_CommunicationFailed",
+                                                  desc.str(),
+                                                  (const char *) "DeviceProxy::write_attribute()");
+            }
+        }
+        catch (CORBA::COMM_FAILURE &comm)
+        {
+            if (comm.minor() == omni::COMM_FAILURE_WaitingForReply)
+            {
+                TRANSIENT_NOT_EXIST_EXCEPT(comm, "DeviceProxy", "write_attribute", this);
+            }
+            else
+            {
+                set_connection_state(CONNECTION_NOTOK);
+                TangoSys_OMemStream desc;
+                desc << "Failed to execute write_attribute on device " << device_name << ends;
+                ApiCommExcept::re_throw_exception(comm,
+                                                  (const char *) "API_CommunicationFailed",
+                                                  desc.str(),
+                                                  (const char *) "DeviceProxy::write_attribute()");
+            }
+        }
         catch (CORBA::SystemException &ce)
         {
-			set_connection_state(CONNECTION_NOTOK);
+            set_connection_state(CONNECTION_NOTOK);
 
-			TangoSys_OMemStream desc;
-			desc << "Failed to execute write_attributes on device " << device_name << ends;
-			ApiCommExcept::re_throw_exception(ce,
-						      (const char*)"API_CommunicationFailed",
-                        			      desc.str(),
-						      (const char*)"DeviceProxy::write_attribute()");
-		}
-	}
+            TangoSys_OMemStream desc;
+            desc << "Failed to execute write_attributes on device " << device_name << ends;
+            ApiCommExcept::re_throw_exception(ce,
+                                              (const char *) "API_CommunicationFailed",
+                                              desc.str(),
+                                              (const char *) "DeviceProxy::write_attribute()");
+        }
+    }
 
-	return;
+    return;
 }
 
 //-----------------------------------------------------------------------------
@@ -6417,148 +6464,147 @@ void DeviceProxy::write_attribute(DeviceAttribute &dev_attr)
 void DeviceProxy::write_attribute(const AttributeValueList &attr_val)
 {
 
-	int ctr = 0;
-	Tango::AccessControlType local_act;
+    int ctr = 0;
+    Tango::AccessControlType local_act;
 
-	while (ctr < 2)
-	{
-		try
-		{
-			check_and_reconnect(local_act);
+    while (ctr < 2)
+    {
+        try
+        {
+            check_and_reconnect(local_act);
 
 //
 // Throw exception if caller not allowed to write_attribute
 //
 
-			if (local_act == ACCESS_READ)
-			{
-				try
-				{
-					Device_var dev = Device::_duplicate(device);
-					dev->ping();
-				}
-				catch(...)
-				{
-					set_connection_state(CONNECTION_NOTOK);
-					throw;
-				}
+            if (local_act == ACCESS_READ)
+            {
+                try
+                {
+                    Device_var dev = Device::_duplicate(device);
+                    dev->ping();
+                }
+                catch (...)
+                {
+                    set_connection_state(CONNECTION_NOTOK);
+                    throw;
+                }
 
-				TangoSys_OMemStream desc;
-				desc << "Writing attribute(s) on device " << dev_name() << " is not authorized" << ends;
+                TangoSys_OMemStream desc;
+                desc << "Writing attribute(s) on device " << dev_name() << " is not authorized" << ends;
 
-				NotAllowedExcept::throw_exception((const char *)API_ReadOnlyMode,desc.str(),
-									  	  		(const char *)"DeviceProxy::write_attribute()");
-			}
+                NotAllowedExcept::throw_exception((const char *) API_ReadOnlyMode, desc.str(),
+                                                  (const char *) "DeviceProxy::write_attribute()");
+            }
 
 //
 // Now, write the attribute(s)
 //
 
 
-			if (version >= 3)
-			{
-				Device_3_var dev = Device_3::_duplicate(device_3);
-				dev->write_attributes_3(attr_val);
-			}
-			else
-			{
-				Device_var dev = Device::_duplicate(device);
-				dev->write_attributes(attr_val);
-			}
-			ctr = 2;
+            if (version >= 3)
+            {
+                Device_3_var dev = Device_3::_duplicate(device_3);
+                dev->write_attributes_3(attr_val);
+            }
+            else
+            {
+                Device_var dev = Device::_duplicate(device);
+                dev->write_attributes(attr_val);
+            }
+            ctr = 2;
 
-		}
-		catch (Tango::MultiDevFailed &e)
-		{
+        }
+        catch (Tango::MultiDevFailed &e)
+        {
 
 //
 // Transfer this exception into a DevFailed exception
 //
 
-			Tango::DevFailed ex(e.errors[0].err_list);
-			TangoSys_OMemStream desc;
-			desc << "Failed to write_attribute on device " << device_name;
-			desc << ", attribute ";
-			desc << attr_val[0].name.in();
-			desc << ends;
-                	Except::re_throw_exception(ex,(const char*)API_AttributeFailed,
-                        	desc.str(), (const char*)"DeviceProxy::write_attribute()");
+            Tango::DevFailed ex(e.errors[0].err_list);
+            TangoSys_OMemStream desc;
+            desc << "Failed to write_attribute on device " << device_name;
+            desc << ", attribute ";
+            desc << attr_val[0].name.in();
+            desc << ends;
+            Except::re_throw_exception(ex, (const char *) API_AttributeFailed,
+                                       desc.str(), (const char *) "DeviceProxy::write_attribute()");
 
-		}
-		catch (Tango::DevFailed &e)
-		{
-			TangoSys_OMemStream desc;
-			desc << "Failed to write_attribute on device " << device_name;
-			desc << ", attribute ";
-			desc << attr_val[0].name.in();
-			desc << ends;
+        }
+        catch (Tango::DevFailed &e)
+        {
+            TangoSys_OMemStream desc;
+            desc << "Failed to write_attribute on device " << device_name;
+            desc << ", attribute ";
+            desc << attr_val[0].name.in();
+            desc << ends;
 
-			if (::strcmp(e.errors[0].reason,DEVICE_UNLOCKED_REASON) == 0)
-				DeviceUnlockedExcept::re_throw_exception(e,(const char*)DEVICE_UNLOCKED_REASON,
-							desc.str(), (const char*)"DeviceProxy::write_attribute()");
-			else
-                Except::re_throw_exception(e,(const char*)API_AttributeFailed,
-                        	desc.str(), (const char*)"DeviceProxy::write_attribute()");
-		}
-		catch (CORBA::TRANSIENT &trans)
-		{
-			TRANSIENT_NOT_EXIST_EXCEPT(trans,"DeviceProxy","write_attribute()",this);
-		}
-		catch (CORBA::OBJECT_NOT_EXIST &one)
-		{
-			if (one.minor() == omni::OBJECT_NOT_EXIST_NoMatch || one.minor() == 0)
-			{
-				TRANSIENT_NOT_EXIST_EXCEPT(one,"DeviceProxy","write_attribute",this);
-			}
-			else
-			{
-				set_connection_state(CONNECTION_NOTOK);
-				TangoSys_OMemStream desc;
-				desc << "Failed to execute write_attribute on device " << device_name << ends;
-				ApiCommExcept::re_throw_exception(one,
-							      (const char*)"API_CommunicationFailed",
-                        				      desc.str(),
-							      (const char*)"DeviceProxy::write_attribute()");
-			}
-		}
-		catch (CORBA::COMM_FAILURE &comm)
-		{
-			if (comm.minor() == omni::COMM_FAILURE_WaitingForReply)
-			{
-				TRANSIENT_NOT_EXIST_EXCEPT(comm,"DeviceProxy","write_attribute",this);
-			}
-			else
-			{
-				set_connection_state(CONNECTION_NOTOK);
-				TangoSys_OMemStream desc;
-				desc << "Failed to execute write_attribute on device " << device_name << ends;
-				ApiCommExcept::re_throw_exception(comm,
-							      (const char*)"API_CommunicationFailed",
-                        				      desc.str(),
-							      (const char*)"DeviceProxy::write_attribute()");
-			}
-		}
+            if (::strcmp(e.errors[0].reason, DEVICE_UNLOCKED_REASON) == 0)
+                DeviceUnlockedExcept::re_throw_exception(e, (const char *) DEVICE_UNLOCKED_REASON,
+                                                         desc.str(), (const char *) "DeviceProxy::write_attribute()");
+            else
+                Except::re_throw_exception(e, (const char *) API_AttributeFailed,
+                                           desc.str(), (const char *) "DeviceProxy::write_attribute()");
+        }
+        catch (CORBA::TRANSIENT &trans)
+        {
+            TRANSIENT_NOT_EXIST_EXCEPT(trans, "DeviceProxy", "write_attribute()", this);
+        }
+        catch (CORBA::OBJECT_NOT_EXIST &one)
+        {
+            if (one.minor() == omni::OBJECT_NOT_EXIST_NoMatch || one.minor() == 0)
+            {
+                TRANSIENT_NOT_EXIST_EXCEPT(one, "DeviceProxy", "write_attribute", this);
+            }
+            else
+            {
+                set_connection_state(CONNECTION_NOTOK);
+                TangoSys_OMemStream desc;
+                desc << "Failed to execute write_attribute on device " << device_name << ends;
+                ApiCommExcept::re_throw_exception(one,
+                                                  (const char *) "API_CommunicationFailed",
+                                                  desc.str(),
+                                                  (const char *) "DeviceProxy::write_attribute()");
+            }
+        }
+        catch (CORBA::COMM_FAILURE &comm)
+        {
+            if (comm.minor() == omni::COMM_FAILURE_WaitingForReply)
+            {
+                TRANSIENT_NOT_EXIST_EXCEPT(comm, "DeviceProxy", "write_attribute", this);
+            }
+            else
+            {
+                set_connection_state(CONNECTION_NOTOK);
+                TangoSys_OMemStream desc;
+                desc << "Failed to execute write_attribute on device " << device_name << ends;
+                ApiCommExcept::re_throw_exception(comm,
+                                                  (const char *) "API_CommunicationFailed",
+                                                  desc.str(),
+                                                  (const char *) "DeviceProxy::write_attribute()");
+            }
+        }
         catch (CORBA::SystemException &ce)
         {
-			set_connection_state(CONNECTION_NOTOK);
+            set_connection_state(CONNECTION_NOTOK);
 
-			TangoSys_OMemStream desc;
-			desc << "Failed to execute write_attributes on device " << device_name << ends;
-			ApiCommExcept::re_throw_exception(ce,
-						      (const char*)"API_CommunicationFailed",
-                        			      desc.str(),
-						      (const char*)"DeviceProxy::write_attribute()");
-		}
-	}
+            TangoSys_OMemStream desc;
+            desc << "Failed to execute write_attributes on device " << device_name << ends;
+            ApiCommExcept::re_throw_exception(ce,
+                                              (const char *) "API_CommunicationFailed",
+                                              desc.str(),
+                                              (const char *) "DeviceProxy::write_attribute()");
+        }
+    }
 
-	return;
+    return;
 }
-
 
 void DeviceProxy::write_attribute(const AttributeValueList_4 &attr_val)
 {
 
-	Tango::AccessControlType local_act;
+    Tango::AccessControlType local_act;
 
     if (version == 0)
         check_and_reconnect(local_act);
@@ -6567,147 +6613,147 @@ void DeviceProxy::write_attribute(const AttributeValueList_4 &attr_val)
 // Check that the device supports IDL V4
 //
 
-	if (version < 4)
-	{
-		TangoSys_OMemStream desc;
-		desc << "Failed to write_attribute on device " << device_name;
-		desc << ", attribute ";
-		desc << attr_val[0].name.in();
-		desc << ". The device does not support thi stype of data (Bad IDL release)";
-		desc << ends;
-		Tango::Except::throw_exception((const char*)API_NotSupportedFeature,
-                    	desc.str(), (const char*)"DeviceProxy::write_attribute()");
-	}
+    if (version < 4)
+    {
+        TangoSys_OMemStream desc;
+        desc << "Failed to write_attribute on device " << device_name;
+        desc << ", attribute ";
+        desc << attr_val[0].name.in();
+        desc << ". The device does not support thi stype of data (Bad IDL release)";
+        desc << ends;
+        Tango::Except::throw_exception((const char *) API_NotSupportedFeature,
+                                       desc.str(), (const char *) "DeviceProxy::write_attribute()");
+    }
 
-	int ctr = 0;
+    int ctr = 0;
 
-	while (ctr < 2)
-	{
-		try
-		{
-			check_and_reconnect(local_act);
+    while (ctr < 2)
+    {
+        try
+        {
+            check_and_reconnect(local_act);
 
 //
 // Throw exception if caller not allowed to write_attribute
 //
 
-			if (local_act == ACCESS_READ)
-			{
-				try
-				{
-					Device_var dev = Device::_duplicate(device);
-					dev->ping();
-				}
-				catch(...)
-				{
-					set_connection_state(CONNECTION_NOTOK);
-					throw;
-				}
+            if (local_act == ACCESS_READ)
+            {
+                try
+                {
+                    Device_var dev = Device::_duplicate(device);
+                    dev->ping();
+                }
+                catch (...)
+                {
+                    set_connection_state(CONNECTION_NOTOK);
+                    throw;
+                }
 
-				TangoSys_OMemStream desc;
-				desc << "Writing attribute(s) on device " << dev_name() << " is not authorized" << ends;
+                TangoSys_OMemStream desc;
+                desc << "Writing attribute(s) on device " << dev_name() << " is not authorized" << ends;
 
-				NotAllowedExcept::throw_exception((const char *)API_ReadOnlyMode,desc.str(),
-									  	  		(const char *)"DeviceProxy::write_attribute()");
-			}
+                NotAllowedExcept::throw_exception((const char *) API_ReadOnlyMode, desc.str(),
+                                                  (const char *) "DeviceProxy::write_attribute()");
+            }
 
 //
 // Now, write the attribute(s)
 //
 
-			ClntIdent ci;
-			ApiUtil *au = ApiUtil::instance();
-			ci.cpp_clnt(au->get_client_pid());
+            ClntIdent ci;
+            ApiUtil *au = ApiUtil::instance();
+            ci.cpp_clnt(au->get_client_pid());
 
-			Device_4_var dev = Device_4::_duplicate(device_4);
-			dev->write_attributes_4(attr_val,ci);
-			ctr = 2;
+            Device_4_var dev = Device_4::_duplicate(device_4);
+            dev->write_attributes_4(attr_val, ci);
+            ctr = 2;
 
-		}
-		catch (Tango::MultiDevFailed &e)
-		{
+        }
+        catch (Tango::MultiDevFailed &e)
+        {
 
 //
 // Transfer this exception into a DevFailed exception
 //
 
-			Tango::DevFailed ex(e.errors[0].err_list);
-			TangoSys_OMemStream desc;
-			desc << "Failed to write_attribute on device " << device_name;
-			desc << ", attribute ";
-			desc << attr_val[0].name.in();
-			desc << ends;
-                	Except::re_throw_exception(ex,(const char*)API_AttributeFailed,
-                        	desc.str(), (const char*)"DeviceProxy::write_attribute()");
+            Tango::DevFailed ex(e.errors[0].err_list);
+            TangoSys_OMemStream desc;
+            desc << "Failed to write_attribute on device " << device_name;
+            desc << ", attribute ";
+            desc << attr_val[0].name.in();
+            desc << ends;
+            Except::re_throw_exception(ex, (const char *) API_AttributeFailed,
+                                       desc.str(), (const char *) "DeviceProxy::write_attribute()");
 
-		}
-		catch (Tango::DevFailed &e)
-		{
-			TangoSys_OMemStream desc;
-			desc << "Failed to write_attribute on device " << device_name;
-			desc << ", attribute ";
-			desc << attr_val[0].name.in();
-			desc << ends;
+        }
+        catch (Tango::DevFailed &e)
+        {
+            TangoSys_OMemStream desc;
+            desc << "Failed to write_attribute on device " << device_name;
+            desc << ", attribute ";
+            desc << attr_val[0].name.in();
+            desc << ends;
 
-			if (::strcmp(e.errors[0].reason,DEVICE_UNLOCKED_REASON) == 0)
-				DeviceUnlockedExcept::re_throw_exception(e,(const char*)DEVICE_UNLOCKED_REASON,
-							desc.str(), (const char*)"DeviceProxy::write_attribute()");
-			else
-                Except::re_throw_exception(e,(const char*)API_AttributeFailed,
-                        	desc.str(), (const char*)"DeviceProxy::write_attribute()");
-		}
-		catch (CORBA::TRANSIENT &trans)
-		{
-			TRANSIENT_NOT_EXIST_EXCEPT(trans,"DeviceProxy","write_attribute()",this);
-		}
-		catch (CORBA::OBJECT_NOT_EXIST &one)
-		{
-			if (one.minor() == omni::OBJECT_NOT_EXIST_NoMatch || one.minor() == 0)
-			{
-				TRANSIENT_NOT_EXIST_EXCEPT(one,"DeviceProxy","write_attribute",this);
-			}
-			else
-			{
-				set_connection_state(CONNECTION_NOTOK);
-				TangoSys_OMemStream desc;
-				desc << "Failed to execute write_attribute on device " << device_name << ends;
-				ApiCommExcept::re_throw_exception(one,
-							      (const char*)"API_CommunicationFailed",
-                        				      desc.str(),
-							      (const char*)"DeviceProxy::write_attribute()");
-			}
-		}
-		catch (CORBA::COMM_FAILURE &comm)
-		{
-			if (comm.minor() == omni::COMM_FAILURE_WaitingForReply)
-			{
-				TRANSIENT_NOT_EXIST_EXCEPT(comm,"DeviceProxy","write_attribute",this);
-			}
-			else
-			{
-				set_connection_state(CONNECTION_NOTOK);
-				TangoSys_OMemStream desc;
-				desc << "Failed to execute write_attribute on device " << device_name << ends;
-				ApiCommExcept::re_throw_exception(comm,
-							      (const char*)"API_CommunicationFailed",
-                        				      desc.str(),
-							      (const char*)"DeviceProxy::write_attribute()");
-			}
-		}
+            if (::strcmp(e.errors[0].reason, DEVICE_UNLOCKED_REASON) == 0)
+                DeviceUnlockedExcept::re_throw_exception(e, (const char *) DEVICE_UNLOCKED_REASON,
+                                                         desc.str(), (const char *) "DeviceProxy::write_attribute()");
+            else
+                Except::re_throw_exception(e, (const char *) API_AttributeFailed,
+                                           desc.str(), (const char *) "DeviceProxy::write_attribute()");
+        }
+        catch (CORBA::TRANSIENT &trans)
+        {
+            TRANSIENT_NOT_EXIST_EXCEPT(trans, "DeviceProxy", "write_attribute()", this);
+        }
+        catch (CORBA::OBJECT_NOT_EXIST &one)
+        {
+            if (one.minor() == omni::OBJECT_NOT_EXIST_NoMatch || one.minor() == 0)
+            {
+                TRANSIENT_NOT_EXIST_EXCEPT(one, "DeviceProxy", "write_attribute", this);
+            }
+            else
+            {
+                set_connection_state(CONNECTION_NOTOK);
+                TangoSys_OMemStream desc;
+                desc << "Failed to execute write_attribute on device " << device_name << ends;
+                ApiCommExcept::re_throw_exception(one,
+                                                  (const char *) "API_CommunicationFailed",
+                                                  desc.str(),
+                                                  (const char *) "DeviceProxy::write_attribute()");
+            }
+        }
+        catch (CORBA::COMM_FAILURE &comm)
+        {
+            if (comm.minor() == omni::COMM_FAILURE_WaitingForReply)
+            {
+                TRANSIENT_NOT_EXIST_EXCEPT(comm, "DeviceProxy", "write_attribute", this);
+            }
+            else
+            {
+                set_connection_state(CONNECTION_NOTOK);
+                TangoSys_OMemStream desc;
+                desc << "Failed to execute write_attribute on device " << device_name << ends;
+                ApiCommExcept::re_throw_exception(comm,
+                                                  (const char *) "API_CommunicationFailed",
+                                                  desc.str(),
+                                                  (const char *) "DeviceProxy::write_attribute()");
+            }
+        }
         catch (CORBA::SystemException &ce)
         {
-			set_connection_state(CONNECTION_NOTOK);
+            set_connection_state(CONNECTION_NOTOK);
 
-			TangoSys_OMemStream desc;
-			desc << "Failed to execute write_attributes on device " << device_name << ends;
-			ApiCommExcept::re_throw_exception(ce,
-						      (const char*)"API_CommunicationFailed",
-                        			      desc.str(),
-						      (const char*)"DeviceProxy::write_attribute()");
-		}
-	}
+            TangoSys_OMemStream desc;
+            desc << "Failed to execute write_attributes on device " << device_name << ends;
+            ApiCommExcept::re_throw_exception(ce,
+                                              (const char *) "API_CommunicationFailed",
+                                              desc.str(),
+                                              (const char *) "DeviceProxy::write_attribute()");
+        }
+    }
 
-	return;
+    return;
 }
 
 //-----------------------------------------------------------------------------
@@ -6718,21 +6764,21 @@ void DeviceProxy::write_attribute(const AttributeValueList_4 &attr_val)
 
 vector<string> *DeviceProxy::get_attribute_list()
 {
-	vector<string> all_attr;
-	AttributeInfoListEx * all_attr_config;
+    vector<string> all_attr;
+    AttributeInfoListEx *all_attr_config;
 
-	all_attr.push_back(AllAttr_3);
-	all_attr_config = get_attribute_config_ex(all_attr);
+    all_attr.push_back(AllAttr_3);
+    all_attr_config = get_attribute_config_ex(all_attr);
 
-	vector<string> *attr_list = new vector<string>;
-	attr_list->resize(all_attr_config->size());
-	for (unsigned int i=0; i<all_attr_config->size(); i++)
-	{
-		(*attr_list)[i] = (*all_attr_config)[i].name;
-	}
-	delete all_attr_config;
+    vector<string> *attr_list = new vector<string>;
+    attr_list->resize(all_attr_config->size());
+    for (unsigned int i = 0; i < all_attr_config->size(); i++)
+    {
+        (*attr_list)[i] = (*all_attr_config)[i].name;
+    }
+    delete all_attr_config;
 
-	return attr_list;
+    return attr_list;
 }
 
 //-----------------------------------------------------------------------------
@@ -6743,13 +6789,13 @@ vector<string> *DeviceProxy::get_attribute_list()
 
 AttributeInfoList *DeviceProxy::attribute_list_query()
 {
-	vector<string> all_attr;
-	AttributeInfoList *all_attr_config;
+    vector<string> all_attr;
+    AttributeInfoList *all_attr_config;
 
-	all_attr.push_back(AllAttr_3);
-	all_attr_config = get_attribute_config(all_attr);
+    all_attr.push_back(AllAttr_3);
+    all_attr_config = get_attribute_config(all_attr);
 
-	return all_attr_config;
+    return all_attr_config;
 }
 
 //-----------------------------------------------------------------------------
@@ -6760,13 +6806,13 @@ AttributeInfoList *DeviceProxy::attribute_list_query()
 
 AttributeInfoListEx *DeviceProxy::attribute_list_query_ex()
 {
-	vector<string> all_attr;
-	AttributeInfoListEx *all_attr_config;
+    vector<string> all_attr;
+    AttributeInfoListEx *all_attr_config;
 
-	all_attr.push_back(AllAttr_3);
-	all_attr_config = get_attribute_config_ex(all_attr);
+    all_attr.push_back(AllAttr_3);
+    all_attr_config = get_attribute_config_ex(all_attr);
 
-	return all_attr_config;
+    return all_attr_config;
 }
 
 //-----------------------------------------------------------------------------
@@ -6775,116 +6821,116 @@ AttributeInfoListEx *DeviceProxy::attribute_list_query_ex()
 //
 //-----------------------------------------------------------------------------
 
-vector<DeviceDataHistory> *DeviceProxy::command_history(string &cmd_name,int depth)
+vector<DeviceDataHistory> *DeviceProxy::command_history(string &cmd_name, int depth)
 {
-	if (version == 1)
-	{
-		TangoSys_OMemStream desc;
-		desc << "Device " << device_name;
-		desc << " does not support command_history feature" << ends;
-		ApiNonSuppExcept::throw_exception((const char *)API_UnsupportedFeature,
-						  desc.str(),
-						  (const char *)"DeviceProxy::command_history");
-	}
+    if (version == 1)
+    {
+        TangoSys_OMemStream desc;
+        desc << "Device " << device_name;
+        desc << " does not support command_history feature" << ends;
+        ApiNonSuppExcept::throw_exception((const char *) API_UnsupportedFeature,
+                                          desc.str(),
+                                          (const char *) "DeviceProxy::command_history");
+    }
 
-	DevCmdHistoryList *hist = NULL;
-	DevCmdHistory_4_var hist_4 = NULL;
+    DevCmdHistoryList *hist = NULL;
+    DevCmdHistory_4_var hist_4 = NULL;
 
-	int ctr = 0;
+    int ctr = 0;
 
-	while (ctr < 2)
-	{
-		try
-		{
-			check_and_reconnect();
+    while (ctr < 2)
+    {
+        try
+        {
+            check_and_reconnect();
 
-			if (version <= 3)
-			{
-				Device_2_var dev = Device_2::_duplicate(device_2);
-				hist = dev->command_inout_history_2(cmd_name.c_str(),depth);
-			}
-			else
-			{
-				Device_4_var dev = Device_4::_duplicate(device_4);
-				hist_4 = dev->command_inout_history_4(cmd_name.c_str(),depth);
-			}
-			ctr = 2;
-		}
-		catch (CORBA::TRANSIENT &trans)
-		{
-			TRANSIENT_NOT_EXIST_EXCEPT(trans,"DeviceProxy","command_history",this);
-		}
-		catch (CORBA::OBJECT_NOT_EXIST &one)
-		{
-			if (one.minor() == omni::OBJECT_NOT_EXIST_NoMatch || one.minor() == 0)
-			{
-				TRANSIENT_NOT_EXIST_EXCEPT(one,"DeviceProxy","command_history",this);
-			}
-			else
-			{
-				set_connection_state(CONNECTION_NOTOK);
-				TangoSys_OMemStream desc;
-				desc << "Command_history failed on device " << device_name << ends;
-				ApiCommExcept::re_throw_exception(one,
-							      (const char*)"API_CommunicationFailed",
-                        				      desc.str(),
-							      (const char*)"DeviceProxy::command_history()");
-			}
-		}
-		catch (CORBA::COMM_FAILURE &comm)
-		{
-			if (comm.minor() == omni::COMM_FAILURE_WaitingForReply)
-			{
-				TRANSIENT_NOT_EXIST_EXCEPT(comm,"DeviceProxy","command_history",this);
-			}
-			else
-			{
-				set_connection_state(CONNECTION_NOTOK);
-				TangoSys_OMemStream desc;
-				desc << "Command_history failed on device " << device_name << ends;
-				ApiCommExcept::re_throw_exception(comm,
-							      (const char*)"API_CommunicationFailed",
-                        				      desc.str(),
-							      (const char*)"DeviceProxy::command_history()");
-			}
-		}
+            if (version <= 3)
+            {
+                Device_2_var dev = Device_2::_duplicate(device_2);
+                hist = dev->command_inout_history_2(cmd_name.c_str(), depth);
+            }
+            else
+            {
+                Device_4_var dev = Device_4::_duplicate(device_4);
+                hist_4 = dev->command_inout_history_4(cmd_name.c_str(), depth);
+            }
+            ctr = 2;
+        }
+        catch (CORBA::TRANSIENT &trans)
+        {
+            TRANSIENT_NOT_EXIST_EXCEPT(trans, "DeviceProxy", "command_history", this);
+        }
+        catch (CORBA::OBJECT_NOT_EXIST &one)
+        {
+            if (one.minor() == omni::OBJECT_NOT_EXIST_NoMatch || one.minor() == 0)
+            {
+                TRANSIENT_NOT_EXIST_EXCEPT(one, "DeviceProxy", "command_history", this);
+            }
+            else
+            {
+                set_connection_state(CONNECTION_NOTOK);
+                TangoSys_OMemStream desc;
+                desc << "Command_history failed on device " << device_name << ends;
+                ApiCommExcept::re_throw_exception(one,
+                                                  (const char *) "API_CommunicationFailed",
+                                                  desc.str(),
+                                                  (const char *) "DeviceProxy::command_history()");
+            }
+        }
+        catch (CORBA::COMM_FAILURE &comm)
+        {
+            if (comm.minor() == omni::COMM_FAILURE_WaitingForReply)
+            {
+                TRANSIENT_NOT_EXIST_EXCEPT(comm, "DeviceProxy", "command_history", this);
+            }
+            else
+            {
+                set_connection_state(CONNECTION_NOTOK);
+                TangoSys_OMemStream desc;
+                desc << "Command_history failed on device " << device_name << ends;
+                ApiCommExcept::re_throw_exception(comm,
+                                                  (const char *) "API_CommunicationFailed",
+                                                  desc.str(),
+                                                  (const char *) "DeviceProxy::command_history()");
+            }
+        }
         catch (CORBA::SystemException &ce)
         {
-			set_connection_state(CONNECTION_NOTOK);
+            set_connection_state(CONNECTION_NOTOK);
 
-			TangoSys_OMemStream desc;
-			desc << "Command_history failed on device " << device_name << ends;
-			ApiCommExcept::re_throw_exception(ce,
-						      (const char*)"API_CommunicationFailed",
-                        			      desc.str(),
-						      (const char*)"DeviceProxy::command_history()");
-		}
-	}
+            TangoSys_OMemStream desc;
+            desc << "Command_history failed on device " << device_name << ends;
+            ApiCommExcept::re_throw_exception(ce,
+                                              (const char *) "API_CommunicationFailed",
+                                              desc.str(),
+                                              (const char *) "DeviceProxy::command_history()");
+        }
+    }
 
 
-	vector<DeviceDataHistory> *ddh = new vector<DeviceDataHistory>;
+    vector<DeviceDataHistory> *ddh = new vector<DeviceDataHistory>;
 
-	if (version <= 3)
-	{
-		int *ctr_ptr = new int;
-		*ctr_ptr = 0;
+    if (version <= 3)
+    {
+        int *ctr_ptr = new int;
+        *ctr_ptr = 0;
 
-		ddh->reserve(hist->length());
+        ddh->reserve(hist->length());
 
-		for (unsigned int i = 0;i < hist->length();i++)
-		{
-			ddh->push_back(DeviceDataHistory(i,ctr_ptr,hist));
-		}
-	}
-	else
-	{
-		ddh->reserve(hist_4->dates.length());
-		for (unsigned int i = 0;i < hist_4->dates.length();i++)
-			ddh->push_back(DeviceDataHistory());
-		from_hist4_2_DataHistory(hist_4,ddh);
-	}
+        for (unsigned int i = 0; i < hist->length(); i++)
+        {
+            ddh->push_back(DeviceDataHistory(i, ctr_ptr, hist));
+        }
+    }
+    else
+    {
+        ddh->reserve(hist_4->dates.length());
+        for (unsigned int i = 0; i < hist_4->dates.length(); i++)
+            ddh->push_back(DeviceDataHistory());
+        from_hist4_2_DataHistory(hist_4, ddh);
+    }
 
-	return ddh;
+    return ddh;
 
 }
 
@@ -6895,142 +6941,142 @@ vector<DeviceDataHistory> *DeviceProxy::command_history(string &cmd_name,int dep
 //
 //-----------------------------------------------------------------------------
 
-vector<DeviceAttributeHistory> *DeviceProxy::attribute_history(string &cmd_name,int depth)
+vector<DeviceAttributeHistory> *DeviceProxy::attribute_history(string &cmd_name, int depth)
 {
-	if (version == 1)
-	{
-		TangoSys_OMemStream desc;
-		desc << "Device " << device_name;
-		desc << " does not support attribute_history feature" << ends;
-		ApiNonSuppExcept::throw_exception((const char *)API_UnsupportedFeature,
-						  desc.str(),
-						  (const char *)"DeviceProxy::attribute_history");
-	}
+    if (version == 1)
+    {
+        TangoSys_OMemStream desc;
+        desc << "Device " << device_name;
+        desc << " does not support attribute_history feature" << ends;
+        ApiNonSuppExcept::throw_exception((const char *) API_UnsupportedFeature,
+                                          desc.str(),
+                                          (const char *) "DeviceProxy::attribute_history");
+    }
 
-	DevAttrHistoryList_var hist;
-	DevAttrHistoryList_3_var hist_3;
-	DevAttrHistory_4_var hist_4;
-	DevAttrHistory_5_var hist_5;
+    DevAttrHistoryList_var hist;
+    DevAttrHistoryList_3_var hist_3;
+    DevAttrHistory_4_var hist_4;
+    DevAttrHistory_5_var hist_5;
 
-	int ctr = 0;
+    int ctr = 0;
 
-	while (ctr < 2)
-	{
-		try
-		{
-			check_and_reconnect();
+    while (ctr < 2)
+    {
+        try
+        {
+            check_and_reconnect();
 
-			if (version == 2)
-			{
-				Device_2_var dev = Device_2::_duplicate(device_2);
-				hist = device_2->read_attribute_history_2(cmd_name.c_str(),depth);
-			}
-			else
-			{
-				if (version == 3)
-				{
-					Device_3_var dev = Device_3::_duplicate(device_3);
-					hist_3 = dev->read_attribute_history_3(cmd_name.c_str(),depth);
-				}
-				else if (version == 4)
-				{
-					Device_4_var dev = Device_4::_duplicate(device_4);
-					hist_4 = dev->read_attribute_history_4(cmd_name.c_str(),depth);
-				}
-				else
-				{
-					Device_5_var dev = Device_5::_duplicate(device_5);
-					hist_5 = dev->read_attribute_history_5(cmd_name.c_str(),depth);
-				}
-			}
-			ctr = 2;
-		}
-		catch (CORBA::TRANSIENT &trans)
-		{
-			TRANSIENT_NOT_EXIST_EXCEPT(trans,"DeviceProxy","attribute_history",this);
-		}
-		catch (CORBA::OBJECT_NOT_EXIST &one)
-		{
-			if (one.minor() == omni::OBJECT_NOT_EXIST_NoMatch || one.minor() == 0)
-			{
-				TRANSIENT_NOT_EXIST_EXCEPT(one,"DeviceProxy","attribute_history",this);
-			}
-			else
-			{
-				set_connection_state(CONNECTION_NOTOK);
-				TangoSys_OMemStream desc;
-				desc << "Attribute_history failed on device " << device_name << ends;
-				ApiCommExcept::re_throw_exception(one,
-							      (const char*)"API_CommunicationFailed",
-                        				      desc.str(),
-							      (const char*)"DeviceProxy::attribute_history()");
-			}
-		}
-		catch (CORBA::COMM_FAILURE &comm)
-		{
-			if (comm.minor() == omni::COMM_FAILURE_WaitingForReply)
-			{
-				TRANSIENT_NOT_EXIST_EXCEPT(comm,"DeviceProxy","attribute_history",this);
-			}
-			else
-			{
-				set_connection_state(CONNECTION_NOTOK);
-				TangoSys_OMemStream desc;
-				desc << "Attribute_history failed on device " << device_name << ends;
-				ApiCommExcept::re_throw_exception(comm,
-							      (const char*)"API_CommunicationFailed",
-                        				      desc.str(),
-							      (const char*)"DeviceProxy::attribute_history()");
-			}
-		}
+            if (version == 2)
+            {
+                Device_2_var dev = Device_2::_duplicate(device_2);
+                hist = device_2->read_attribute_history_2(cmd_name.c_str(), depth);
+            }
+            else
+            {
+                if (version == 3)
+                {
+                    Device_3_var dev = Device_3::_duplicate(device_3);
+                    hist_3 = dev->read_attribute_history_3(cmd_name.c_str(), depth);
+                }
+                else if (version == 4)
+                {
+                    Device_4_var dev = Device_4::_duplicate(device_4);
+                    hist_4 = dev->read_attribute_history_4(cmd_name.c_str(), depth);
+                }
+                else
+                {
+                    Device_5_var dev = Device_5::_duplicate(device_5);
+                    hist_5 = dev->read_attribute_history_5(cmd_name.c_str(), depth);
+                }
+            }
+            ctr = 2;
+        }
+        catch (CORBA::TRANSIENT &trans)
+        {
+            TRANSIENT_NOT_EXIST_EXCEPT(trans, "DeviceProxy", "attribute_history", this);
+        }
+        catch (CORBA::OBJECT_NOT_EXIST &one)
+        {
+            if (one.minor() == omni::OBJECT_NOT_EXIST_NoMatch || one.minor() == 0)
+            {
+                TRANSIENT_NOT_EXIST_EXCEPT(one, "DeviceProxy", "attribute_history", this);
+            }
+            else
+            {
+                set_connection_state(CONNECTION_NOTOK);
+                TangoSys_OMemStream desc;
+                desc << "Attribute_history failed on device " << device_name << ends;
+                ApiCommExcept::re_throw_exception(one,
+                                                  (const char *) "API_CommunicationFailed",
+                                                  desc.str(),
+                                                  (const char *) "DeviceProxy::attribute_history()");
+            }
+        }
+        catch (CORBA::COMM_FAILURE &comm)
+        {
+            if (comm.minor() == omni::COMM_FAILURE_WaitingForReply)
+            {
+                TRANSIENT_NOT_EXIST_EXCEPT(comm, "DeviceProxy", "attribute_history", this);
+            }
+            else
+            {
+                set_connection_state(CONNECTION_NOTOK);
+                TangoSys_OMemStream desc;
+                desc << "Attribute_history failed on device " << device_name << ends;
+                ApiCommExcept::re_throw_exception(comm,
+                                                  (const char *) "API_CommunicationFailed",
+                                                  desc.str(),
+                                                  (const char *) "DeviceProxy::attribute_history()");
+            }
+        }
         catch (CORBA::SystemException &ce)
         {
-			set_connection_state(CONNECTION_NOTOK);
-			TangoSys_OMemStream desc;
-			desc << "Attribute_history failed on device " << device_name << ends;
-			ApiCommExcept::re_throw_exception(ce,
-						      (const char*)"API_CommunicationFailed",
-                        			      desc.str(),
-						      (const char*)"DeviceProxy::attribute_history()");
-		}
-	}
+            set_connection_state(CONNECTION_NOTOK);
+            TangoSys_OMemStream desc;
+            desc << "Attribute_history failed on device " << device_name << ends;
+            ApiCommExcept::re_throw_exception(ce,
+                                              (const char *) "API_CommunicationFailed",
+                                              desc.str(),
+                                              (const char *) "DeviceProxy::attribute_history()");
+        }
+    }
 
-	vector<DeviceAttributeHistory> *ddh = new vector<DeviceAttributeHistory>;
+    vector<DeviceAttributeHistory> *ddh = new vector<DeviceAttributeHistory>;
 
-	if (version > 4)
-	{
-		ddh->reserve(hist_5->dates.length());
-		for (unsigned int i = 0;i < hist_5->dates.length();i++)
-			ddh->push_back(DeviceAttributeHistory());
-		from_hist_2_AttHistory(hist_5,ddh);
-		for (unsigned int i = 0;i < hist_5->dates.length();i++)
-			(*ddh)[i].data_type = hist_5->data_type;
-	}
-	else if (version == 4)
-	{
-		ddh->reserve(hist_4->dates.length());
-		for (unsigned int i = 0;i < hist_4->dates.length();i++)
-			ddh->push_back(DeviceAttributeHistory());
-		from_hist_2_AttHistory(hist_4,ddh);
-	}
-	else if (version == 3)
-	{
-		ddh->reserve(hist_3->length());
-		for (unsigned int i = 0;i < hist_3->length();i++)
-		{
-			ddh->push_back(DeviceAttributeHistory(i,hist_3));
-		}
-	}
-	else
-	{
-		ddh->reserve(hist->length());
-		for (unsigned int i = 0;i < hist->length();i++)
-		{
-			ddh->push_back(DeviceAttributeHistory(i,hist));
-		}
-	}
+    if (version > 4)
+    {
+        ddh->reserve(hist_5->dates.length());
+        for (unsigned int i = 0; i < hist_5->dates.length(); i++)
+            ddh->push_back(DeviceAttributeHistory());
+        from_hist_2_AttHistory(hist_5, ddh);
+        for (unsigned int i = 0; i < hist_5->dates.length(); i++)
+            (*ddh)[i].data_type = hist_5->data_type;
+    }
+    else if (version == 4)
+    {
+        ddh->reserve(hist_4->dates.length());
+        for (unsigned int i = 0; i < hist_4->dates.length(); i++)
+            ddh->push_back(DeviceAttributeHistory());
+        from_hist_2_AttHistory(hist_4, ddh);
+    }
+    else if (version == 3)
+    {
+        ddh->reserve(hist_3->length());
+        for (unsigned int i = 0; i < hist_3->length(); i++)
+        {
+            ddh->push_back(DeviceAttributeHistory(i, hist_3));
+        }
+    }
+    else
+    {
+        ddh->reserve(hist->length());
+        for (unsigned int i = 0; i < hist->length(); i++)
+        {
+            ddh->push_back(DeviceAttributeHistory(i, hist));
+        }
+    }
 
-	return ddh;
+    return ddh;
 }
 
 //---------------------------------------------------------------------------------------------------------------------
@@ -7045,9 +7091,9 @@ vector<DeviceAttributeHistory> *DeviceProxy::attribute_history(string &cmd_name,
 
 void DeviceProxy::connect_to_adm_device()
 {
-	adm_dev_name = adm_name();
+    adm_dev_name = adm_name();
 
-	adm_device = new DeviceProxy(adm_dev_name);
+    adm_device = new DeviceProxy(adm_dev_name);
 }
 
 //-----------------------------------------------------------------------------
@@ -7058,37 +7104,37 @@ void DeviceProxy::connect_to_adm_device()
 
 vector<string> *DeviceProxy::polling_status()
 {
-	check_connect_adm_device();
+    check_connect_adm_device();
 
-	DeviceData dout,din;
-	string cmd("DevPollStatus");
-	din.any <<= device_name.c_str();
+    DeviceData dout, din;
+    string cmd("DevPollStatus");
+    din.any <<= device_name.c_str();
 
 //
 // In case of connection failed error, do a re-try
 //
 
-	try
-	{
-		dout = adm_device->command_inout(cmd,din);
-	}
-	catch (Tango::CommunicationFailed &)
-	{
-		dout = adm_device->command_inout(cmd,din);
-	}
+    try
+    {
+        dout = adm_device->command_inout(cmd, din);
+    }
+    catch (Tango::CommunicationFailed &)
+    {
+        dout = adm_device->command_inout(cmd, din);
+    }
 
-	const DevVarStringArray *out_str;
-	dout >> out_str;
+    const DevVarStringArray *out_str;
+    dout >> out_str;
 
-	vector<string> *poll_stat = new vector<string>;
-	poll_stat->reserve(out_str->length());
+    vector<string> *poll_stat = new vector<string>;
+    poll_stat->reserve(out_str->length());
 
-	for (unsigned int i = 0;i < out_str->length();i++)
-	{
-		string str = (*out_str)[i].in();
-		poll_stat->push_back(str);
-	}
-	return poll_stat;
+    for (unsigned int i = 0; i < out_str->length(); i++)
+    {
+        string str = (*out_str)[i].in();
+        poll_stat->push_back(str);
+    }
+    return poll_stat;
 }
 
 //-----------------------------------------------------------------------------
@@ -7099,81 +7145,81 @@ vector<string> *DeviceProxy::polling_status()
 //
 //-----------------------------------------------------------------------------
 
-bool DeviceProxy::is_polled(polled_object obj, string &obj_name,string &upd)
+bool DeviceProxy::is_polled(polled_object obj, string &obj_name, string &upd)
 {
-	bool ret = false;
-	vector<string> *poll_str;
+    bool ret = false;
+    vector<string> *poll_str;
 
-	poll_str = polling_status();
-	if (poll_str->empty() == true)
-	{
-		delete poll_str;
-		return ret;
-	}
+    poll_str = polling_status();
+    if (poll_str->empty() == true)
+    {
+        delete poll_str;
+        return ret;
+    }
 
-	string loc_obj_name(obj_name);
-	transform(loc_obj_name.begin(),loc_obj_name.end(),loc_obj_name.begin(),::tolower);
+    string loc_obj_name(obj_name);
+    transform(loc_obj_name.begin(), loc_obj_name.end(), loc_obj_name.begin(), ::tolower);
 
-	for (unsigned int i = 0;i < poll_str->size();i++)
-	{
-		string &tmp_str = (*poll_str)[i];
-		string::size_type pos,end;
-		pos = tmp_str.find(' ');
-		pos++;
-		end = tmp_str.find(' ',pos + 1);
-		string obj_type = tmp_str.substr(pos, end - pos);
-		if (obj_type == "command")
-		{
-			if (obj == Attr)
-				continue;
-		}
-		else if (obj_type == "attribute")
-		{
-			if (obj == Cmd)
-			{
-				if ((loc_obj_name != "state") && (loc_obj_name != "status"))
-					continue;
-			}
-		}
+    for (unsigned int i = 0; i < poll_str->size(); i++)
+    {
+        string &tmp_str = (*poll_str)[i];
+        string::size_type pos, end;
+        pos = tmp_str.find(' ');
+        pos++;
+        end = tmp_str.find(' ', pos + 1);
+        string obj_type = tmp_str.substr(pos, end - pos);
+        if (obj_type == "command")
+        {
+            if (obj == Attr)
+                continue;
+        }
+        else if (obj_type == "attribute")
+        {
+            if (obj == Cmd)
+            {
+                if ((loc_obj_name != "state") && (loc_obj_name != "status"))
+                    continue;
+            }
+        }
 
-		pos = tmp_str.find('=');
-		pos = pos + 2;
-		end = tmp_str.find(". S",pos + 1);
-		if (end == string::npos)
-			end = tmp_str.find('\n',pos + 1);
-		string name = tmp_str.substr(pos, end - pos);
-		transform(name.begin(),name.end(),name.begin(),::tolower);
+        pos = tmp_str.find('=');
+        pos = pos + 2;
+        end = tmp_str.find(". S", pos + 1);
+        if (end == string::npos)
+            end = tmp_str.find('\n', pos + 1);
+        string name = tmp_str.substr(pos, end - pos);
+        transform(name.begin(), name.end(), name.begin(), ::tolower);
 
-		if (name == loc_obj_name)
-		{
+        if (name == loc_obj_name)
+        {
 
 //
 // Now that it's found, search for its polling period
 //
 
-			pos = tmp_str.find("triggered",end);
-			if (pos != string::npos)
-			{
-				ret = true;
-				upd = "0";
-				break;
-			}
-			else
-			{
-				pos = tmp_str.find('=',end);
-				pos = pos + 2;
-				end = tmp_str.find('\n',pos + 1);
-				string per = tmp_str.substr(pos, end - pos);
-				upd = per;
-				ret = true;
-				break;
-			}
-		}
-	}
+            pos = tmp_str.find("triggered", end);
+            if (pos != string::npos)
+            {
+                ret = true;
+                upd = "0";
+                break;
+            }
+            else
+            {
+                pos = tmp_str.find('=', end);
+                pos = pos + 2;
+                end = tmp_str.find('\n', pos + 1);
+                string per = tmp_str.substr(pos, end - pos);
+                upd = per;
+                ret = true;
+                break;
+            }
+        }
+    }
 
-	delete poll_str;
+    delete poll_str;
 
-	return  ret;
+    return ret;
 }
 
 //-----------------------------------------------------------------------------
@@ -7185,21 +7231,21 @@ bool DeviceProxy::is_polled(polled_object obj, string &obj_name,string &upd)
 
 int DeviceProxy::get_command_poll_period(string &cmd_name)
 {
-	string poll_per;
-	bool poll = is_polled(Cmd,cmd_name,poll_per);
+    string poll_per;
+    bool poll = is_polled(Cmd, cmd_name, poll_per);
 
-	int ret;
-	if (poll == true)
-	{
-		TangoSys_MemStream stream;
+    int ret;
+    if (poll == true)
+    {
+        TangoSys_MemStream stream;
 
-		stream << poll_per << ends;
-		stream >> ret;
-	}
-	else
-		ret = 0;
+        stream << poll_per << ends;
+        stream >> ret;
+    }
+    else
+        ret = 0;
 
-	return ret;
+    return ret;
 }
 
 //-----------------------------------------------------------------------------
@@ -7211,21 +7257,21 @@ int DeviceProxy::get_command_poll_period(string &cmd_name)
 
 int DeviceProxy::get_attribute_poll_period(string &attr_name)
 {
-	string poll_per;
-	bool poll = is_polled(Attr,attr_name,poll_per);
+    string poll_per;
+    bool poll = is_polled(Attr, attr_name, poll_per);
 
-	int ret;
-	if (poll == true)
-	{
-		TangoSys_MemStream stream;
+    int ret;
+    if (poll == true)
+    {
+        TangoSys_MemStream stream;
 
-		stream << poll_per << ends;
-		stream >> ret;
-	}
-	else
-		ret = 0;
+        stream << poll_per << ends;
+        stream >> ret;
+    }
+    else
+        ret = 0;
 
-	return ret;
+    return ret;
 }
 
 //-----------------------------------------------------------------------------
@@ -7238,75 +7284,75 @@ int DeviceProxy::get_attribute_poll_period(string &attr_name)
 
 void DeviceProxy::poll_command(string &cmd_name, int period)
 {
-	string poll_per;
-	bool poll = is_polled(Cmd,cmd_name,poll_per);
+    string poll_per;
+    bool poll = is_polled(Cmd, cmd_name, poll_per);
 
-	DevVarLongStringArray in;
-	in.lvalue.length(1);
-	in.svalue.length(3);
+    DevVarLongStringArray in;
+    in.lvalue.length(1);
+    in.svalue.length(3);
 
-	in.svalue[0] = CORBA::string_dup(device_name.c_str());
-	in.svalue[1] = CORBA::string_dup("command");
-	in.svalue[2] = CORBA::string_dup(cmd_name.c_str());
-	in.lvalue[0] = period;
+    in.svalue[0] = CORBA::string_dup(device_name.c_str());
+    in.svalue[1] = CORBA::string_dup("command");
+    in.svalue[2] = CORBA::string_dup(cmd_name.c_str());
+    in.lvalue[0] = period;
 
-	if (poll == true)
-	{
+    if (poll == true)
+    {
 
 //
 // If object is polled and the polling period is the same, simply retruns
 //
-		TangoSys_MemStream stream;
-		int per;
+        TangoSys_MemStream stream;
+        int per;
 
-		stream << poll_per << ends;
-		stream >> per;
+        stream << poll_per << ends;
+        stream >> per;
 
-		if ((per == period) || (per == 0))
-			return;
-		else
-		{
+        if ((per == period) || (per == 0))
+            return;
+        else
+        {
 
 //
 // If object is polled, this is an update of the polling period
 //
 
-			DeviceData din;
-			string cmd("UpdObjPollingPeriod");
-			din.any <<= in;
+            DeviceData din;
+            string cmd("UpdObjPollingPeriod");
+            din.any <<= in;
 
-			try
-			{
-				adm_device->command_inout(cmd,din);
-			}
-			catch (Tango::CommunicationFailed &)
-			{
-				adm_device->command_inout(cmd,din);
-			}
+            try
+            {
+                adm_device->command_inout(cmd, din);
+            }
+            catch (Tango::CommunicationFailed &)
+            {
+                adm_device->command_inout(cmd, din);
+            }
 
-		}
-	}
-	else
-	{
+        }
+    }
+    else
+    {
 
 //
 // This a AddObjPolling command
 //
 
-		DeviceData din;
-		string cmd("AddObjPolling");
-		din.any <<= in;
+        DeviceData din;
+        string cmd("AddObjPolling");
+        din.any <<= in;
 
-		try
-		{
-			adm_device->command_inout(cmd,din);
-		}
-		catch (Tango::CommunicationFailed &)
-		{
-			adm_device->command_inout(cmd,din);
-		}
+        try
+        {
+            adm_device->command_inout(cmd, din);
+        }
+        catch (Tango::CommunicationFailed &)
+        {
+            adm_device->command_inout(cmd, din);
+        }
 
-	}
+    }
 
 }
 
@@ -7320,76 +7366,76 @@ void DeviceProxy::poll_command(string &cmd_name, int period)
 
 void DeviceProxy::poll_attribute(string &attr_name, int period)
 {
-	string poll_per;
-	bool poll = is_polled(Attr,attr_name,poll_per);
+    string poll_per;
+    bool poll = is_polled(Attr, attr_name, poll_per);
 
-	DevVarLongStringArray in;
-	in.lvalue.length(1);
-	in.svalue.length(3);
+    DevVarLongStringArray in;
+    in.lvalue.length(1);
+    in.svalue.length(3);
 
-	in.svalue[0] = CORBA::string_dup(device_name.c_str());
-	in.svalue[1] = CORBA::string_dup("attribute");
-	in.svalue[2] = CORBA::string_dup(attr_name.c_str());
-	in.lvalue[0] = period;
+    in.svalue[0] = CORBA::string_dup(device_name.c_str());
+    in.svalue[1] = CORBA::string_dup("attribute");
+    in.svalue[2] = CORBA::string_dup(attr_name.c_str());
+    in.lvalue[0] = period;
 
-	if (poll == true)
-	{
+    if (poll == true)
+    {
 
 //
 // If object is polled and the polling period is the same, simply returns
 //
 
-		TangoSys_MemStream stream;
-		int per;
+        TangoSys_MemStream stream;
+        int per;
 
-		stream << poll_per << ends;
-		stream >> per;
+        stream << poll_per << ends;
+        stream >> per;
 
-		if ((per == period) || (per == 0))
-			return;
-		else
-		{
+        if ((per == period) || (per == 0))
+            return;
+        else
+        {
 
 //
 // If object is polled, this is an update of the polling period
 //
 
-			DeviceData din;
-			string cmd("UpdObjPollingPeriod");
-			din.any <<= in;
+            DeviceData din;
+            string cmd("UpdObjPollingPeriod");
+            din.any <<= in;
 
-			try
-			{
-				adm_device->command_inout(cmd,din);
-			}
-			catch (Tango::CommunicationFailed &)
-			{
-				adm_device->command_inout(cmd,din);
-			}
+            try
+            {
+                adm_device->command_inout(cmd, din);
+            }
+            catch (Tango::CommunicationFailed &)
+            {
+                adm_device->command_inout(cmd, din);
+            }
 
-		}
-	}
-	else
-	{
+        }
+    }
+    else
+    {
 
 //
 // This a AddObjPolling command
 //
 
-		DeviceData din;
-		string cmd("AddObjPolling");
-		din.any <<= in;
+        DeviceData din;
+        string cmd("AddObjPolling");
+        din.any <<= in;
 
-		try
-		{
-			adm_device->command_inout(cmd,din);
-		}
-		catch (Tango::CommunicationFailed &)
-		{
-			adm_device->command_inout(cmd,din);
-		}
+        try
+        {
+            adm_device->command_inout(cmd, din);
+        }
+        catch (Tango::CommunicationFailed &)
+        {
+            adm_device->command_inout(cmd, din);
+        }
 
-	}
+    }
 
 }
 
@@ -7401,8 +7447,8 @@ void DeviceProxy::poll_attribute(string &attr_name, int period)
 
 bool DeviceProxy::is_command_polled(string &cmd_name)
 {
-	string upd;
-	return is_polled(Cmd,cmd_name,upd);
+    string upd;
+    return is_polled(Cmd, cmd_name, upd);
 }
 
 //-----------------------------------------------------------------------------
@@ -7413,8 +7459,8 @@ bool DeviceProxy::is_command_polled(string &cmd_name)
 
 bool DeviceProxy::is_attribute_polled(string &attr_name)
 {
-	string upd;
-	return is_polled(Attr,attr_name,upd);
+    string upd;
+    return is_polled(Attr, attr_name, upd);
 }
 
 //-----------------------------------------------------------------------------
@@ -7425,27 +7471,27 @@ bool DeviceProxy::is_attribute_polled(string &attr_name)
 
 void DeviceProxy::stop_poll_command(string &cmd_name)
 {
-	check_connect_adm_device();
+    check_connect_adm_device();
 
-	DevVarStringArray in;
-	in.length(3);
+    DevVarStringArray in;
+    in.length(3);
 
-	in[0] = CORBA::string_dup(device_name.c_str());
-	in[1] = CORBA::string_dup("command");
-	in[2] = CORBA::string_dup(cmd_name.c_str());
+    in[0] = CORBA::string_dup(device_name.c_str());
+    in[1] = CORBA::string_dup("command");
+    in[2] = CORBA::string_dup(cmd_name.c_str());
 
-	DeviceData din;
-	string cmd("RemObjPolling");
-	din.any <<= in;
+    DeviceData din;
+    string cmd("RemObjPolling");
+    din.any <<= in;
 
-	try
-	{
-		adm_device->command_inout(cmd,din);
-	}
-	catch (Tango::CommunicationFailed &)
-	{
-		adm_device->command_inout(cmd,din);
-	}
+    try
+    {
+        adm_device->command_inout(cmd, din);
+    }
+    catch (Tango::CommunicationFailed &)
+    {
+        adm_device->command_inout(cmd, din);
+    }
 
 }
 
@@ -7457,27 +7503,27 @@ void DeviceProxy::stop_poll_command(string &cmd_name)
 
 void DeviceProxy::stop_poll_attribute(string &attr_name)
 {
-	check_connect_adm_device();
+    check_connect_adm_device();
 
-	DevVarStringArray in;
-	in.length(3);
+    DevVarStringArray in;
+    in.length(3);
 
-	in[0] = CORBA::string_dup(device_name.c_str());
-	in[1] = CORBA::string_dup("attribute");
-	in[2] = CORBA::string_dup(attr_name.c_str());
+    in[0] = CORBA::string_dup(device_name.c_str());
+    in[1] = CORBA::string_dup("attribute");
+    in[2] = CORBA::string_dup(attr_name.c_str());
 
-	DeviceData din;
-	string cmd("RemObjPolling");
-	din.any <<= in;
+    DeviceData din;
+    string cmd("RemObjPolling");
+    din.any <<= in;
 
-	try
-	{
-		adm_device->command_inout(cmd,din);
-	}
-	catch (Tango::CommunicationFailed &)
-	{
-		adm_device->command_inout(cmd,din);
-	}
+    try
+    {
+        adm_device->command_inout(cmd, din);
+    }
+    catch (Tango::CommunicationFailed &)
+    {
+        adm_device->command_inout(cmd, din);
+    }
 
 }
 
@@ -7489,26 +7535,26 @@ void DeviceProxy::stop_poll_attribute(string &attr_name)
 //-----------------------------------------------------------------------------
 void DeviceProxy::add_logging_target(const string &target_type_name)
 {
-	check_connect_adm_device();
+    check_connect_adm_device();
 
-	DevVarStringArray in(2);
-	in.length(2);
+    DevVarStringArray in(2);
+    in.length(2);
 
-	in[0] = CORBA::string_dup(device_name.c_str());
-	in[1] = CORBA::string_dup(target_type_name.c_str());
+    in[0] = CORBA::string_dup(device_name.c_str());
+    in[1] = CORBA::string_dup(target_type_name.c_str());
 
-	DeviceData din;
-	string cmd("AddLoggingTarget");
-	din.any <<= in;
+    DeviceData din;
+    string cmd("AddLoggingTarget");
+    din.any <<= in;
 
-	try
-	{
-		adm_device->command_inout(cmd,din);
-	}
-	catch (Tango::CommunicationFailed &)
-	{
-		adm_device->command_inout(cmd,din);
-	}
+    try
+    {
+        adm_device->command_inout(cmd, din);
+    }
+    catch (Tango::CommunicationFailed &)
+    {
+        adm_device->command_inout(cmd, din);
+    }
 }
 
 //-----------------------------------------------------------------------------
@@ -7516,28 +7562,28 @@ void DeviceProxy::add_logging_target(const string &target_type_name)
 // DeviceProxy::remove_logging_target - Remove a logging target
 //
 //-----------------------------------------------------------------------------
-void DeviceProxy::remove_logging_target (const string &target_type_name)
+void DeviceProxy::remove_logging_target(const string &target_type_name)
 {
-	check_connect_adm_device();
+    check_connect_adm_device();
 
-	DevVarStringArray in(2);
-	in.length(2);
+    DevVarStringArray in(2);
+    in.length(2);
 
-	in[0] = CORBA::string_dup(device_name.c_str());
-	in[1] = CORBA::string_dup(target_type_name.c_str());
+    in[0] = CORBA::string_dup(device_name.c_str());
+    in[1] = CORBA::string_dup(target_type_name.c_str());
 
-	DeviceData din;
-	string cmd("RemoveLoggingTarget");
-	din.any <<= in;
+    DeviceData din;
+    string cmd("RemoveLoggingTarget");
+    din.any <<= in;
 
-	try
-	{
-		adm_device->command_inout(cmd,din);
-	}
-	catch (Tango::CommunicationFailed &)
-	{
-		adm_device->command_inout(cmd,din);
-	}
+    try
+    {
+        adm_device->command_inout(cmd, din);
+    }
+    catch (Tango::CommunicationFailed &)
+    {
+        adm_device->command_inout(cmd, din);
+    }
 }
 
 //-----------------------------------------------------------------------------
@@ -7545,31 +7591,31 @@ void DeviceProxy::remove_logging_target (const string &target_type_name)
 // DeviceProxy::get_logging_target - Returns the logging target list
 //
 //-----------------------------------------------------------------------------
-vector<string> DeviceProxy::get_logging_target (void)
+vector<string> DeviceProxy::get_logging_target(void)
 {
-	check_connect_adm_device();
+    check_connect_adm_device();
 
-  	DeviceData din;
-	din << device_name;
+    DeviceData din;
+    din << device_name;
 
-  	string cmd("GetLoggingTarget");
+    string cmd("GetLoggingTarget");
 
-  	DeviceData dout;
-  	DevVarStringArray_var logging_targets;
-	try
-	{
-		dout = adm_device->command_inout(cmd, din);
-	}
-	catch (Tango::CommunicationFailed &)
-	{
-		dout = adm_device->command_inout(cmd, din);
-	}
+    DeviceData dout;
+    DevVarStringArray_var logging_targets;
+    try
+    {
+        dout = adm_device->command_inout(cmd, din);
+    }
+    catch (Tango::CommunicationFailed &)
+    {
+        dout = adm_device->command_inout(cmd, din);
+    }
 
-  	vector<string> logging_targets_vec;
+    vector<string> logging_targets_vec;
 
-  	dout >> logging_targets_vec;
+    dout >> logging_targets_vec;
 
-  	return logging_targets_vec;
+    return logging_targets_vec;
 }
 
 //-----------------------------------------------------------------------------
@@ -7578,52 +7624,52 @@ vector<string> DeviceProxy::get_logging_target (void)
 //
 //-----------------------------------------------------------------------------
 
-int DeviceProxy::get_logging_level (void)
+int DeviceProxy::get_logging_level(void)
 {
-	check_connect_adm_device();
+    check_connect_adm_device();
 
-  	string cmd("GetLoggingLevel");
+    string cmd("GetLoggingLevel");
 
-  	DevVarStringArray in;
-	in.length(1);
-	in[0] = CORBA::string_dup(device_name.c_str());
+    DevVarStringArray in;
+    in.length(1);
+    in[0] = CORBA::string_dup(device_name.c_str());
 
-  	DeviceData din;
-  	din.any <<= in;
+    DeviceData din;
+    din.any <<= in;
 
-  	DeviceData dout;
-	try
-	{
-		dout = adm_device->command_inout(cmd, din);
-	}
-	catch (Tango::CommunicationFailed &)
-	{
-		dout = adm_device->command_inout(cmd, din);
-	}
+    DeviceData dout;
+    try
+    {
+        dout = adm_device->command_inout(cmd, din);
+    }
+    catch (Tango::CommunicationFailed &)
+    {
+        dout = adm_device->command_inout(cmd, din);
+    }
 
-  	long level;
-  	if ((dout >> level) == false)
-	{
-		const Tango::DevVarLongStringArray *lsarr;
-		dout >> lsarr;
+    long level;
+    if ((dout >> level) == false)
+    {
+        const Tango::DevVarLongStringArray *lsarr;
+        dout >> lsarr;
 
-		string devnm = dev_name();
-		std::transform( devnm.begin(), devnm.end(), devnm.begin(), ::tolower );
+        string devnm = dev_name();
+        std::transform(devnm.begin(), devnm.end(), devnm.begin(), ::tolower);
 
-		for( unsigned int i = 0; i < lsarr->svalue.length(); i++ )
-		{
-			string nm( lsarr->svalue[i] );
-			std::transform( nm.begin(), nm.end(), nm.begin(), ::tolower );
+        for (unsigned int i = 0; i < lsarr->svalue.length(); i++)
+        {
+            string nm(lsarr->svalue[i]);
+            std::transform(nm.begin(), nm.end(), nm.begin(), ::tolower);
 
-			if( devnm == nm )
-			{
-				level = lsarr->lvalue[i];
-				break;
-			}
-		}
-	}
+            if (devnm == nm)
+            {
+                level = lsarr->lvalue[i];
+                break;
+            }
+        }
+    }
 
-	return (int)level;
+    return (int) level;
 }
 
 //-----------------------------------------------------------------------------
@@ -7632,29 +7678,29 @@ int DeviceProxy::get_logging_level (void)
 //
 //-----------------------------------------------------------------------------
 
-void DeviceProxy::set_logging_level (int level)
+void DeviceProxy::set_logging_level(int level)
 {
-	check_connect_adm_device();
+    check_connect_adm_device();
 
-  	string cmd("SetLoggingLevel");
+    string cmd("SetLoggingLevel");
 
-  	DevVarLongStringArray in;
-	in.lvalue.length(1);
-	in.lvalue[0] = level;
-  	in.svalue.length(1);
-	in.svalue[0] = CORBA::string_dup(device_name.c_str());
+    DevVarLongStringArray in;
+    in.lvalue.length(1);
+    in.lvalue[0] = level;
+    in.svalue.length(1);
+    in.svalue[0] = CORBA::string_dup(device_name.c_str());
 
-  	DeviceData din;
-  	din.any <<= in;
+    DeviceData din;
+    din.any <<= in;
 
-	try
-	{
-		adm_device->command_inout(cmd, din);
-	}
-	catch (Tango::CommunicationFailed &)
-	{
-		adm_device->command_inout(cmd, din);
-	}
+    try
+    {
+        adm_device->command_inout(cmd, din);
+    }
+    catch (Tango::CommunicationFailed &)
+    {
+        adm_device->command_inout(cmd, din);
+    }
 }
 #endif // TANGO_HAS_LOG4TANGO
 
@@ -7670,10 +7716,10 @@ void DeviceProxy::set_logging_level (int level)
 //
 //-------------------------------------------------------------------------------------------------------------------
 
-int DeviceProxy::subscribe_event (const string &attr_name, EventType event,
+int DeviceProxy::subscribe_event(const string &attr_name, EventType event,
                                  CallBack *callback, const vector<string> &filters)
 {
-	return subscribe_event (attr_name, event, callback, filters, false);
+    return subscribe_event(attr_name, event, callback, filters, false);
 }
 
 //-------------------------------------------------------------------------------------------------------------------
@@ -7686,42 +7732,43 @@ int DeviceProxy::subscribe_event (const string &attr_name, EventType event,
 //
 //-------------------------------------------------------------------------------------------------------------------
 
-int DeviceProxy::subscribe_event (const string &attr_name, EventType event,
+int DeviceProxy::subscribe_event(const string &attr_name, EventType event,
                                  CallBack *callback, const vector<string> &filters,
-                                    bool stateless)
+                                 bool stateless)
 {
     ApiUtil *api_ptr = ApiUtil::instance();
-  	if (api_ptr->get_zmq_event_consumer() == NULL)
-	{
-		api_ptr->create_zmq_event_consumer();
-	}
+    if (api_ptr->get_zmq_event_consumer() == NULL)
+    {
+        api_ptr->create_zmq_event_consumer();
+    }
 
 //
 // First, try using zmq. If it fails with the error "Command Not Found", try using notifd
 //
 
     int ret;
-	try
-	{
-        ret = api_ptr->get_zmq_event_consumer()->subscribe_event(this, attr_name,event, callback, filters, stateless);
-	}
-	catch (DevFailed &e)
-	{
-	    string reason(e.errors[0].reason.in());
-	    if (reason == API_CommandNotFound)
-	    {
+    try
+    {
+        ret = api_ptr->get_zmq_event_consumer()->subscribe_event(this, attr_name, event, callback, filters, stateless);
+    }
+    catch (DevFailed &e)
+    {
+        string reason(e.errors[0].reason.in());
+        if (reason == API_CommandNotFound)
+        {
             if (api_ptr->get_notifd_event_consumer() == NULL)
             {
                 api_ptr->create_notifd_event_consumer();
             }
 
-            ret = api_ptr->get_notifd_event_consumer()->subscribe_event(this, attr_name,event, callback, filters, stateless);
-	    }
-	    else
+            ret = api_ptr->get_notifd_event_consumer()
+                ->subscribe_event(this, attr_name, event, callback, filters, stateless);
+        }
+        else
             throw;
-	}
+    }
 
-	return ret;
+    return ret;
 }
 
 //------------------------------------------------------------------------------------------------------------------
@@ -7735,42 +7782,44 @@ int DeviceProxy::subscribe_event (const string &attr_name, EventType event,
 //
 //-----------------------------------------------------------------------------------------------------------------
 
-int DeviceProxy::subscribe_event (const string &attr_name, EventType event,
+int DeviceProxy::subscribe_event(const string &attr_name, EventType event,
                                  int event_queue_size, const vector<string> &filters,
                                  bool stateless)
 {
     ApiUtil *api_ptr = ApiUtil::instance();
-	if (api_ptr->get_zmq_event_consumer() == NULL)
-	{
-		api_ptr->create_zmq_event_consumer();
-	}
+    if (api_ptr->get_zmq_event_consumer() == NULL)
+    {
+        api_ptr->create_zmq_event_consumer();
+    }
 
 //
 // First, try using zmq. If it fails with the error "Command Not Found", try using notifd
 //
 
     int ret;
-	try
-	{
-        ret = api_ptr->get_zmq_event_consumer()->subscribe_event(this, attr_name,event, event_queue_size, filters, stateless);
-	}
-	catch (DevFailed &e)
-	{
-	    string reason(e.errors[0].reason.in());
-	    if (reason == API_CommandNotFound)
-	    {
+    try
+    {
+        ret = api_ptr->get_zmq_event_consumer()
+            ->subscribe_event(this, attr_name, event, event_queue_size, filters, stateless);
+    }
+    catch (DevFailed &e)
+    {
+        string reason(e.errors[0].reason.in());
+        if (reason == API_CommandNotFound)
+        {
             if (api_ptr->get_notifd_event_consumer() == NULL)
             {
                 api_ptr->create_notifd_event_consumer();
             }
 
-            ret = api_ptr->get_notifd_event_consumer()->subscribe_event(this, attr_name,event, event_queue_size, filters, stateless);
-	    }
-	    else
+            ret = api_ptr->get_notifd_event_consumer()
+                ->subscribe_event(this, attr_name, event, event_queue_size, filters, stateless);
+        }
+        else
             throw;
-	}
+    }
 
-	return ret;
+    return ret;
 }
 
 //-------------------------------------------------------------------------------------------------------------------
@@ -7783,27 +7832,27 @@ int DeviceProxy::subscribe_event (const string &attr_name, EventType event,
 //
 //-------------------------------------------------------------------------------------------------------------------
 
-int DeviceProxy::subscribe_event (EventType event,CallBack *callback,bool stateless)
+int DeviceProxy::subscribe_event(EventType event, CallBack *callback, bool stateless)
 {
-	if (version < MIN_IDL_DEV_INTR)
-	{
-		stringstream ss;
-		ss << "Device " << dev_name() << " does not support device interface change event\n";
-		ss << "Available since Tango release 9 AND for device inheriting from IDL release 5 (Device_5Impl)";
+    if (version < MIN_IDL_DEV_INTR)
+    {
+        stringstream ss;
+        ss << "Device " << dev_name() << " does not support device interface change event\n";
+        ss << "Available since Tango release 9 AND for device inheriting from IDL release 5 (Device_5Impl)";
 
-		Tango::Except::throw_exception(API_NotSupportedFeature,ss.str(),"DeviceProxy::subscribe_event()");
-	}
+        Tango::Except::throw_exception(API_NotSupportedFeature, ss.str(), "DeviceProxy::subscribe_event()");
+    }
 
     ApiUtil *api_ptr = ApiUtil::instance();
-  	if (api_ptr->get_zmq_event_consumer() == NULL)
-	{
-		api_ptr->create_zmq_event_consumer();
-	}
+    if (api_ptr->get_zmq_event_consumer() == NULL)
+    {
+        api_ptr->create_zmq_event_consumer();
+    }
 
     int ret;
-	ret = api_ptr->get_zmq_event_consumer()->subscribe_event(this,event,callback,stateless);
+    ret = api_ptr->get_zmq_event_consumer()->subscribe_event(this, event, callback, stateless);
 
-	return ret;
+    return ret;
 }
 
 //------------------------------------------------------------------------------------------------------------------
@@ -7817,27 +7866,27 @@ int DeviceProxy::subscribe_event (EventType event,CallBack *callback,bool statel
 //
 //-----------------------------------------------------------------------------------------------------------------
 
-int DeviceProxy::subscribe_event (EventType event,int event_queue_size,bool stateless)
+int DeviceProxy::subscribe_event(EventType event, int event_queue_size, bool stateless)
 {
-	if (version < MIN_IDL_DEV_INTR)
-	{
-		stringstream ss;
-		ss << "Device " << dev_name() << " does not support device interface change event\n";
-		ss << "Available since Tango release 9 AND for device inheriting from IDL release 5 (Device_5Impl)";
+    if (version < MIN_IDL_DEV_INTR)
+    {
+        stringstream ss;
+        ss << "Device " << dev_name() << " does not support device interface change event\n";
+        ss << "Available since Tango release 9 AND for device inheriting from IDL release 5 (Device_5Impl)";
 
-		Tango::Except::throw_exception(API_NotSupportedFeature,ss.str(),"DeviceProxy::subscribe_event()");
-	}
+        Tango::Except::throw_exception(API_NotSupportedFeature, ss.str(), "DeviceProxy::subscribe_event()");
+    }
 
     ApiUtil *api_ptr = ApiUtil::instance();
-  	if (api_ptr->get_zmq_event_consumer() == NULL)
-	{
-		api_ptr->create_zmq_event_consumer();
-	}
+    if (api_ptr->get_zmq_event_consumer() == NULL)
+    {
+        api_ptr->create_zmq_event_consumer();
+    }
 
     int ret;
-	ret = api_ptr->get_zmq_event_consumer()->subscribe_event(this,event,event_queue_size,stateless);
+    ret = api_ptr->get_zmq_event_consumer()->subscribe_event(this, event, event_queue_size, stateless);
 
-	return ret;
+    return ret;
 }
 
 //--------------------------------------------------------------------------------------------------------------------
@@ -7850,27 +7899,27 @@ int DeviceProxy::subscribe_event (EventType event,int event_queue_size,bool stat
 //
 //-------------------------------------------------------------------------------------------------------------------
 
-void DeviceProxy::unsubscribe_event (int event_id)
+void DeviceProxy::unsubscribe_event(int event_id)
 {
     ApiUtil *api_ptr = ApiUtil::instance();
-  	if (api_ptr->get_zmq_event_consumer() == NULL)
-	{
-		TangoSys_OMemStream desc;
-		desc << "Could not find event consumer object, \n";
-		desc << "probably no event subscription was done before!";
-		desc << ends;
-		Tango::Except::throw_exception(
-						(const char*)"API_EventConsumer",
-						desc.str(),
-						(const char*)"DeviceProxy::unsubscribe_event()");
-	}
+    if (api_ptr->get_zmq_event_consumer() == NULL)
+    {
+        TangoSys_OMemStream desc;
+        desc << "Could not find event consumer object, \n";
+        desc << "probably no event subscription was done before!";
+        desc << ends;
+        Tango::Except::throw_exception(
+            (const char *) "API_EventConsumer",
+            desc.str(),
+            (const char *) "DeviceProxy::unsubscribe_event()");
+    }
 
     if (api_ptr->get_zmq_event_consumer()->get_event_system_for_event_id(event_id) == ZMQ)
     {
         api_ptr->get_zmq_event_consumer()->unsubscribe_event(event_id);
     }
-	else
-	{
+    else
+    {
         if (api_ptr->get_notifd_event_consumer() == NULL)
         {
             TangoSys_OMemStream desc;
@@ -7878,12 +7927,12 @@ void DeviceProxy::unsubscribe_event (int event_id)
             desc << "probably no event subscription was done before!";
             desc << ends;
             Tango::Except::throw_exception(
-                            (const char*)"API_EventConsumer",
-                            desc.str(),
-                            (const char*)"DeviceProxy::unsubscribe_event()");
+                (const char *) "API_EventConsumer",
+                desc.str(),
+                (const char *) "DeviceProxy::unsubscribe_event()");
         }
         api_ptr->get_notifd_event_consumer()->unsubscribe_event(event_id);
-	}
+    }
 }
 
 //-----------------------------------------------------------------------------
@@ -7899,20 +7948,20 @@ void DeviceProxy::unsubscribe_event (int event_id)
 // argument : in  : event_id   : The event identifier
 // argument : out : event_list : A reference to an event data list to be filled
 //-----------------------------------------------------------------------------
-void DeviceProxy::get_events (int event_id, EventDataList &event_list)
+void DeviceProxy::get_events(int event_id, EventDataList &event_list)
 {
     ApiUtil *api_ptr = ApiUtil::instance();
-	if (api_ptr->get_zmq_event_consumer() == NULL)
-	{
-		TangoSys_OMemStream desc;
-		desc << "Could not find event consumer object, \n";
-		desc << "probably no event subscription was done before!";
-		desc << ends;
-		Tango::Except::throw_exception(
-						(const char*)"API_EventConsumer",
-						desc.str(),
-						(const char*)"DeviceProxy::get_events()");
-	}
+    if (api_ptr->get_zmq_event_consumer() == NULL)
+    {
+        TangoSys_OMemStream desc;
+        desc << "Could not find event consumer object, \n";
+        desc << "probably no event subscription was done before!";
+        desc << ends;
+        Tango::Except::throw_exception(
+            (const char *) "API_EventConsumer",
+            desc.str(),
+            (const char *) "DeviceProxy::get_events()");
+    }
 
     if (api_ptr->get_zmq_event_consumer()->get_event_system_for_event_id(event_id) == ZMQ)
     {
@@ -7927,14 +7976,13 @@ void DeviceProxy::get_events (int event_id, EventDataList &event_list)
             desc << "probably no event subscription was done before!";
             desc << ends;
             Tango::Except::throw_exception(
-                            (const char*)"API_EventConsumer",
-                            desc.str(),
-                            (const char*)"DeviceProxy::get_events()");
+                (const char *) "API_EventConsumer",
+                desc.str(),
+                (const char *) "DeviceProxy::get_events()");
         }
-        api_ptr->get_notifd_event_consumer()->get_events(event_id,event_list);
+        api_ptr->get_notifd_event_consumer()->get_events(event_id, event_list);
     }
 }
-
 
 //-----------------------------------------------------------------------------
 //
@@ -7950,17 +7998,17 @@ void DeviceProxy::get_events (int event_id, EventDataList &event_list)
 // argument : in  : event_id   : The event identifier
 // argument : out : event_list : A reference to an event data list to be filled
 //-----------------------------------------------------------------------------
-void DeviceProxy::get_events (int event_id, AttrConfEventDataList &event_list)
+void DeviceProxy::get_events(int event_id, AttrConfEventDataList &event_list)
 {
     ApiUtil *api_ptr = ApiUtil::instance();
-	if (api_ptr->get_zmq_event_consumer() == NULL)
-	{
-		TangoSys_OMemStream desc;
-		desc << "Could not find event consumer object, \n";
-		desc << "probably no event subscription was done before!";
-		desc << ends;
-		Tango::Except::throw_exception(API_EventConsumer,desc.str(),"DeviceProxy::get_events()");
-	}
+    if (api_ptr->get_zmq_event_consumer() == NULL)
+    {
+        TangoSys_OMemStream desc;
+        desc << "Could not find event consumer object, \n";
+        desc << "probably no event subscription was done before!";
+        desc << ends;
+        Tango::Except::throw_exception(API_EventConsumer, desc.str(), "DeviceProxy::get_events()");
+    }
 
     if (api_ptr->get_zmq_event_consumer()->get_event_system_for_event_id(event_id) == ZMQ)
     {
@@ -7974,23 +8022,23 @@ void DeviceProxy::get_events (int event_id, AttrConfEventDataList &event_list)
             desc << "Could not find event consumer object, \n";
             desc << "probably no event subscription was done before!";
             desc << ends;
-            Tango::Except::throw_exception(API_EventConsumer,desc.str(),"DeviceProxy::get_events()");
+            Tango::Except::throw_exception(API_EventConsumer, desc.str(), "DeviceProxy::get_events()");
         }
-        api_ptr->get_notifd_event_consumer()->get_events(event_id,event_list);
+        api_ptr->get_notifd_event_consumer()->get_events(event_id, event_list);
     }
 }
 
-void DeviceProxy::get_events (int event_id, DataReadyEventDataList &event_list)
+void DeviceProxy::get_events(int event_id, DataReadyEventDataList &event_list)
 {
     ApiUtil *api_ptr = ApiUtil::instance();
-	if (api_ptr->get_zmq_event_consumer() == NULL)
-	{
-		TangoSys_OMemStream desc;
-		desc << "Could not find event consumer object, \n";
-		desc << "probably no event subscription was done before!";
-		desc << ends;
-		Tango::Except::throw_exception(API_EventConsumer,desc.str(),"DeviceProxy::get_events()");
-	}
+    if (api_ptr->get_zmq_event_consumer() == NULL)
+    {
+        TangoSys_OMemStream desc;
+        desc << "Could not find event consumer object, \n";
+        desc << "probably no event subscription was done before!";
+        desc << ends;
+        Tango::Except::throw_exception(API_EventConsumer, desc.str(), "DeviceProxy::get_events()");
+    }
 
     if (api_ptr->get_zmq_event_consumer()->get_event_system_for_event_id(event_id) == ZMQ)
     {
@@ -8004,22 +8052,22 @@ void DeviceProxy::get_events (int event_id, DataReadyEventDataList &event_list)
             desc << "Could not find event consumer object, \n";
             desc << "probably no event subscription was done before!";
             desc << ends;
-            Tango::Except::throw_exception(API_EventConsumer,desc.str(),"DeviceProxy::get_events()");
+            Tango::Except::throw_exception(API_EventConsumer, desc.str(), "DeviceProxy::get_events()");
         }
-        api_ptr->get_notifd_event_consumer()->get_events(event_id,event_list);
+        api_ptr->get_notifd_event_consumer()->get_events(event_id, event_list);
     }
 }
 
-void DeviceProxy::get_events (int event_id, DevIntrChangeEventDataList &event_list)
+void DeviceProxy::get_events(int event_id, DevIntrChangeEventDataList &event_list)
 {
     ApiUtil *api_ptr = ApiUtil::instance();
-	if (api_ptr->get_zmq_event_consumer() == NULL)
-	{
-		stringstream desc;
-		desc << "Could not find event consumer object, \n";
-		desc << "probably no event subscription was done before!";
-		Tango::Except::throw_exception(API_EventConsumer,desc.str(),"DeviceProxy::get_events()");
-	}
+    if (api_ptr->get_zmq_event_consumer() == NULL)
+    {
+        stringstream desc;
+        desc << "Could not find event consumer object, \n";
+        desc << "probably no event subscription was done before!";
+        Tango::Except::throw_exception(API_EventConsumer, desc.str(), "DeviceProxy::get_events()");
+    }
 
     if (api_ptr->get_zmq_event_consumer()->get_event_system_for_event_id(event_id) == ZMQ)
     {
@@ -8027,22 +8075,22 @@ void DeviceProxy::get_events (int event_id, DevIntrChangeEventDataList &event_li
     }
     else
     {
-		stringstream desc;
-		desc << "Event Device Interface Change not implemented in old Tango event system (notifd)";
-		Tango::Except::throw_exception(API_UnsupportedFeature,desc.str(),"DeviceProxy::get_events()");
+        stringstream desc;
+        desc << "Event Device Interface Change not implemented in old Tango event system (notifd)";
+        Tango::Except::throw_exception(API_UnsupportedFeature, desc.str(), "DeviceProxy::get_events()");
     }
 }
 
-void DeviceProxy::get_events (int event_id, PipeEventDataList &event_list)
+void DeviceProxy::get_events(int event_id, PipeEventDataList &event_list)
 {
     ApiUtil *api_ptr = ApiUtil::instance();
-	if (api_ptr->get_zmq_event_consumer() == NULL)
-	{
-		stringstream desc;
-		desc << "Could not find event consumer object, \n";
-		desc << "probably no event subscription was done before!";
-		Tango::Except::throw_exception(API_EventConsumer,desc.str(),"DeviceProxy::get_events()");
-	}
+    if (api_ptr->get_zmq_event_consumer() == NULL)
+    {
+        stringstream desc;
+        desc << "Could not find event consumer object, \n";
+        desc << "probably no event subscription was done before!";
+        Tango::Except::throw_exception(API_EventConsumer, desc.str(), "DeviceProxy::get_events()");
+    }
 
     if (api_ptr->get_zmq_event_consumer()->get_event_system_for_event_id(event_id) == ZMQ)
     {
@@ -8050,9 +8098,9 @@ void DeviceProxy::get_events (int event_id, PipeEventDataList &event_list)
     }
     else
     {
-		stringstream desc;
-		desc << "Pipe event not implemented in old Tango event system (notifd)";
-		Tango::Except::throw_exception(API_UnsupportedFeature,desc.str(),"DeviceProxy::get_events()");
+        stringstream desc;
+        desc << "Pipe event not implemented in old Tango event system (notifd)";
+        Tango::Except::throw_exception(API_UnsupportedFeature, desc.str(), "DeviceProxy::get_events()");
     }
 }
 
@@ -8070,20 +8118,20 @@ void DeviceProxy::get_events (int event_id, PipeEventDataList &event_list)
 // argument : in  : event_id   : The event identifier
 // argument : out : cb : The callback object pointer
 //-----------------------------------------------------------------------------
-void DeviceProxy::get_events (int event_id, CallBack *cb)
+void DeviceProxy::get_events(int event_id, CallBack *cb)
 {
     ApiUtil *api_ptr = ApiUtil::instance();
-	if (api_ptr->get_zmq_event_consumer() == NULL)
-	{
-		TangoSys_OMemStream desc;
-		desc << "Could not find event consumer object, \n";
-		desc << "probably no event subscription was done before!";
-		desc << ends;
-		Tango::Except::throw_exception(
-						(const char*)"API_EventConsumer",
-						desc.str(),
-						(const char*)"DeviceProxy::get_events()");
-	}
+    if (api_ptr->get_zmq_event_consumer() == NULL)
+    {
+        TangoSys_OMemStream desc;
+        desc << "Could not find event consumer object, \n";
+        desc << "probably no event subscription was done before!";
+        desc << ends;
+        Tango::Except::throw_exception(
+            (const char *) "API_EventConsumer",
+            desc.str(),
+            (const char *) "DeviceProxy::get_events()");
+    }
 
     if (api_ptr->get_zmq_event_consumer()->get_event_system_for_event_id(event_id) == ZMQ)
     {
@@ -8098,11 +8146,11 @@ void DeviceProxy::get_events (int event_id, CallBack *cb)
             desc << "probably no event subscription was done before!";
             desc << ends;
             Tango::Except::throw_exception(
-                            (const char*)"API_EventConsumer",
-                            desc.str(),
-                            (const char*)"DeviceProxy::get_events()");
+                (const char *) "API_EventConsumer",
+                desc.str(),
+                (const char *) "DeviceProxy::get_events()");
         }
-        api_ptr->get_notifd_event_consumer()->get_events(event_id,cb);
+        api_ptr->get_notifd_event_consumer()->get_events(event_id, cb);
     }
 }
 
@@ -8115,20 +8163,20 @@ void DeviceProxy::get_events (int event_id, CallBack *cb)
 // argument : in : event_id   : The event identifier
 //
 //-----------------------------------------------------------------------------
-int  DeviceProxy::event_queue_size(int event_id)
+int DeviceProxy::event_queue_size(int event_id)
 {
     ApiUtil *api_ptr = ApiUtil::instance();
-	if (api_ptr->get_zmq_event_consumer() == NULL)
-	{
-		TangoSys_OMemStream desc;
-		desc << "Could not find event consumer object, \n";
-		desc << "probably no event subscription was done before!";
-		desc << ends;
-		Tango::Except::throw_exception(
-						(const char*)"API_EventConsumer",
-						desc.str(),
-						(const char*)"DeviceProxy::event_queue_size()");
-	}
+    if (api_ptr->get_zmq_event_consumer() == NULL)
+    {
+        TangoSys_OMemStream desc;
+        desc << "Could not find event consumer object, \n";
+        desc << "probably no event subscription was done before!";
+        desc << ends;
+        Tango::Except::throw_exception(
+            (const char *) "API_EventConsumer",
+            desc.str(),
+            (const char *) "DeviceProxy::event_queue_size()");
+    }
 
     EventConsumer *ev = NULL;
     if (api_ptr->get_zmq_event_consumer()->get_event_system_for_event_id(event_id) == ZMQ)
@@ -8144,9 +8192,9 @@ int  DeviceProxy::event_queue_size(int event_id)
             desc << "probably no event subscription was done before!";
             desc << ends;
             Tango::Except::throw_exception(
-                            (const char*)"API_EventConsumer",
-                            desc.str(),
-                            (const char*)"DeviceProxy::event_queue_size()");
+                (const char *) "API_EventConsumer",
+                desc.str(),
+                (const char *) "DeviceProxy::event_queue_size()");
         }
         else
             ev = api_ptr->get_notifd_event_consumer();
@@ -8167,17 +8215,17 @@ int  DeviceProxy::event_queue_size(int event_id)
 bool DeviceProxy::is_event_queue_empty(int event_id)
 {
     ApiUtil *api_ptr = ApiUtil::instance();
-	if (api_ptr->get_zmq_event_consumer() == NULL)
-	{
-		TangoSys_OMemStream desc;
-		desc << "Could not find event consumer object, \n";
-		desc << "probably no event subscription was done before!";
-		desc << ends;
-		Tango::Except::throw_exception(
-						(const char*)"API_EventConsumer",
-						desc.str(),
-						(const char*)"DeviceProxy::is_event_queue_empty()");
-	}
+    if (api_ptr->get_zmq_event_consumer() == NULL)
+    {
+        TangoSys_OMemStream desc;
+        desc << "Could not find event consumer object, \n";
+        desc << "probably no event subscription was done before!";
+        desc << ends;
+        Tango::Except::throw_exception(
+            (const char *) "API_EventConsumer",
+            desc.str(),
+            (const char *) "DeviceProxy::is_event_queue_empty()");
+    }
 
     EventConsumer *ev = NULL;
     if (api_ptr->get_zmq_event_consumer()->get_event_system_for_event_id(event_id) == ZMQ)
@@ -8193,9 +8241,9 @@ bool DeviceProxy::is_event_queue_empty(int event_id)
             desc << "probably no event subscription was done before!";
             desc << ends;
             Tango::Except::throw_exception(
-                            (const char*)"API_EventConsumer",
-                            desc.str(),
-                            (const char*)"DeviceProxy::is_event_queue_empty()");
+                (const char *) "API_EventConsumer",
+                desc.str(),
+                (const char *) "DeviceProxy::is_event_queue_empty()");
         }
         else
             ev = api_ptr->get_notifd_event_consumer();
@@ -8216,17 +8264,17 @@ bool DeviceProxy::is_event_queue_empty(int event_id)
 TimeVal DeviceProxy::get_last_event_date(int event_id)
 {
     ApiUtil *api_ptr = ApiUtil::instance();
-	if (api_ptr->get_zmq_event_consumer() == NULL)
-	{
-		TangoSys_OMemStream desc;
-		desc << "Could not find event consumer object, \n";
-		desc << "probably no event subscription was done before!";
-		desc << ends;
-		Tango::Except::throw_exception(
-						(const char*)"API_EventConsumer",
-						desc.str(),
-						(const char*)"DeviceProxy::get_last_event_date()");
-	}
+    if (api_ptr->get_zmq_event_consumer() == NULL)
+    {
+        TangoSys_OMemStream desc;
+        desc << "Could not find event consumer object, \n";
+        desc << "probably no event subscription was done before!";
+        desc << ends;
+        Tango::Except::throw_exception(
+            (const char *) "API_EventConsumer",
+            desc.str(),
+            (const char *) "DeviceProxy::get_last_event_date()");
+    }
 
     EventConsumer *ev = NULL;
     if (api_ptr->get_zmq_event_consumer()->get_event_system_for_event_id(event_id) == ZMQ)
@@ -8242,9 +8290,9 @@ TimeVal DeviceProxy::get_last_event_date(int event_id)
             desc << "probably no event subscription was done before!";
             desc << ends;
             Tango::Except::throw_exception(
-                            (const char*)"API_EventConsumer",
-                            desc.str(),
-                            (const char*)"DeviceProxy::get_last_event_date()");
+                (const char *) "API_EventConsumer",
+                desc.str(),
+                (const char *) "DeviceProxy::get_last_event_date()");
         }
         else
             ev = api_ptr->get_notifd_event_consumer();
@@ -8260,12 +8308,12 @@ TimeVal DeviceProxy::get_last_event_date(int event_id)
 //
 //-----------------------------------------------------------------------------
 
-Database * DeviceProxy::get_device_db()
+Database *DeviceProxy::get_device_db()
 {
-	if ((db_port_num != 0) && (db_dev != NULL))
-		return db_dev->get_dbase();
-	else
-		return (Database *)NULL;
+    if ((db_port_num != 0) && (db_dev != NULL))
+        return db_dev->get_dbase();
+    else
+        return (Database *) NULL;
 }
 
 //-----------------------------------------------------------------------------
@@ -8277,11 +8325,11 @@ Database * DeviceProxy::get_device_db()
 
 void clean_lock()
 {
-	if (ApiUtil::_is_instance_null() == false)
-	{
-		ApiUtil *au = ApiUtil::instance();
-		au->clean_locking_threads();
-	}
+    if (ApiUtil::_is_instance_null() == false)
+    {
+        ApiUtil *au = ApiUtil::instance();
+        au->clean_locking_threads();
+    }
 }
 
 //-----------------------------------------------------------------------------
@@ -8297,91 +8345,91 @@ void DeviceProxy::lock(int lock_validity)
 // Feature unavailable for device without database
 //
 
-	if (dbase_used == false)
-	{
-		TangoSys_OMemStream desc;
-		desc << "Feature not available for device ";
-		desc << device_name;
-		desc << " which is a non database device";
+    if (dbase_used == false)
+    {
+        TangoSys_OMemStream desc;
+        desc << "Feature not available for device ";
+        desc << device_name;
+        desc << " which is a non database device";
 
-		ApiNonDbExcept::throw_exception((const char *)API_NonDatabaseDevice,
-					desc.str(),
-					(const char *)"DeviceProxy::lock");
-	}
+        ApiNonDbExcept::throw_exception((const char *) API_NonDatabaseDevice,
+                                        desc.str(),
+                                        (const char *) "DeviceProxy::lock");
+    }
 
 //
 // Some checks on lock validity
 //
 
-	if (lock_validity < MIN_LOCK_VALIDITY)
-	{
-		TangoSys_OMemStream desc;
-		desc << "Lock validity can not be lower than " << MIN_LOCK_VALIDITY << " seconds" << ends;
+    if (lock_validity < MIN_LOCK_VALIDITY)
+    {
+        TangoSys_OMemStream desc;
+        desc << "Lock validity can not be lower than " << MIN_LOCK_VALIDITY << " seconds" << ends;
 
-		Except::throw_exception((const char*)API_MethodArgument,desc.str(),
-								(const char*)"DeviceProxy::lock");
-	}
+        Except::throw_exception((const char *) API_MethodArgument, desc.str(),
+                                (const char *) "DeviceProxy::lock");
+    }
 
-	{
-		omni_mutex_lock guard(lock_mutex);
-		if (lock_ctr != 0)
-		{
-			if (lock_validity != lock_valid)
-			{
-				TangoSys_OMemStream desc;
+    {
+        omni_mutex_lock guard(lock_mutex);
+        if (lock_ctr != 0)
+        {
+            if (lock_validity != lock_valid)
+            {
+                TangoSys_OMemStream desc;
 
-				desc << "Device " << device_name << " is already locked with another lock validity (";
-				desc << lock_valid << " sec)" << ends;
+                desc << "Device " << device_name << " is already locked with another lock validity (";
+                desc << lock_valid << " sec)" << ends;
 
-				Except::throw_exception((const char*)API_MethodArgument,desc.str(),
-									(const char*)"DeviceProxy::lock");
-			}
-		}
-	}
+                Except::throw_exception((const char *) API_MethodArgument, desc.str(),
+                                        (const char *) "DeviceProxy::lock");
+            }
+        }
+    }
 
 //
 // Check if the function to be executed atexit is already installed
 //
 
-	Tango::ApiUtil *au = ApiUtil::instance();
-	if (au->is_lock_exit_installed() == false)
-	{
-		atexit(clean_lock);
-		au->set_sig_handler();
-		au->set_lock_exit_installed(true);
-	}
+    Tango::ApiUtil *au = ApiUtil::instance();
+    if (au->is_lock_exit_installed() == false)
+    {
+        atexit(clean_lock);
+        au->set_sig_handler();
+        au->set_lock_exit_installed(true);
+    }
 
 //
 // Connect to the admin device if not already done
 //
 
-	check_connect_adm_device();
+    check_connect_adm_device();
 
 //
 // Send command to admin device
 //
 
-  	string cmd("LockDevice");
-  	DeviceData din;
-  	DevVarLongStringArray sent_data;
-  	sent_data.svalue.length(1);
-  	sent_data.svalue[0] = CORBA::string_dup(device_name.c_str());
-  	sent_data.lvalue.length(1);
-  	sent_data.lvalue[0] = lock_validity;
-  	din << sent_data;
+    string cmd("LockDevice");
+    DeviceData din;
+    DevVarLongStringArray sent_data;
+    sent_data.svalue.length(1);
+    sent_data.svalue[0] = CORBA::string_dup(device_name.c_str());
+    sent_data.lvalue.length(1);
+    sent_data.lvalue[0] = lock_validity;
+    din << sent_data;
 
-	adm_device->command_inout(cmd, din);
+    adm_device->command_inout(cmd, din);
 
 //
 // Increment locking counter
 //
 
-	{
-		omni_mutex_lock guard(lock_mutex);
+    {
+        omni_mutex_lock guard(lock_mutex);
 
-		lock_ctr++;
-		lock_valid = lock_validity;
-	}
+        lock_ctr++;
+        lock_valid = lock_validity;
+    }
 
 //
 // Try to find the device's server admin device locking thread
@@ -8391,74 +8439,74 @@ void DeviceProxy::lock(int lock_validity)
 // of locked devices
 //
 
-	{
-		omni_mutex_lock oml(au->lock_th_map);
+    {
+        omni_mutex_lock oml(au->lock_th_map);
 
-		map<string,LockingThread>::iterator pos = au->lock_threads.find(adm_dev_name);
-		if (pos == au->lock_threads.end())
-		{
-			create_locking_thread(au,lock_validity);
-		}
-		else
-		{
-			bool local_suicide;
-			{
-				omni_mutex_lock sync(*(pos->second.mon));
-				local_suicide = pos->second.shared->suicide;
-			}
+        map<string, LockingThread>::iterator pos = au->lock_threads.find(adm_dev_name);
+        if (pos == au->lock_threads.end())
+        {
+            create_locking_thread(au, lock_validity);
+        }
+        else
+        {
+            bool local_suicide;
+            {
+                omni_mutex_lock sync(*(pos->second.mon));
+                local_suicide = pos->second.shared->suicide;
+            }
 
-			if (local_suicide == true)
-			{
-				delete pos->second.shared;
-				delete pos->second.mon;
-				au->lock_threads.erase(pos);
+            if (local_suicide == true)
+            {
+                delete pos->second.shared;
+                delete pos->second.mon;
+                au->lock_threads.erase(pos);
 
-				create_locking_thread(au,lock_validity);
-			}
-			else
-			{
-			    int interupted;
+                create_locking_thread(au, lock_validity);
+            }
+            else
+            {
+                int interupted;
 
-				omni_mutex_lock sync(*(pos->second.mon));
-				if (pos->second.shared->cmd_pending == true)
-				{
-					interupted = pos->second.mon->wait(DEFAULT_TIMEOUT);
+                omni_mutex_lock sync(*(pos->second.mon));
+                if (pos->second.shared->cmd_pending == true)
+                {
+                    interupted = pos->second.mon->wait(DEFAULT_TIMEOUT);
 
-					if ((pos->second.shared->cmd_pending == true) && (interupted == 0))
-					{
-						cout4 << "TIME OUT" << endl;
-						Except::throw_exception((const char *)API_CommandTimedOut,
-								        		(const char *)"Locking thread blocked !!!",
-								        		(const char *)"DeviceProxy::lock");
-					}
-				}
-				pos->second.shared->cmd_pending = true;
-				pos->second.shared->cmd_code = LOCK_ADD_DEV;
-				pos->second.shared->dev_name = device_name;
-				{
-					omni_mutex_lock guard(lock_mutex);
-					pos->second.shared->lock_validity = lock_valid;
-				}
+                    if ((pos->second.shared->cmd_pending == true) && (interupted == 0))
+                    {
+                        cout4 << "TIME OUT" << endl;
+                        Except::throw_exception((const char *) API_CommandTimedOut,
+                                                (const char *) "Locking thread blocked !!!",
+                                                (const char *) "DeviceProxy::lock");
+                    }
+                }
+                pos->second.shared->cmd_pending = true;
+                pos->second.shared->cmd_code = LOCK_ADD_DEV;
+                pos->second.shared->dev_name = device_name;
+                {
+                    omni_mutex_lock guard(lock_mutex);
+                    pos->second.shared->lock_validity = lock_valid;
+                }
 
-				pos->second.mon->signal();
+                pos->second.mon->signal();
 
-				cout4 << "Cmd sent to locking thread" << endl;
+                cout4 << "Cmd sent to locking thread" << endl;
 
-				while (pos->second.shared->cmd_pending == true)
-				{
-					interupted = pos->second.mon->wait(DEFAULT_TIMEOUT);
+                while (pos->second.shared->cmd_pending == true)
+                {
+                    interupted = pos->second.mon->wait(DEFAULT_TIMEOUT);
 
-					if ((pos->second.shared->cmd_pending == true) && (interupted == 0))
-					{
-						cout4 << "TIME OUT" << endl;
-						Except::throw_exception((const char *)API_CommandTimedOut,
-								        		(const char *)"Locking thread blocked !!!",
-								        		(const char *)"DeviceProxy::lock");
-					}
-				}
-			}
-		}
-	}
+                    if ((pos->second.shared->cmd_pending == true) && (interupted == 0))
+                    {
+                        cout4 << "TIME OUT" << endl;
+                        Except::throw_exception((const char *) API_CommandTimedOut,
+                                                (const char *) "Locking thread blocked !!!",
+                                                (const char *) "DeviceProxy::lock");
+                    }
+                }
+            }
+        }
+    }
 }
 
 //-----------------------------------------------------------------------------
@@ -8474,60 +8522,60 @@ void DeviceProxy::unlock(bool force)
 // Feature unavailable for device without database
 //
 
-	if (dbase_used == false)
-	{
-		TangoSys_OMemStream desc;
-		desc << "Feature not available for device ";
-		desc << device_name;
-		desc << " which is a non database device";
+    if (dbase_used == false)
+    {
+        TangoSys_OMemStream desc;
+        desc << "Feature not available for device ";
+        desc << device_name;
+        desc << " which is a non database device";
 
-		ApiNonDbExcept::throw_exception((const char *)API_NonDatabaseDevice,
-					desc.str(),
-					(const char *)"DeviceProxy::unlock");
-	}
+        ApiNonDbExcept::throw_exception((const char *) API_NonDatabaseDevice,
+                                        desc.str(),
+                                        (const char *) "DeviceProxy::unlock");
+    }
 
-	check_connect_adm_device();
+    check_connect_adm_device();
 
 //
 // Send command to admin device
 //
 
-  	string cmd("UnLockDevice");
-  	DeviceData din,dout;
-  	DevVarLongStringArray sent_data;
-  	sent_data.svalue.length(1);
-  	sent_data.svalue[0] = CORBA::string_dup(device_name.c_str());
-  	sent_data.lvalue.length(1);
-  	if (force == true)
-  		sent_data.lvalue[0] = 1;
-  	else
-  		sent_data.lvalue[0] = 0;
-  	din << sent_data;
+    string cmd("UnLockDevice");
+    DeviceData din, dout;
+    DevVarLongStringArray sent_data;
+    sent_data.svalue.length(1);
+    sent_data.svalue[0] = CORBA::string_dup(device_name.c_str());
+    sent_data.lvalue.length(1);
+    if (force == true)
+        sent_data.lvalue[0] = 1;
+    else
+        sent_data.lvalue[0] = 0;
+    din << sent_data;
 
 //
 // Send request to the DS admin device
 //
 
-	dout = adm_device->command_inout(cmd, din);
+    dout = adm_device->command_inout(cmd, din);
 
 //
 // Decrement locking counter or replace it by the device global counter
 // returned by the server
 //
 
-	Tango::DevLong glob_ctr;
+    Tango::DevLong glob_ctr;
 
-	dout >> glob_ctr;
-	int local_lock_ctr;
+    dout >> glob_ctr;
+    int local_lock_ctr;
 
-	{
-		omni_mutex_lock guard(lock_mutex);
+    {
+        omni_mutex_lock guard(lock_mutex);
 
-		lock_ctr--;
-		if (glob_ctr != lock_ctr)
-			lock_ctr = glob_ctr;
-		local_lock_ctr = lock_ctr;
-	}
+        lock_ctr--;
+        if (glob_ctr != lock_ctr)
+            lock_ctr = glob_ctr;
+        local_lock_ctr = lock_ctr;
+    }
 
 //
 // Try to find the device's server admin device locking thread
@@ -8535,70 +8583,70 @@ void DeviceProxy::unlock(bool force)
 // Ask the thread to remove the device to its list of locked devices
 //
 
-	if ((local_lock_ctr == 0) || (force == true))
-	{
-		Tango::ApiUtil *au = Tango::ApiUtil::instance();
+    if ((local_lock_ctr == 0) || (force == true))
+    {
+        Tango::ApiUtil *au = Tango::ApiUtil::instance();
 
-		{
-			omni_mutex_lock oml(au->lock_th_map);
-			map<string,LockingThread>::iterator pos = au->lock_threads.find(adm_dev_name);
-			if (pos == au->lock_threads.end())
-			{
+        {
+            omni_mutex_lock oml(au->lock_th_map);
+            map<string, LockingThread>::iterator pos = au->lock_threads.find(adm_dev_name);
+            if (pos == au->lock_threads.end())
+            {
 //				TangoSys_OMemStream o;
 
 //				o << "Can't find the locking thread for device " << device_name << " and admin device " << adm_dev_name << ends;
 //				Tango::Except::throw_exception((const char *)API_CantFindLockingThread,o.str(),
 //                                           		(const char *)"DeviceProxy::unlock()");
-			}
-			else
-			{
-				if (pos->second.shared->suicide == true)
-				{
-					delete pos->second.shared;
-					delete pos->second.mon;
-					au->lock_threads.erase(pos);
-				}
-				else
-				{
+            }
+            else
+            {
+                if (pos->second.shared->suicide == true)
+                {
+                    delete pos->second.shared;
+                    delete pos->second.mon;
+                    au->lock_threads.erase(pos);
+                }
+                else
+                {
                     int interupted;
 
-					omni_mutex_lock sync(*(pos->second.mon));
-					if (pos->second.shared->cmd_pending == true)
-					{
-						interupted = pos->second.mon->wait(DEFAULT_TIMEOUT);
+                    omni_mutex_lock sync(*(pos->second.mon));
+                    if (pos->second.shared->cmd_pending == true)
+                    {
+                        interupted = pos->second.mon->wait(DEFAULT_TIMEOUT);
 
-						if ((pos->second.shared->cmd_pending == true) && (interupted == 0))
-						{
-							cout4 << "TIME OUT" << endl;
-							Except::throw_exception((const char *)API_CommandTimedOut,
-								        		(const char *)"Locking thread blocked !!!",
-								        		(const char *)"DeviceProxy::unlock");
-						}
-					}
-					pos->second.shared->cmd_pending = true;
-					pos->second.shared->cmd_code = LOCK_REM_DEV;
-					pos->second.shared->dev_name = device_name;
+                        if ((pos->second.shared->cmd_pending == true) && (interupted == 0))
+                        {
+                            cout4 << "TIME OUT" << endl;
+                            Except::throw_exception((const char *) API_CommandTimedOut,
+                                                    (const char *) "Locking thread blocked !!!",
+                                                    (const char *) "DeviceProxy::unlock");
+                        }
+                    }
+                    pos->second.shared->cmd_pending = true;
+                    pos->second.shared->cmd_code = LOCK_REM_DEV;
+                    pos->second.shared->dev_name = device_name;
 
-					pos->second.mon->signal();
+                    pos->second.mon->signal();
 
-					cout4 << "Cmd sent to locking thread" << endl;
+                    cout4 << "Cmd sent to locking thread" << endl;
 
-					while (pos->second.shared->cmd_pending == true)
-					{
-						interupted = pos->second.mon->wait(DEFAULT_TIMEOUT);
+                    while (pos->second.shared->cmd_pending == true)
+                    {
+                        interupted = pos->second.mon->wait(DEFAULT_TIMEOUT);
 
-						if ((pos->second.shared->cmd_pending == true) && (interupted == 0))
-						{
-							cout4 << "TIME OUT" << endl;
-							Except::throw_exception((const char *)API_CommandTimedOut,
-										        		(const char *)"Locking thread blocked !!!",
-										        		(const char *)"DeviceProxy::unlock");
-						}
-					}
-				}
-			}
-		}
-	}
+                        if ((pos->second.shared->cmd_pending == true) && (interupted == 0))
+                        {
+                            cout4 << "TIME OUT" << endl;
+                            Except::throw_exception((const char *) API_CommandTimedOut,
+                                                    (const char *) "Locking thread blocked !!!",
+                                                    (const char *) "DeviceProxy::unlock");
+                        }
+                    }
+                }
+            }
+        }
+    }
 }
 
 //-----------------------------------------------------------------------------
@@ -8607,36 +8655,37 @@ void DeviceProxy::unlock(bool force)
 //
 //-----------------------------------------------------------------------------
 
-void DeviceProxy::create_locking_thread(ApiUtil *au,DevLong dl)
+void DeviceProxy::create_locking_thread(ApiUtil *au, DevLong dl)
 {
 
-	LockingThread lt;
-	lt.mon = NULL;
-	lt.l_thread = NULL;
-	lt.shared = NULL;
+    LockingThread lt;
+    lt.mon = NULL;
+    lt.l_thread = NULL;
+    lt.shared = NULL;
 
-	pair<map<string,LockingThread>::iterator,bool> status;
-	status = au->lock_threads.insert(make_pair(adm_dev_name,lt));
-	if (status.second == false)
-	{
-		TangoSys_OMemStream o;
-		o << "Can't create the locking thread for device " << device_name << " and admin device " << adm_dev_name << ends;
-		Tango::Except::throw_exception((const char *)API_CantCreateLockingThread,o.str(),
-	                               (const char *)"DeviceProxy::create_locking_thread()");
-	}
-	else
-	{
-		map<string,LockingThread>::iterator pos;
+    pair<map<string, LockingThread>::iterator, bool> status;
+    status = au->lock_threads.insert(make_pair(adm_dev_name, lt));
+    if (status.second == false)
+    {
+        TangoSys_OMemStream o;
+        o << "Can't create the locking thread for device " << device_name << " and admin device " << adm_dev_name
+          << ends;
+        Tango::Except::throw_exception((const char *) API_CantCreateLockingThread, o.str(),
+                                       (const char *) "DeviceProxy::create_locking_thread()");
+    }
+    else
+    {
+        map<string, LockingThread>::iterator pos;
 
-		pos = status.first;
-		pos->second.mon = new TangoMonitor(adm_dev_name.c_str());
-		pos->second.shared = new LockThCmd;
-		pos->second.shared->cmd_pending = false;
-		pos->second.shared->suicide = false;
-		pos->second.l_thread = new LockThread(*pos->second.shared,*pos->second.mon,adm_device,device_name,dl);
+        pos = status.first;
+        pos->second.mon = new TangoMonitor(adm_dev_name.c_str());
+        pos->second.shared = new LockThCmd;
+        pos->second.shared->cmd_pending = false;
+        pos->second.shared->suicide = false;
+        pos->second.l_thread = new LockThread(*pos->second.shared, *pos->second.mon, adm_device, device_name, dl);
 
-		pos->second.l_thread->start();
-	}
+        pos->second.l_thread->start();
+    }
 }
 
 //-----------------------------------------------------------------------------
@@ -8647,13 +8696,13 @@ void DeviceProxy::create_locking_thread(ApiUtil *au,DevLong dl)
 
 string DeviceProxy::locking_status()
 {
-	vector<string> v_str;
-	vector<DevLong> v_l;
+    vector<string> v_str;
+    vector<DevLong> v_l;
 
-	ask_locking_status(v_str,v_l);
+    ask_locking_status(v_str, v_l);
 
-	string str(v_str[0]);
-	return str;
+    string str(v_str[0]);
+    return str;
 }
 
 //-----------------------------------------------------------------------------
@@ -8666,12 +8715,12 @@ string DeviceProxy::locking_status()
 
 bool DeviceProxy::is_locked()
 {
-	vector<string> v_str;
-	vector<DevLong> v_l;
+    vector<string> v_str;
+    vector<DevLong> v_l;
 
-	ask_locking_status(v_str,v_l);
+    ask_locking_status(v_str, v_l);
 
-	return (bool)v_l[0];
+    return (bool) v_l[0];
 }
 
 //-----------------------------------------------------------------------------
@@ -8684,38 +8733,38 @@ bool DeviceProxy::is_locked()
 
 bool DeviceProxy::is_locked_by_me()
 {
-	vector<string> v_str;
-	vector<DevLong> v_l;
+    vector<string> v_str;
+    vector<DevLong> v_l;
 
-	ask_locking_status(v_str,v_l);
+    ask_locking_status(v_str, v_l);
 
-	bool ret = false;
+    bool ret = false;
 
-	if (v_l[0] == 0)
-		ret = false;
-	else
-	{
+    if (v_l[0] == 0)
+        ret = false;
+    else
+    {
 #ifndef _TG_WINDOWS_
-		if (getpid() != v_l[1])
+        if (getpid() != v_l[1])
 #else
-		if (_getpid() != v_l[1])
+            if (_getpid() != v_l[1])
 #endif
-			ret = false;
-		else if ((v_l[2] != 0) || (v_l[3] != 0) || (v_l[4] != 0) || (v_l[5] != 0))
-			ret = false;
-		else
-		{
-			string full_ip_str;
-			get_locker_host(v_str[1],full_ip_str);
+            ret = false;
+        else if ((v_l[2] != 0) || (v_l[3] != 0) || (v_l[4] != 0) || (v_l[5] != 0))
+            ret = false;
+        else
+        {
+            string full_ip_str;
+            get_locker_host(v_str[1], full_ip_str);
 
 //
 // If the call is local, as the PID is already the good one, the caller is the locker
 //
 
-			if (full_ip_str == TG_LOCAL_HOST)
-				ret = true;
-			else
-			{
+            if (full_ip_str == TG_LOCAL_HOST)
+                ret = true;
+            else
+            {
 
 //
 // Get the host address(es) and check if it is the same than the one sent by the server
@@ -8727,7 +8776,7 @@ bool DeviceProxy::is_locked_by_me()
 
                 au->get_ip_from_if(adrs);
 
-                for (unsigned int nb_adrs = 0;nb_adrs < adrs.size();nb_adrs++)
+                for (unsigned int nb_adrs = 0; nb_adrs < adrs.size(); nb_adrs++)
                 {
                     if (adrs[nb_adrs] == full_ip_str)
                     {
@@ -8735,10 +8784,10 @@ bool DeviceProxy::is_locked_by_me()
                         break;
                     }
                 }
-			}
-		}
-	}
-	return ret;
+            }
+        }
+    }
+    return ret;
 }
 
 //-----------------------------------------------------------------------------
@@ -8752,82 +8801,82 @@ bool DeviceProxy::is_locked_by_me()
 
 bool DeviceProxy::get_locker(LockerInfo &lock_info)
 {
-	vector<string> v_str;
-	vector<DevLong> v_l;
+    vector<string> v_str;
+    vector<DevLong> v_l;
 
-	ask_locking_status(v_str,v_l);
+    ask_locking_status(v_str, v_l);
 
-	if (v_l[0] == 0)
-		return false;
-	else
-	{
+    if (v_l[0] == 0)
+        return false;
+    else
+    {
 
 //
 // If the PID info coming from server is not 0, the locker is CPP
 // Otherwise, it is Java
 //
 
-		if (v_l[1] != 0)
-		{
-			lock_info.ll = Tango::CPP;
-			lock_info.li.LockerPid = v_l[1];
+        if (v_l[1] != 0)
+        {
+            lock_info.ll = Tango::CPP;
+            lock_info.li.LockerPid = v_l[1];
 
-			lock_info.locker_class = "Not defined";
-		}
-		else
-		{
-			lock_info.ll = Tango::JAVA;
-			for (int loop = 0;loop < 4;loop++)
-				lock_info.li.UUID[loop] = v_l[2 + loop];
+            lock_info.locker_class = "Not defined";
+        }
+        else
+        {
+            lock_info.ll = Tango::JAVA;
+            for (int loop = 0; loop < 4; loop++)
+                lock_info.li.UUID[loop] = v_l[2 + loop];
 
-			string full_ip;
-			get_locker_host(v_str[1],full_ip);
+            string full_ip;
+            get_locker_host(v_str[1], full_ip);
 
-			lock_info.locker_class = v_str[2];
-		}
+            lock_info.locker_class = v_str[2];
+        }
 
 //
 // Add locker host name
 //
 
-		string full_ip;
-		get_locker_host(v_str[1],full_ip);
+        string full_ip;
+        get_locker_host(v_str[1], full_ip);
 
 //
 // Convert locker IP address to its name
 //
 
-		if (full_ip != TG_LOCAL_HOST)
-		{
-			struct sockaddr_in si;
-			si.sin_family = AF_INET;
-			si.sin_port = 0;
+        if (full_ip != TG_LOCAL_HOST)
+        {
+            struct sockaddr_in si;
+            si.sin_family = AF_INET;
+            si.sin_port = 0;
 #ifdef _TG_WINDOWS_
-			int slen = sizeof(si);
+                                                                                                                                    int slen = sizeof(si);
 			WSAStringToAddress((char *)full_ip.c_str(),AF_INET,NULL,(SOCKADDR *)&si,&slen);
 #else
-			inet_pton(AF_INET,full_ip.c_str(),&si.sin_addr);
+            inet_pton(AF_INET, full_ip.c_str(), &si.sin_addr);
 #endif
 
-			char host_os[512];
+            char host_os[512];
 
-			int res = getnameinfo((const sockaddr *)&si,sizeof(si),host_os,512,0,0,0);
+            int res = getnameinfo((const sockaddr *) &si, sizeof(si), host_os, 512, 0, 0, 0);
 
-			if (res == 0)
-				lock_info.locker_host = host_os;
-			else
-				lock_info.locker_host = full_ip;
-		}
-		else
-		{
-			char h_name[80];
-			gethostname(h_name,80);
+            if (res == 0)
+                lock_info.locker_host = host_os;
+            else
+                lock_info.locker_host = full_ip;
+        }
+        else
+        {
+            char h_name[80];
+            gethostname(h_name, 80);
 
-			lock_info.locker_host = h_name;
-		}
-	}
+            lock_info.locker_host = h_name;
+        }
+    }
 
-	return true;
+    return true;
 }
 
 //-----------------------------------------------------------------------------
@@ -8836,42 +8885,42 @@ bool DeviceProxy::get_locker(LockerInfo &lock_info)
 //
 //-----------------------------------------------------------------------------
 
-void DeviceProxy::ask_locking_status(vector<string> &v_str,vector<DevLong> &v_l)
+void DeviceProxy::ask_locking_status(vector<string> &v_str, vector<DevLong> &v_l)
 {
 
 //
 // Feature unavailable for device without database
 //
 
-	if (dbase_used == false)
-	{
-		TangoSys_OMemStream desc;
-		desc << "Feature not available for device ";
-		desc << device_name;
-		desc << " which is a non database device";
+    if (dbase_used == false)
+    {
+        TangoSys_OMemStream desc;
+        desc << "Feature not available for device ";
+        desc << device_name;
+        desc << " which is a non database device";
 
-		ApiNonDbExcept::throw_exception((const char *)API_NonDatabaseDevice,
-					desc.str(),
-					(const char *)"DeviceProxy::locking_status");
-	}
+        ApiNonDbExcept::throw_exception((const char *) API_NonDatabaseDevice,
+                                        desc.str(),
+                                        (const char *) "DeviceProxy::locking_status");
+    }
 
-	check_connect_adm_device();
+    check_connect_adm_device();
 
 //
 // Send command to admin device
 //
 
-  	string cmd("DevLockStatus");
-  	DeviceData din,dout;
-  	din.any <<= device_name.c_str();
+    string cmd("DevLockStatus");
+    DeviceData din, dout;
+    din.any <<= device_name.c_str();
 
-	dout = adm_device->command_inout(cmd, din);
+    dout = adm_device->command_inout(cmd, din);
 
 //
 // Extract data and return data to caller
 //
 
-	dout.extract(v_l,v_str);
+    dout.extract(v_l, v_str);
 }
 
 //-----------------------------------------------------------------------------
@@ -8881,7 +8930,7 @@ void DeviceProxy::ask_locking_status(vector<string> &v_str,vector<DevLong> &v_l)
 //
 //-----------------------------------------------------------------------------
 
-void DeviceProxy::get_locker_host(string &f_addr,string &ip_addr)
+void DeviceProxy::get_locker_host(string &f_addr, string &ip_addr)
 {
 //
 // The hostname is returned in the following format:
@@ -8890,64 +8939,64 @@ void DeviceProxy::get_locker_host(string &f_addr,string &ip_addr)
 // We need to isolate the IP address
 //
 
-	bool ipv6 = false;
+    bool ipv6 = false;
 
-	if (f_addr.find('[') != string::npos)
-		ipv6 = true;
+    if (f_addr.find('[') != string::npos)
+        ipv6 = true;
 
-	if (f_addr.find(":unix:") != string::npos)
-	{
-		ip_addr = TG_LOCAL_HOST;
-	}
-	else
-	{
-		string::size_type pos;
-		if ((pos = f_addr.find(':')) == string::npos)
-		{
-			Tango::Except::throw_exception((const char*)API_WrongLockingStatus,
-											(const char *)"Locker IP address returned by server is unvalid",
-											(const char *)"DeviceProxy::get_locker_host()");
-		}
-		pos++;
-		if ((pos = f_addr.find(':',pos)) == string::npos)
-		{
-			Tango::Except::throw_exception((const char*)API_WrongLockingStatus,
-											(const char *)"Locker IP address returned by server is unvalid",
-											(const char *)"DeviceProxy::get_locker_host()");
-		}
-		pos++;
+    if (f_addr.find(":unix:") != string::npos)
+    {
+        ip_addr = TG_LOCAL_HOST;
+    }
+    else
+    {
+        string::size_type pos;
+        if ((pos = f_addr.find(':')) == string::npos)
+        {
+            Tango::Except::throw_exception((const char *) API_WrongLockingStatus,
+                                           (const char *) "Locker IP address returned by server is unvalid",
+                                           (const char *) "DeviceProxy::get_locker_host()");
+        }
+        pos++;
+        if ((pos = f_addr.find(':', pos)) == string::npos)
+        {
+            Tango::Except::throw_exception((const char *) API_WrongLockingStatus,
+                                           (const char *) "Locker IP address returned by server is unvalid",
+                                           (const char *) "DeviceProxy::get_locker_host()");
+        }
+        pos++;
 
-		if (ipv6 == true)
-		{
-			pos = pos + 3;
-			if ((pos = f_addr.find(':',pos)) == string::npos)
-			{
-				Tango::Except::throw_exception((const char*)API_WrongLockingStatus,
-											(const char *)"Locker IP address returned by server is unvalid",
-											(const char *)"DeviceProxy::get_locker_host()");
-			}
-			pos++;
-			string ip_str = f_addr.substr(pos);
-			if ((pos = ip_str.find(']')) == string::npos)
-			{
-				Tango::Except::throw_exception((const char*)API_WrongLockingStatus,
-											(const char *)"Locker IP address returned by server is unvalid",
-											(const char *)"DeviceProxy::get_locker_host()");
-			}
-			ip_addr = ip_str.substr(0,pos);
-		}
-		else
-		{
-			string ip_str = f_addr.substr(pos);
-			if ((pos = ip_str.find(':')) == string::npos)
-			{
-				Tango::Except::throw_exception((const char*)API_WrongLockingStatus,
-											(const char *)"Locker IP address returned by server is unvalid",
-											(const char *)"DeviceProxy::get_locker_host()");
-			}
-			ip_addr = ip_str.substr(0,pos);
-		}
-	}
+        if (ipv6 == true)
+        {
+            pos = pos + 3;
+            if ((pos = f_addr.find(':', pos)) == string::npos)
+            {
+                Tango::Except::throw_exception((const char *) API_WrongLockingStatus,
+                                               (const char *) "Locker IP address returned by server is unvalid",
+                                               (const char *) "DeviceProxy::get_locker_host()");
+            }
+            pos++;
+            string ip_str = f_addr.substr(pos);
+            if ((pos = ip_str.find(']')) == string::npos)
+            {
+                Tango::Except::throw_exception((const char *) API_WrongLockingStatus,
+                                               (const char *) "Locker IP address returned by server is unvalid",
+                                               (const char *) "DeviceProxy::get_locker_host()");
+            }
+            ip_addr = ip_str.substr(0, pos);
+        }
+        else
+        {
+            string ip_str = f_addr.substr(pos);
+            if ((pos = ip_str.find(':')) == string::npos)
+            {
+                Tango::Except::throw_exception((const char *) API_WrongLockingStatus,
+                                               (const char *) "Locker IP address returned by server is unvalid",
+                                               (const char *) "DeviceProxy::get_locker_host()");
+            }
+            ip_addr = ip_str.substr(0, pos);
+        }
+    }
 }
 
 //-----------------------------------------------------------------------------
@@ -8963,233 +9012,235 @@ DeviceAttribute DeviceProxy::write_read_attribute(DeviceAttribute &dev_attr)
 // This call is available only for Devices implemented IDL V4
 //
 
-	if (version < 4)
-	{
-		TangoSys_OMemStream desc;
-		desc << "Device " << device_name;
-		desc << " does not support write_read_attribute feature" << ends;
-		ApiNonSuppExcept::throw_exception((const char *)API_UnsupportedFeature,
-						  desc.str(),
-						  (const char *)"DeviceProxy::write_read_attribute");
-	}
+    if (version < 4)
+    {
+        TangoSys_OMemStream desc;
+        desc << "Device " << device_name;
+        desc << " does not support write_read_attribute feature" << ends;
+        ApiNonSuppExcept::throw_exception((const char *) API_UnsupportedFeature,
+                                          desc.str(),
+                                          (const char *) "DeviceProxy::write_read_attribute");
+    }
 
 //
 // Data into the AttributeValue object
 //
 
-	AttributeValueList_4 attr_value_list;
-	attr_value_list.length(1);
+    AttributeValueList_4 attr_value_list;
+    attr_value_list.length(1);
 
-	attr_value_list[0].name = dev_attr.name.c_str();
-	attr_value_list[0].quality = dev_attr.quality;
-	attr_value_list[0].data_format = dev_attr.data_format;
-	attr_value_list[0].time = dev_attr.time;
-	attr_value_list[0].w_dim.dim_x = dev_attr.dim_x;
-	attr_value_list[0].w_dim.dim_y = dev_attr.dim_y;
+    attr_value_list[0].name = dev_attr.name.c_str();
+    attr_value_list[0].quality = dev_attr.quality;
+    attr_value_list[0].data_format = dev_attr.data_format;
+    attr_value_list[0].time = dev_attr.time;
+    attr_value_list[0].w_dim.dim_x = dev_attr.dim_x;
+    attr_value_list[0].w_dim.dim_y = dev_attr.dim_y;
 
-	if (dev_attr.LongSeq.operator->() != NULL)
-		attr_value_list[0].value.long_att_value(dev_attr.LongSeq.in());
-	else if (dev_attr.Long64Seq.operator->() != NULL)
-		attr_value_list[0].value.long64_att_value(dev_attr.Long64Seq.in());
-	else if (dev_attr.ShortSeq.operator->() != NULL)
-		attr_value_list[0].value.short_att_value(dev_attr.ShortSeq.in());
-	else if (dev_attr.DoubleSeq.operator->() != NULL)
-		attr_value_list[0].value.double_att_value(dev_attr.DoubleSeq.in());
-	else if (dev_attr.StringSeq.operator->() != NULL)
-		attr_value_list[0].value.string_att_value(dev_attr.StringSeq.in());
-	else if (dev_attr.FloatSeq.operator->() != NULL)
-		attr_value_list[0].value.float_att_value(dev_attr.FloatSeq.in());
-	else if (dev_attr.BooleanSeq.operator->() != NULL)
-		attr_value_list[0].value.bool_att_value(dev_attr.BooleanSeq.in());
-	else if (dev_attr.UShortSeq.operator->() != NULL)
-		attr_value_list[0].value.ushort_att_value(dev_attr.UShortSeq.in());
-	else if (dev_attr.UCharSeq.operator->() != NULL)
-		attr_value_list[0].value.uchar_att_value(dev_attr.UCharSeq.in());
-	else if (dev_attr.ULongSeq.operator->() != NULL)
-		attr_value_list[0].value.ulong_att_value(dev_attr.ULongSeq.in());
-	else if (dev_attr.ULong64Seq.operator->() != NULL)
-		attr_value_list[0].value.ulong64_att_value(dev_attr.ULong64Seq.in());
-	else if (dev_attr.StateSeq.operator->() != NULL)
-		attr_value_list[0].value.state_att_value(dev_attr.StateSeq.in());
-	else if (dev_attr.EncodedSeq.operator->() != NULL)
-		attr_value_list[0].value.encoded_att_value(dev_attr.EncodedSeq.in());
+    if (dev_attr.LongSeq.operator->() != NULL)
+        attr_value_list[0].value.long_att_value(dev_attr.LongSeq.in());
+    else if (dev_attr.Long64Seq.operator->() != NULL)
+        attr_value_list[0].value.long64_att_value(dev_attr.Long64Seq.in());
+    else if (dev_attr.ShortSeq.operator->() != NULL)
+        attr_value_list[0].value.short_att_value(dev_attr.ShortSeq.in());
+    else if (dev_attr.DoubleSeq.operator->() != NULL)
+        attr_value_list[0].value.double_att_value(dev_attr.DoubleSeq.in());
+    else if (dev_attr.StringSeq.operator->() != NULL)
+        attr_value_list[0].value.string_att_value(dev_attr.StringSeq.in());
+    else if (dev_attr.FloatSeq.operator->() != NULL)
+        attr_value_list[0].value.float_att_value(dev_attr.FloatSeq.in());
+    else if (dev_attr.BooleanSeq.operator->() != NULL)
+        attr_value_list[0].value.bool_att_value(dev_attr.BooleanSeq.in());
+    else if (dev_attr.UShortSeq.operator->() != NULL)
+        attr_value_list[0].value.ushort_att_value(dev_attr.UShortSeq.in());
+    else if (dev_attr.UCharSeq.operator->() != NULL)
+        attr_value_list[0].value.uchar_att_value(dev_attr.UCharSeq.in());
+    else if (dev_attr.ULongSeq.operator->() != NULL)
+        attr_value_list[0].value.ulong_att_value(dev_attr.ULongSeq.in());
+    else if (dev_attr.ULong64Seq.operator->() != NULL)
+        attr_value_list[0].value.ulong64_att_value(dev_attr.ULong64Seq.in());
+    else if (dev_attr.StateSeq.operator->() != NULL)
+        attr_value_list[0].value.state_att_value(dev_attr.StateSeq.in());
+    else if (dev_attr.EncodedSeq.operator->() != NULL)
+        attr_value_list[0].value.encoded_att_value(dev_attr.EncodedSeq.in());
 
-	Tango::DevVarStringArray dvsa;
-	dvsa.length(1);
-	dvsa[0] = CORBA::string_dup(dev_attr.name.c_str());
+    Tango::DevVarStringArray dvsa;
+    dvsa.length(1);
+    dvsa[0] = CORBA::string_dup(dev_attr.name.c_str());
 
-	int ctr = 0;
-	AttributeValueList_4_var attr_value_list_4;
-	AttributeValueList_5_var attr_value_list_5;
-	Tango::AccessControlType local_act;
+    int ctr = 0;
+    AttributeValueList_4_var attr_value_list_4;
+    AttributeValueList_5_var attr_value_list_5;
+    Tango::AccessControlType local_act;
 
-	while (ctr < 2)
-	{
-		try
-		{
-			check_and_reconnect(local_act);
+    while (ctr < 2)
+    {
+        try
+        {
+            check_and_reconnect(local_act);
 
 //
 // Throw exception if caller not allowed to write_attribute
 //
 
-			if (local_act == ACCESS_READ)
-			{
-				try
-				{
-					Device_var dev = Device::_duplicate(device);
-					dev->ping();
-				}
-				catch(...)
-				{
-					set_connection_state(CONNECTION_NOTOK);
-					throw;
-				}
+            if (local_act == ACCESS_READ)
+            {
+                try
+                {
+                    Device_var dev = Device::_duplicate(device);
+                    dev->ping();
+                }
+                catch (...)
+                {
+                    set_connection_state(CONNECTION_NOTOK);
+                    throw;
+                }
 
-				TangoSys_OMemStream desc;
-				desc << "Writing attribute(s) on device " << dev_name() << " is not authorized" << ends;
+                TangoSys_OMemStream desc;
+                desc << "Writing attribute(s) on device " << dev_name() << " is not authorized" << ends;
 
-				NotAllowedExcept::throw_exception((const char *)API_ReadOnlyMode,desc.str(),
-											  	  (const char *)"DeviceProxy::write_read_attribute()");
-			}
+                NotAllowedExcept::throw_exception((const char *) API_ReadOnlyMode, desc.str(),
+                                                  (const char *) "DeviceProxy::write_read_attribute()");
+            }
 
 //
 // Now, call the server
 //
 
-			ClntIdent ci;
-			ApiUtil *au = ApiUtil::instance();
-			ci.cpp_clnt(au->get_client_pid());
+            ClntIdent ci;
+            ApiUtil *au = ApiUtil::instance();
+            ci.cpp_clnt(au->get_client_pid());
 
-			if (version >= 5)
-			{
-				Device_5_var dev = Device_5::_duplicate(device_5);
-				attr_value_list_5 = dev->write_read_attributes_5(attr_value_list,dvsa,ci);
-			}
-			else
-			{
-				Device_4_var dev = Device_4::_duplicate(device_4);
-				attr_value_list_4 = dev->write_read_attributes_4(attr_value_list,ci);
-			}
+            if (version >= 5)
+            {
+                Device_5_var dev = Device_5::_duplicate(device_5);
+                attr_value_list_5 = dev->write_read_attributes_5(attr_value_list, dvsa, ci);
+            }
+            else
+            {
+                Device_4_var dev = Device_4::_duplicate(device_4);
+                attr_value_list_4 = dev->write_read_attributes_4(attr_value_list, ci);
+            }
 
-			ctr = 2;
+            ctr = 2;
 
-		}
-		catch (Tango::MultiDevFailed &e)
-		{
+        }
+        catch (Tango::MultiDevFailed &e)
+        {
 
 //
 // Transfer this exception into a DevFailed exception
 //
 
-			Tango::DevFailed ex(e.errors[0].err_list);
-			TangoSys_OMemStream desc;
-			desc << "Failed to write_read_attribute on device " << device_name;
-			desc << ", attribute ";
-			desc << attr_value_list[0].name.in();
-			desc << ends;
-			Except::re_throw_exception(ex,(const char*)API_AttributeFailed,
-                        	desc.str(), (const char*)"DeviceProxy::write_read_attribute()");
+            Tango::DevFailed ex(e.errors[0].err_list);
+            TangoSys_OMemStream desc;
+            desc << "Failed to write_read_attribute on device " << device_name;
+            desc << ", attribute ";
+            desc << attr_value_list[0].name.in();
+            desc << ends;
+            Except::re_throw_exception(ex, (const char *) API_AttributeFailed,
+                                       desc.str(), (const char *) "DeviceProxy::write_read_attribute()");
 
-		}
-		catch (Tango::DevFailed &e)
-		{
-			TangoSys_OMemStream desc;
-			desc << "Failed to write_read_attribute on device " << device_name;
-			desc << ", attribute ";
-			desc << attr_value_list[0].name.in();
-			desc << ends;
+        }
+        catch (Tango::DevFailed &e)
+        {
+            TangoSys_OMemStream desc;
+            desc << "Failed to write_read_attribute on device " << device_name;
+            desc << ", attribute ";
+            desc << attr_value_list[0].name.in();
+            desc << ends;
 
-			if (::strcmp(e.errors[0].reason,DEVICE_UNLOCKED_REASON) == 0)
-				DeviceUnlockedExcept::re_throw_exception(e,(const char*)DEVICE_UNLOCKED_REASON,
-							desc.str(), (const char*)"DeviceProxy::write_read_attribute()");
-			else
-                Except::re_throw_exception(e,(const char*)API_AttributeFailed,
-                        	desc.str(), (const char*)"DeviceProxy::write_read_attribute()");
-		}
-		catch (CORBA::TRANSIENT &trans)
-		{
-			TRANSIENT_NOT_EXIST_EXCEPT(trans,"DeviceProxy","write_read_attribute()",this);
-		}
-		catch (CORBA::OBJECT_NOT_EXIST &one)
-		{
-			if (one.minor() == omni::OBJECT_NOT_EXIST_NoMatch || one.minor() == 0)
-			{
-				TRANSIENT_NOT_EXIST_EXCEPT(one,"DeviceProxy","write_read_attribute",this);
-			}
-			else
-			{
-				set_connection_state(CONNECTION_NOTOK);
-				TangoSys_OMemStream desc;
-				desc << "Failed to execute write_read_attribute on device " << device_name << ends;
-				ApiCommExcept::re_throw_exception(one,
-							      (const char*)"API_CommunicationFailed",
-                        				      desc.str(),
-							      (const char*)"DeviceProxy::write_read_attribute()");
-			}
-		}
-		catch (CORBA::COMM_FAILURE &comm)
-		{
-			if (comm.minor() == omni::COMM_FAILURE_WaitingForReply)
-			{
-				TRANSIENT_NOT_EXIST_EXCEPT(comm,"DeviceProxy","write_read_attribute",this);
-			}
-			else
-			{
-				set_connection_state(CONNECTION_NOTOK);
-				TangoSys_OMemStream desc;
-				desc << "Failed to execute write_attribute on device " << device_name << ends;
-				ApiCommExcept::re_throw_exception(comm,
-							      (const char*)"API_CommunicationFailed",
-                        				      desc.str(),
-							      (const char*)"DeviceProxy::write_read_attribute()");
-			}
-		}
+            if (::strcmp(e.errors[0].reason, DEVICE_UNLOCKED_REASON) == 0)
+                DeviceUnlockedExcept::re_throw_exception(e,
+                                                         (const char *) DEVICE_UNLOCKED_REASON,
+                                                         desc.str(),
+                                                         (const char *) "DeviceProxy::write_read_attribute()");
+            else
+                Except::re_throw_exception(e, (const char *) API_AttributeFailed,
+                                           desc.str(), (const char *) "DeviceProxy::write_read_attribute()");
+        }
+        catch (CORBA::TRANSIENT &trans)
+        {
+            TRANSIENT_NOT_EXIST_EXCEPT(trans, "DeviceProxy", "write_read_attribute()", this);
+        }
+        catch (CORBA::OBJECT_NOT_EXIST &one)
+        {
+            if (one.minor() == omni::OBJECT_NOT_EXIST_NoMatch || one.minor() == 0)
+            {
+                TRANSIENT_NOT_EXIST_EXCEPT(one, "DeviceProxy", "write_read_attribute", this);
+            }
+            else
+            {
+                set_connection_state(CONNECTION_NOTOK);
+                TangoSys_OMemStream desc;
+                desc << "Failed to execute write_read_attribute on device " << device_name << ends;
+                ApiCommExcept::re_throw_exception(one,
+                                                  (const char *) "API_CommunicationFailed",
+                                                  desc.str(),
+                                                  (const char *) "DeviceProxy::write_read_attribute()");
+            }
+        }
+        catch (CORBA::COMM_FAILURE &comm)
+        {
+            if (comm.minor() == omni::COMM_FAILURE_WaitingForReply)
+            {
+                TRANSIENT_NOT_EXIST_EXCEPT(comm, "DeviceProxy", "write_read_attribute", this);
+            }
+            else
+            {
+                set_connection_state(CONNECTION_NOTOK);
+                TangoSys_OMemStream desc;
+                desc << "Failed to execute write_attribute on device " << device_name << ends;
+                ApiCommExcept::re_throw_exception(comm,
+                                                  (const char *) "API_CommunicationFailed",
+                                                  desc.str(),
+                                                  (const char *) "DeviceProxy::write_read_attribute()");
+            }
+        }
         catch (CORBA::SystemException &ce)
         {
-			set_connection_state(CONNECTION_NOTOK);
+            set_connection_state(CONNECTION_NOTOK);
 
-			TangoSys_OMemStream desc;
-			desc << "Failed to execute write_attributes on device " << device_name << ends;
-			ApiCommExcept::re_throw_exception(ce,
-						      (const char*)"API_CommunicationFailed",
-                        			      desc.str(),
-						      (const char*)"DeviceProxy::write_read_attribute()");
-		}
-	}
+            TangoSys_OMemStream desc;
+            desc << "Failed to execute write_attributes on device " << device_name << ends;
+            ApiCommExcept::re_throw_exception(ce,
+                                              (const char *) "API_CommunicationFailed",
+                                              desc.str(),
+                                              (const char *) "DeviceProxy::write_read_attribute()");
+        }
+    }
 
 //
 // Init the returned DeviceAttribute instance
 //
 
-	DeviceAttribute ret_dev_attr;
-	if (version >= 5)
-		ApiUtil::attr_to_device(&(attr_value_list_5[0]),version,&ret_dev_attr);
-	else
-		ApiUtil::attr_to_device(&(attr_value_list_4[0]),version,&ret_dev_attr);
+    DeviceAttribute ret_dev_attr;
+    if (version >= 5)
+        ApiUtil::attr_to_device(&(attr_value_list_5[0]), version, &ret_dev_attr);
+    else
+        ApiUtil::attr_to_device(&(attr_value_list_4[0]), version, &ret_dev_attr);
 
 //
 // Add an error in the error stack in case there is one
 //
 
     DevErrorList_var &err_list = ret_dev_attr.get_error_list();
-	long nb_except = err_list.in().length();
-	if (nb_except != 0)
-	{
-		TangoSys_OMemStream desc;
-		desc << "Failed to write_read_attribute on device " << device_name;
-		desc << ", attribute " << dev_attr.name << ends;
+    long nb_except = err_list.in().length();
+    if (nb_except != 0)
+    {
+        TangoSys_OMemStream desc;
+        desc << "Failed to write_read_attribute on device " << device_name;
+        desc << ", attribute " << dev_attr.name << ends;
 
-		err_list.inout().length(nb_except + 1);
-		err_list[nb_except].reason = CORBA::string_dup(API_AttributeFailed);
-		err_list[nb_except].origin = CORBA::string_dup("DeviceProxy::write_read_attribute()");
+        err_list.inout().length(nb_except + 1);
+        err_list[nb_except].reason = CORBA::string_dup(API_AttributeFailed);
+        err_list[nb_except].origin = CORBA::string_dup("DeviceProxy::write_read_attribute()");
 
-		string st = desc.str();
-		err_list[nb_except].desc = CORBA::string_dup(st.c_str());
-		err_list[nb_except].severity = Tango::ERR;
-	}
+        string st = desc.str();
+        err_list[nb_except].desc = CORBA::string_dup(st.c_str());
+        err_list[nb_except].severity = Tango::ERR;
+    }
 
-	return(ret_dev_attr);
+    return (ret_dev_attr);
 }
 
 //-----------------------------------------------------------------------------
@@ -9198,244 +9249,246 @@ DeviceAttribute DeviceProxy::write_read_attribute(DeviceAttribute &dev_attr)
 //
 //-----------------------------------------------------------------------------
 
-vector<DeviceAttribute> *DeviceProxy::write_read_attributes(vector<DeviceAttribute> &attr_list,vector<string> &r_names)
+vector<DeviceAttribute> *DeviceProxy::write_read_attributes(vector<DeviceAttribute> &attr_list, vector<string> &r_names)
 {
 
 //
 // This call is available only for Devices implemented IDL V5
 //
 
-	if (version < 5)
-	{
-		TangoSys_OMemStream desc;
-		desc << "Device " << device_name;
-		desc << " does not support write_read_attributes feature" << ends;
-		ApiNonSuppExcept::throw_exception((const char *)API_UnsupportedFeature,
-						  desc.str(),
-						  (const char *)"DeviceProxy::write_read_attributes");
-	}
+    if (version < 5)
+    {
+        TangoSys_OMemStream desc;
+        desc << "Device " << device_name;
+        desc << " does not support write_read_attributes feature" << ends;
+        ApiNonSuppExcept::throw_exception((const char *) API_UnsupportedFeature,
+                                          desc.str(),
+                                          (const char *) "DeviceProxy::write_read_attributes");
+    }
 
 //
 // Data into the AttributeValue object
 //
 
-	AttributeValueList_4 attr_value_list;
-	attr_value_list.length(attr_list.size());
+    AttributeValueList_4 attr_value_list;
+    attr_value_list.length(attr_list.size());
 
-	for (unsigned int i=0; i<attr_list.size(); i++)
-	{
-		attr_value_list[i].name = attr_list[i].name.c_str();
-		attr_value_list[i].quality = attr_list[i].quality;
-		attr_value_list[i].data_format = attr_list[i].data_format;
-		attr_value_list[i].time = attr_list[i].time;
-		attr_value_list[i].w_dim.dim_x = attr_list[i].dim_x;
-		attr_value_list[i].w_dim.dim_y = attr_list[i].dim_y;
+    for (unsigned int i = 0; i < attr_list.size(); i++)
+    {
+        attr_value_list[i].name = attr_list[i].name.c_str();
+        attr_value_list[i].quality = attr_list[i].quality;
+        attr_value_list[i].data_format = attr_list[i].data_format;
+        attr_value_list[i].time = attr_list[i].time;
+        attr_value_list[i].w_dim.dim_x = attr_list[i].dim_x;
+        attr_value_list[i].w_dim.dim_y = attr_list[i].dim_y;
 
-		if (attr_list[i].LongSeq.operator->() != NULL)
-			attr_value_list[i].value.long_att_value(attr_list[i].LongSeq.in());
-		else if (attr_list[i].Long64Seq.operator->() != NULL)
-			attr_value_list[i].value.long64_att_value(attr_list[i].Long64Seq.in());
-		else if (attr_list[i].ShortSeq.operator->() != NULL)
-			attr_value_list[i].value.short_att_value(attr_list[i].ShortSeq.in());
-		else if (attr_list[i].DoubleSeq.operator->() != NULL)
-			attr_value_list[i].value.double_att_value(attr_list[i].DoubleSeq.in());
-		else if (attr_list[i].StringSeq.operator->() != NULL)
-			attr_value_list[i].value.string_att_value(attr_list[i].StringSeq.in());
-		else if (attr_list[i].FloatSeq.operator->() != NULL)
-			attr_value_list[i].value.float_att_value(attr_list[i].FloatSeq.in());
-		else if (attr_list[i].BooleanSeq.operator->() != NULL)
-			attr_value_list[i].value.bool_att_value(attr_list[i].BooleanSeq.in());
-		else if (attr_list[i].UShortSeq.operator->() != NULL)
-			attr_value_list[i].value.ushort_att_value(attr_list[i].UShortSeq.in());
-		else if (attr_list[i].UCharSeq.operator->() != NULL)
-			attr_value_list[i].value.uchar_att_value(attr_list[i].UCharSeq.in());
-		else if (attr_list[i].ULongSeq.operator->() != NULL)
-			attr_value_list[i].value.ulong_att_value(attr_list[i].ULongSeq.in());
-		else if (attr_list[i].ULong64Seq.operator->() != NULL)
-			attr_value_list[i].value.ulong64_att_value(attr_list[i].ULong64Seq.in());
-		else if (attr_list[i].StateSeq.operator->() != NULL)
-			attr_value_list[i].value.state_att_value(attr_list[i].StateSeq.in());
-		else if (attr_list[i].EncodedSeq.operator->() != NULL)
-			attr_value_list[i].value.encoded_att_value(attr_list[i].EncodedSeq.in());
-	}
+        if (attr_list[i].LongSeq.operator->() != NULL)
+            attr_value_list[i].value.long_att_value(attr_list[i].LongSeq.in());
+        else if (attr_list[i].Long64Seq.operator->() != NULL)
+            attr_value_list[i].value.long64_att_value(attr_list[i].Long64Seq.in());
+        else if (attr_list[i].ShortSeq.operator->() != NULL)
+            attr_value_list[i].value.short_att_value(attr_list[i].ShortSeq.in());
+        else if (attr_list[i].DoubleSeq.operator->() != NULL)
+            attr_value_list[i].value.double_att_value(attr_list[i].DoubleSeq.in());
+        else if (attr_list[i].StringSeq.operator->() != NULL)
+            attr_value_list[i].value.string_att_value(attr_list[i].StringSeq.in());
+        else if (attr_list[i].FloatSeq.operator->() != NULL)
+            attr_value_list[i].value.float_att_value(attr_list[i].FloatSeq.in());
+        else if (attr_list[i].BooleanSeq.operator->() != NULL)
+            attr_value_list[i].value.bool_att_value(attr_list[i].BooleanSeq.in());
+        else if (attr_list[i].UShortSeq.operator->() != NULL)
+            attr_value_list[i].value.ushort_att_value(attr_list[i].UShortSeq.in());
+        else if (attr_list[i].UCharSeq.operator->() != NULL)
+            attr_value_list[i].value.uchar_att_value(attr_list[i].UCharSeq.in());
+        else if (attr_list[i].ULongSeq.operator->() != NULL)
+            attr_value_list[i].value.ulong_att_value(attr_list[i].ULongSeq.in());
+        else if (attr_list[i].ULong64Seq.operator->() != NULL)
+            attr_value_list[i].value.ulong64_att_value(attr_list[i].ULong64Seq.in());
+        else if (attr_list[i].StateSeq.operator->() != NULL)
+            attr_value_list[i].value.state_att_value(attr_list[i].StateSeq.in());
+        else if (attr_list[i].EncodedSeq.operator->() != NULL)
+            attr_value_list[i].value.encoded_att_value(attr_list[i].EncodedSeq.in());
+    }
 
 //
 // Create remaining parameter
 //
 
-	Tango::DevVarStringArray dvsa;
-	dvsa << r_names;
+    Tango::DevVarStringArray dvsa;
+    dvsa << r_names;
 
 //
 // Call device
 //
 
-	int ctr = 0;
-	AttributeValueList_5_var attr_value_list_5;
-	Tango::AccessControlType local_act;
+    int ctr = 0;
+    AttributeValueList_5_var attr_value_list_5;
+    Tango::AccessControlType local_act;
 
-	while (ctr < 2)
-	{
-		try
-		{
-			check_and_reconnect(local_act);
+    while (ctr < 2)
+    {
+        try
+        {
+            check_and_reconnect(local_act);
 
 //
 // Throw exception if caller not allowed to write_attribute
 //
 
-			if (local_act == ACCESS_READ)
-			{
-				try
-				{
-					Device_var dev = Device::_duplicate(device);
-					dev->ping();
-				}
-				catch(...)
-				{
-					set_connection_state(CONNECTION_NOTOK);
-					throw;
-				}
+            if (local_act == ACCESS_READ)
+            {
+                try
+                {
+                    Device_var dev = Device::_duplicate(device);
+                    dev->ping();
+                }
+                catch (...)
+                {
+                    set_connection_state(CONNECTION_NOTOK);
+                    throw;
+                }
 
-				TangoSys_OMemStream desc;
-				desc << "Writing attribute(s) on device " << dev_name() << " is not authorized" << ends;
+                TangoSys_OMemStream desc;
+                desc << "Writing attribute(s) on device " << dev_name() << " is not authorized" << ends;
 
-				NotAllowedExcept::throw_exception((const char *)API_ReadOnlyMode,desc.str(),
-											  	  (const char *)"DeviceProxy::write_read_attribute()");
-			}
+                NotAllowedExcept::throw_exception((const char *) API_ReadOnlyMode, desc.str(),
+                                                  (const char *) "DeviceProxy::write_read_attribute()");
+            }
 
 //
 // Now, call the server
 //
 
-			ClntIdent ci;
-			ApiUtil *au = ApiUtil::instance();
-			ci.cpp_clnt(au->get_client_pid());
+            ClntIdent ci;
+            ApiUtil *au = ApiUtil::instance();
+            ci.cpp_clnt(au->get_client_pid());
 
-			Device_5_var dev = Device_5::_duplicate(device_5);
-			attr_value_list_5 = dev->write_read_attributes_5(attr_value_list,dvsa,ci);
+            Device_5_var dev = Device_5::_duplicate(device_5);
+            attr_value_list_5 = dev->write_read_attributes_5(attr_value_list, dvsa, ci);
 
-			ctr = 2;
-		}
-		catch (Tango::MultiDevFailed &e)
-		{
+            ctr = 2;
+        }
+        catch (Tango::MultiDevFailed &e)
+        {
 
 //
 // Transfer this exception into a DevFailed exception
 //
 
-			Tango::DevFailed ex(e.errors[0].err_list);
-			TangoSys_OMemStream desc;
-			desc << "Failed to write_read_attributes on device " << device_name;
-			desc << ", attribute ";
-			desc << attr_value_list[0].name.in();
-			desc << ends;
-			Except::re_throw_exception(ex,(const char*)API_AttributeFailed,
-                        	desc.str(), (const char*)"DeviceProxy::write_read_attributes()");
+            Tango::DevFailed ex(e.errors[0].err_list);
+            TangoSys_OMemStream desc;
+            desc << "Failed to write_read_attributes on device " << device_name;
+            desc << ", attribute ";
+            desc << attr_value_list[0].name.in();
+            desc << ends;
+            Except::re_throw_exception(ex, (const char *) API_AttributeFailed,
+                                       desc.str(), (const char *) "DeviceProxy::write_read_attributes()");
 
-		}
-		catch (Tango::DevFailed &e)
-		{
-			TangoSys_OMemStream desc;
-			desc << "Failed to write_read_attributes on device " << device_name;
-			desc << ", attribute ";
-			desc << attr_value_list[0].name.in();
-			desc << ends;
+        }
+        catch (Tango::DevFailed &e)
+        {
+            TangoSys_OMemStream desc;
+            desc << "Failed to write_read_attributes on device " << device_name;
+            desc << ", attribute ";
+            desc << attr_value_list[0].name.in();
+            desc << ends;
 
-			if (::strcmp(e.errors[0].reason,DEVICE_UNLOCKED_REASON) == 0)
-				DeviceUnlockedExcept::re_throw_exception(e,(const char*)DEVICE_UNLOCKED_REASON,
-							desc.str(), (const char*)"DeviceProxy::write_read_attributes()");
-			else
-                Except::re_throw_exception(e,(const char*)API_AttributeFailed,
-                        	desc.str(), (const char*)"DeviceProxy::write_read_attributes()");
-		}
-		catch (CORBA::TRANSIENT &trans)
-		{
-			TRANSIENT_NOT_EXIST_EXCEPT(trans,"DeviceProxy","write_read_attributes()",this);
-		}
-		catch (CORBA::OBJECT_NOT_EXIST &one)
-		{
-			if (one.minor() == omni::OBJECT_NOT_EXIST_NoMatch || one.minor() == 0)
-			{
-				TRANSIENT_NOT_EXIST_EXCEPT(one,"DeviceProxy","write_read_attributes",this);
-			}
-			else
-			{
-				set_connection_state(CONNECTION_NOTOK);
-				TangoSys_OMemStream desc;
-				desc << "Failed to execute write_read_attributes on device " << device_name << ends;
-				ApiCommExcept::re_throw_exception(one,
-							      (const char*)"API_CommunicationFailed",
-                        				      desc.str(),
-							      (const char*)"DeviceProxy::write_read_attributes()");
-			}
-		}
-		catch (CORBA::COMM_FAILURE &comm)
-		{
-			if (comm.minor() == omni::COMM_FAILURE_WaitingForReply)
-			{
-				TRANSIENT_NOT_EXIST_EXCEPT(comm,"DeviceProxy","write_read_attributes",this);
-			}
-			else
-			{
-				set_connection_state(CONNECTION_NOTOK);
-				TangoSys_OMemStream desc;
-				desc << "Failed to execute write_attributes on device " << device_name << ends;
-				ApiCommExcept::re_throw_exception(comm,
-							      (const char*)"API_CommunicationFailed",
-                        				      desc.str(),
-							      (const char*)"DeviceProxy::write_read_attributes()");
-			}
-		}
+            if (::strcmp(e.errors[0].reason, DEVICE_UNLOCKED_REASON) == 0)
+                DeviceUnlockedExcept::re_throw_exception(e,
+                                                         (const char *) DEVICE_UNLOCKED_REASON,
+                                                         desc.str(),
+                                                         (const char *) "DeviceProxy::write_read_attributes()");
+            else
+                Except::re_throw_exception(e, (const char *) API_AttributeFailed,
+                                           desc.str(), (const char *) "DeviceProxy::write_read_attributes()");
+        }
+        catch (CORBA::TRANSIENT &trans)
+        {
+            TRANSIENT_NOT_EXIST_EXCEPT(trans, "DeviceProxy", "write_read_attributes()", this);
+        }
+        catch (CORBA::OBJECT_NOT_EXIST &one)
+        {
+            if (one.minor() == omni::OBJECT_NOT_EXIST_NoMatch || one.minor() == 0)
+            {
+                TRANSIENT_NOT_EXIST_EXCEPT(one, "DeviceProxy", "write_read_attributes", this);
+            }
+            else
+            {
+                set_connection_state(CONNECTION_NOTOK);
+                TangoSys_OMemStream desc;
+                desc << "Failed to execute write_read_attributes on device " << device_name << ends;
+                ApiCommExcept::re_throw_exception(one,
+                                                  (const char *) "API_CommunicationFailed",
+                                                  desc.str(),
+                                                  (const char *) "DeviceProxy::write_read_attributes()");
+            }
+        }
+        catch (CORBA::COMM_FAILURE &comm)
+        {
+            if (comm.minor() == omni::COMM_FAILURE_WaitingForReply)
+            {
+                TRANSIENT_NOT_EXIST_EXCEPT(comm, "DeviceProxy", "write_read_attributes", this);
+            }
+            else
+            {
+                set_connection_state(CONNECTION_NOTOK);
+                TangoSys_OMemStream desc;
+                desc << "Failed to execute write_attributes on device " << device_name << ends;
+                ApiCommExcept::re_throw_exception(comm,
+                                                  (const char *) "API_CommunicationFailed",
+                                                  desc.str(),
+                                                  (const char *) "DeviceProxy::write_read_attributes()");
+            }
+        }
         catch (CORBA::SystemException &ce)
         {
-			set_connection_state(CONNECTION_NOTOK);
+            set_connection_state(CONNECTION_NOTOK);
 
-			TangoSys_OMemStream desc;
-			desc << "Failed to execute write_read_attributes on device " << device_name << ends;
-			ApiCommExcept::re_throw_exception(ce,
-						      (const char*)"API_CommunicationFailed",
-                        			      desc.str(),
-						      (const char*)"DeviceProxy::write_read_attributes()");
-		}
-	}
+            TangoSys_OMemStream desc;
+            desc << "Failed to execute write_read_attributes on device " << device_name << ends;
+            ApiCommExcept::re_throw_exception(ce,
+                                              (const char *) "API_CommunicationFailed",
+                                              desc.str(),
+                                              (const char *) "DeviceProxy::write_read_attributes()");
+        }
+    }
 
 //
 // Init the returned DeviceAttribute vector
 
-	unsigned long nb_received;
-	nb_received = attr_value_list_5->length();
+    unsigned long nb_received;
+    nb_received = attr_value_list_5->length();
 
-	vector<DeviceAttribute> *dev_attr = new(vector<DeviceAttribute>);
-	dev_attr->resize(nb_received);
+    vector<DeviceAttribute> *dev_attr = new(vector<DeviceAttribute>);
+    dev_attr->resize(nb_received);
 
-	for (unsigned int i=0; i < nb_received; i++)
-	{
-		ApiUtil::attr_to_device(&(attr_value_list_5[i]),5,&(*dev_attr)[i]);
+    for (unsigned int i = 0; i < nb_received; i++)
+    {
+        ApiUtil::attr_to_device(&(attr_value_list_5[i]), 5, &(*dev_attr)[i]);
 
 //
 // Add an error in the error stack in case there is one
 //
 
-		DevErrorList_var &err_list = (*dev_attr)[i].get_error_list();
-		long nb_except = err_list.in().length();
-		if (nb_except != 0)
-		{
-			TangoSys_OMemStream desc;
-			desc << "Failed to write_read_attribute on device " << device_name;
-			desc << ", attribute " << (*dev_attr)[i].name << ends;
+        DevErrorList_var &err_list = (*dev_attr)[i].get_error_list();
+        long nb_except = err_list.in().length();
+        if (nb_except != 0)
+        {
+            TangoSys_OMemStream desc;
+            desc << "Failed to write_read_attribute on device " << device_name;
+            desc << ", attribute " << (*dev_attr)[i].name << ends;
 
-			err_list.inout().length(nb_except + 1);
-			err_list[nb_except].reason = CORBA::string_dup(API_AttributeFailed);
-			err_list[nb_except].origin = CORBA::string_dup("DeviceProxy::write_read_attributes()");
+            err_list.inout().length(nb_except + 1);
+            err_list[nb_except].reason = CORBA::string_dup(API_AttributeFailed);
+            err_list[nb_except].origin = CORBA::string_dup("DeviceProxy::write_read_attributes()");
 
-			string st = desc.str();
-			err_list[nb_except].desc = CORBA::string_dup(st.c_str());
-			err_list[nb_except].severity = Tango::ERR;
-		}
-	}
+            string st = desc.str();
+            err_list[nb_except].desc = CORBA::string_dup(st.c_str());
+            err_list[nb_except].severity = Tango::ERR;
+        }
+    }
 
-	return(dev_attr);
+    return (dev_attr);
 }
 
 //-----------------------------------------------------------------------------
@@ -9451,42 +9504,42 @@ vector<DeviceAttribute> *DeviceProxy::write_read_attributes(vector<DeviceAttribu
 //-----------------------------------------------------------------------------
 
 
-void DeviceProxy::same_att_name(vector<string> &attr_list,const char *met_name)
+void DeviceProxy::same_att_name(vector<string> &attr_list, const char *met_name)
 {
-	if (attr_list.size() > 1)
-	{
-	    unsigned int i;
-		vector<string> same_att = attr_list;
+    if (attr_list.size() > 1)
+    {
+        unsigned int i;
+        vector<string> same_att = attr_list;
 
-		for (i = 0;i < same_att.size();++i)
-			transform(same_att[i].begin(),same_att[i].end(),same_att[i].begin(),::tolower);
-		sort(same_att.begin(),same_att.end());
-		vector<string> same_att_lower = same_att;
+        for (i = 0; i < same_att.size(); ++i)
+            transform(same_att[i].begin(), same_att[i].end(), same_att[i].begin(), ::tolower);
+        sort(same_att.begin(), same_att.end());
+        vector<string> same_att_lower = same_att;
 
-		vector<string>::iterator pos = unique(same_att.begin(),same_att.end());
+        vector<string>::iterator pos = unique(same_att.begin(), same_att.end());
 
-		int duplicate_att;
-		duplicate_att = distance(attr_list.begin(),attr_list.end()) - distance(same_att.begin(),pos);
+        int duplicate_att;
+        duplicate_att = distance(attr_list.begin(), attr_list.end()) - distance(same_att.begin(), pos);
 
-		if (duplicate_att != 0)
-		{
-			TangoSys_OMemStream desc;
-			desc << "Several times the same attribute in required attributes list: ";
-			int ctr = 0;
-			for (i = 0;i < same_att_lower.size() - 1;i++)
-			{
-				if (same_att_lower[i] == same_att_lower[i + 1])
-				{
-					ctr++;
-					desc << same_att_lower[i];
-					if (ctr < duplicate_att)
-						desc << ", ";
-				}
-			}
-			desc << ends;
-			ApiConnExcept::throw_exception((const char*)API_AttributeFailed,desc.str(), met_name);
-		}
-	}
+        if (duplicate_att != 0)
+        {
+            TangoSys_OMemStream desc;
+            desc << "Several times the same attribute in required attributes list: ";
+            int ctr = 0;
+            for (i = 0; i < same_att_lower.size() - 1; i++)
+            {
+                if (same_att_lower[i] == same_att_lower[i + 1])
+                {
+                    ctr++;
+                    desc << same_att_lower[i];
+                    if (ctr < duplicate_att)
+                        desc << ", ";
+                }
+            }
+            desc << ends;
+            ApiConnExcept::throw_exception((const char *) API_AttributeFailed, desc.str(), met_name);
+        }
+    }
 }
 
 //-----------------------------------------------------------------------------
@@ -9498,7 +9551,7 @@ void DeviceProxy::same_att_name(vector<string> &attr_list,const char *met_name)
 
 void DeviceProxy::local_import(string &local_ior)
 {
-	Tango::Util *tg = NULL;
+    Tango::Util *tg = NULL;
 
 //
 // In case of controlled access used, this method is called while the
@@ -9506,26 +9559,26 @@ void DeviceProxy::local_import(string &local_ior)
 // Catch this exception and return from this method in this case
 //
 
-	try
-	{
-		tg = Tango::Util::instance(false);
-	}
-	catch (Tango::DevFailed &e)
-	{
-		string reas(e.errors[0].reason);
-		if (reas ==  "API_UtilSingletonNotCreated")
-			return;
-	}
+    try
+    {
+        tg = Tango::Util::instance(false);
+    }
+    catch (Tango::DevFailed &e)
+    {
+        string reas(e.errors[0].reason);
+        if (reas == "API_UtilSingletonNotCreated")
+            return;
+    }
 
-	const vector<Tango::DeviceClass *> *cl_list_ptr = tg->get_class_list();
-	for (unsigned int loop = 0;loop < cl_list_ptr->size();loop++)
-	{
-		Tango::DeviceClass *cl_ptr = (*cl_list_ptr)[loop];
-		vector<Tango::DeviceImpl *> dev_list = cl_ptr->get_device_list();
-		for (unsigned int lo = 0;lo < dev_list.size();lo++)
-		{
-			if (dev_list[lo]->get_name_lower() == device_name)
-			{
+    const vector<Tango::DeviceClass *> *cl_list_ptr = tg->get_class_list();
+    for (unsigned int loop = 0; loop < cl_list_ptr->size(); loop++)
+    {
+        Tango::DeviceClass *cl_ptr = (*cl_list_ptr)[loop];
+        vector<Tango::DeviceImpl *> dev_list = cl_ptr->get_device_list();
+        for (unsigned int lo = 0; lo < dev_list.size(); lo++)
+        {
+            if (dev_list[lo]->get_name_lower() == device_name)
+            {
                 if (Tango::Util::_UseDb == true)
                 {
                     Database *db = tg->get_database();
@@ -9533,19 +9586,19 @@ void DeviceProxy::local_import(string &local_ior)
                         return;
                 }
 
-				Tango::Device_var d_var = dev_list[lo]->get_d_var();
-				CORBA::ORB_ptr orb_ptr = tg->get_orb();
+                Tango::Device_var d_var = dev_list[lo]->get_d_var();
+                CORBA::ORB_ptr orb_ptr = tg->get_orb();
 
-				char *s = orb_ptr->object_to_string(d_var);
-				local_ior = s;
+                char *s = orb_ptr->object_to_string(d_var);
+                local_ior = s;
 
-				CORBA::release(orb_ptr);
-				CORBA::string_free(s);
+                CORBA::release(orb_ptr);
+                CORBA::string_free(s);
 
-				return;
-			}
-		}
-	}
+                return;
+            }
+        }
+    }
 }
 
 //---------------------------------------------------------------------------------------------------------------------
@@ -9564,30 +9617,30 @@ void DeviceProxy::local_import(string &local_ior)
 
 int DeviceProxy::get_tango_lib_version()
 {
-	int ret = 0;
+    int ret = 0;
 
-	check_connect_adm_device();
+    check_connect_adm_device();
 
 //
 // Get admin device IDL release and command list
 //
 
-	int admin_idl_vers = adm_device->get_idl_version();
-	Tango::CommandInfoList *cmd_list;
-	cmd_list = adm_device->command_list_query();
+    int admin_idl_vers = adm_device->get_idl_version();
+    Tango::CommandInfoList *cmd_list;
+    cmd_list = adm_device->command_list_query();
 
-	switch (admin_idl_vers)
-	{
-	case 1:
-		ret = 100;
-		break;
+    switch (admin_idl_vers)
+    {
+        case 1:
+            ret = 100;
+            break;
 
-	case 2:
-		ret = 200;
-		break;
+        case 2:
+            ret = 200;
+            break;
 
-	case 3:
-	{
+        case 3:
+        {
 
 //
 // IDL 3 is for Tango 5 and 6. Unfortunately, there is no way from the client side to determmine if it is
@@ -9595,50 +9648,50 @@ int DeviceProxy::get_tango_lib_version()
 //
 
 #ifdef HAS_LAMBDA_FUNC
-		auto pos = find_if((*cmd_list).begin(),(*cmd_list).end(),
-					[] (Tango::CommandInfo &cc) -> bool
-					{
-						return cc.cmd_name == "QueryWizardClassProperty";
-					});
+            auto pos = find_if((*cmd_list).begin(), (*cmd_list).end(),
+                               [](Tango::CommandInfo &cc) -> bool
+                               {
+                                   return cc.cmd_name == "QueryWizardClassProperty";
+                               });
 #else
-		vector<CommandInfo>::iterator pos,end;
+                                                                                                                                    vector<CommandInfo>::iterator pos,end;
 		for (pos = (*cmd_list).begin(), end = (*cmd_list).end();pos != end;++pos)
 		{
 			if (pos->cmd_name == "QueryWizardClassProperty")
 				break;
 		}
 #endif
-		if (pos != (*cmd_list).end())
-			ret = 520;
-		else
-			ret = 500;
-		break;
-	}
+            if (pos != (*cmd_list).end())
+                ret = 520;
+            else
+                ret = 500;
+            break;
+        }
 
-	case 4:
-	{
+        case 4:
+        {
 
 //
 // IDL 4 is for Tango 7 and 8.
 //
 
-		bool ecs = false;
-		bool zesc = false;
+            bool ecs = false;
+            bool zesc = false;
 
 #ifdef HAS_RANGE_BASE_FOR
-		for (const auto &cmd : *cmd_list)
-		{
-			if (cmd.cmd_name == "EventConfirmSubscription")
-			{
-				ecs = true;
-				break;
-			}
+            for (const auto &cmd : *cmd_list)
+            {
+                if (cmd.cmd_name == "EventConfirmSubscription")
+                {
+                    ecs = true;
+                    break;
+                }
 
-			if (cmd.cmd_name == "ZmqEventSubscriptionChange")
-				zesc = true;
-		}
+                if (cmd.cmd_name == "ZmqEventSubscriptionChange")
+                    zesc = true;
+            }
 #else
-		vector<CommandInfo>::iterator pos,pos_end;
+                                                                                                                                    vector<CommandInfo>::iterator pos,pos_end;
 		for (pos = (*cmd_list).begin(), pos_end = (*cmd_list).end();pos != pos_end;++pos)
 		{
 			if (pos->cmd_name == "EventConfirmSubscription")
@@ -9651,27 +9704,27 @@ int DeviceProxy::get_tango_lib_version()
 				zesc = true;
 		}
 #endif
-		if (ecs == true)
-			ret = 810;
-		else if (zesc == true)
-			ret = 800;
-		else
-			ret = 700;
+            if (ecs == true)
+                ret = 810;
+            else if (zesc == true)
+                ret = 800;
+            else
+                ret = 700;
 
-		break;
-	}
+            break;
+        }
 
-	case 5:
-		ret = 902;
-		break;
+        case 5:
+            ret = 902;
+            break;
 
-	default:
-		break;
-	}
+        default:
+            break;
+    }
 
-	delete cmd_list;
+    delete cmd_list;
 
-	return ret;
+    return ret;
 }
 
 } // End of Tango namespace

--- a/cppapi/client/devapi_base.cpp
+++ b/cppapi/client/devapi_base.cpp
@@ -1100,7 +1100,7 @@ void Connection::get_fqdn(string &the_host)
 //
 
     size_t i;
-    for (i = 0; i < ip_list.size() && !host_found; i++)
+    for (i = 0; i < ip_list.size() &&  not host_found; i++)
     {
         int result = getaddrinfo(ip_list[i].c_str(), NULL, &hints, &info);
 
@@ -9171,7 +9171,7 @@ bool DeviceProxy::is_locked_by_me()
 #ifndef _TG_WINDOWS_
         if (getpid() != v_l[1])
 #else
-            if (_getpid() != v_l[1])
+        if (_getpid() != v_l[1])
 #endif
         {
             ret = false;

--- a/cppapi/client/devapi_base.cpp
+++ b/cppapi/client/devapi_base.cpp
@@ -36,7 +36,7 @@
 #include <devapi_utils.tpp>
 
 #ifdef _TG_WINDOWS_
-                                                                                                                        #include <sys/timeb.h>
+#include <sys/timeb.h>
 #include <process.h>
 #include <ws2tcpip.h>
 #else
@@ -211,13 +211,15 @@ Connection::Connection(const Connection &sou)
         *(ext.get()) = *(sou.ext.get());
     }
 #else
-                                                                                                                            if (sou.ext != NULL)
-	{
-		ext = new ConnectionExt();
-		*ext = *(sou.ext);
-	}
-	else
-		ext = NULL;
+    if (sou.ext != NULL)
+    {
+        ext = new ConnectionExt();
+        *ext = *(sou.ext);
+    }
+    else
+    {
+        ext = NULL;
+    }
 #endif
 }
 
@@ -281,13 +283,15 @@ Connection &Connection::operator=(const Connection &rval)
         ext.reset(Tango_nullptr);
     }
 #else
-                                                                                                                            if (rval.ext != NULL)
-	{
-		ext = new ConnectionExt();
-		*ext = *(rval.ext);
-	}
-	else
-		ext = NULL;
+    if (rval.ext != NULL)
+    {
+        ext = new ConnectionExt();
+        *ext = *(rval.ext);
+    }
+    else
+    {
+        ext = NULL;
+    }
 #endif
 
     return *this;
@@ -732,10 +736,10 @@ void Connection::reconnect(bool db_used)
 #ifndef _TG_WINDOWS_
     gettimeofday(&now, NULL);
 #else
-                                                                                                                            struct _timeb now_win;
-	_ftime(&now_win);
-	now.tv_sec = (unsigned long)now_win.time;
-	now.tv_usec = (long)now_win.millitm * 1000;
+    struct _timeb now_win;
+    _ftime(&now_win);
+    now.tv_sec = (unsigned long) now_win.time;
+    now.tv_usec = (long) now_win.millitm * 1000;
 #endif /* _TG_WINDOWS_ */
 
     double t = (double) now.tv_sec + ((double) now.tv_usec / 1000000);
@@ -942,24 +946,24 @@ int Connection::get_env_var(const char *env_var_name, string &env_var)
             }
         }
 #else
-                                                                                                                                char *env_tango_root;
+        char *env_tango_root;
 
-		env_tango_root = getenv(WindowsEnvVariable);
-		if (env_tango_root != NULL)
-		{
-			string home_file(env_tango_root);
-			home_file = home_file + "/" + WINDOWS_ENV_VAR_FILE;
+        env_tango_root = getenv(WindowsEnvVariable);
+        if (env_tango_root != NULL)
+        {
+            string home_file(env_tango_root);
+            home_file = home_file + "/" + WINDOWS_ENV_VAR_FILE;
 
-			int local_ret;
-			string local_env_var;
-			local_ret = get_env_var_from_file(home_file,env_var_name,local_env_var);
+            int local_ret;
+            string local_env_var;
+            local_ret = get_env_var_from_file(home_file, env_var_name, local_env_var);
 
-			if (local_ret == 0)
-			{
-				env_var = local_env_var;
-				ret = 0;
-			}
-		}
+            if (local_ret == 0)
+            {
+                env_var = local_env_var;
+                ret = 0;
+            }
+        }
 
 #endif
     }
@@ -993,7 +997,7 @@ int Connection::get_env_var_from_file(string &f_name, const char *env_var, strin
     int ret = -1;
 
     inFile.open(f_name.c_str());
-    if (!inFile)
+    if (not inFile)
     {
         return ret;
     }
@@ -1002,7 +1006,7 @@ int Connection::get_env_var_from_file(string &f_name, const char *env_var, strin
 
     string::size_type pos_env, pos_comment;
 
-    while (!inFile.eof())
+    while (not inFile.eof())
     {
         getline(inFile, file_line);
         transform(file_line.begin(), file_line.end(), file_line.begin(), ::tolower);
@@ -1948,13 +1952,15 @@ DeviceProxy::DeviceProxy(const DeviceProxy &sou)
         *(ext_proxy.get()) = *(sou.ext_proxy.get());
     }
 #else
-                                                                                                                            if (sou.ext_proxy == NULL)
-		ext_proxy = NULL;
-	else
-	{
-		ext_proxy = new DeviceProxyExt();
-		*ext_proxy = *(sou.ext_proxy);
-	}
+    if (sou.ext_proxy == NULL)
+    {
+        ext_proxy = NULL;
+    }
+    else
+    {
+        ext_proxy = new DeviceProxyExt();
+        *ext_proxy = *(sou.ext_proxy);
+    }
 #endif
 
 }
@@ -2033,7 +2039,9 @@ DeviceProxy &DeviceProxy::operator=(const DeviceProxy &rval)
             *ext_proxy = *(rval.ext_proxy);
         }
         else
+        {
             ext_proxy = NULL;
+        }
 #endif
     }
 
@@ -2696,9 +2704,9 @@ int DeviceProxy::ping()
 
     gettimeofday(&before, NULL);
 #else
-                                                                                                                            struct _timeb before, after;
+    struct _timeb before, after;
 
-	_ftime(&before);
+    _ftime(&before);
 #endif /* _TG_WINDOWS_ */
 
     int ctr = 0;
@@ -2768,9 +2776,9 @@ int DeviceProxy::ping()
     elapsed = (after.tv_sec - before.tv_sec) * 1000000;
     elapsed = (after.tv_usec - before.tv_usec) + elapsed;
 #else
-                                                                                                                            _ftime(&after);
-	elapsed = (after.time-before.time)*1000000;
-	elapsed = (after.millitm-before.millitm)*1000 + elapsed;
+    _ftime(&after);
+    elapsed = (after.time - before.time) * 1000000;
+    elapsed = (after.millitm - before.millitm) * 1000 + elapsed;
 #endif /* _TG_WINDOWS_ */
 
     return (elapsed);
@@ -9286,8 +9294,8 @@ bool DeviceProxy::get_locker(LockerInfo &lock_info)
             si.sin_family = AF_INET;
             si.sin_port = 0;
 #ifdef _TG_WINDOWS_
-                                                                                                                                    int slen = sizeof(si);
-			WSAStringToAddress((char *)full_ip.c_str(),AF_INET,NULL,(SOCKADDR *)&si,&slen);
+            int slen = sizeof(si);
+            WSAStringToAddress((char *) full_ip.c_str(), AF_INET, NULL, (SOCKADDR * ) & si, &slen);
 #else
             inet_pton(AF_INET, full_ip.c_str(), &si.sin_addr);
 #endif
@@ -10166,12 +10174,14 @@ int DeviceProxy::get_tango_lib_version()
                                    return cc.cmd_name == "QueryWizardClassProperty";
                                });
 #else
-                                                                                                                                    vector<CommandInfo>::iterator pos,end;
-		for (pos = (*cmd_list).begin(), end = (*cmd_list).end();pos != end;++pos)
-		{
-			if (pos->cmd_name == "QueryWizardClassProperty")
-				break;
-		}
+            vector<CommandInfo>::iterator pos, end;
+            for (pos = (*cmd_list).begin(), end = (*cmd_list).end(); pos != end; ++pos)
+            {
+                if (pos->cmd_name == "QueryWizardClassProperty")
+                {
+                    break;
+                }
+            }
 #endif
             if (pos != (*cmd_list).end())
             {
@@ -10209,18 +10219,20 @@ int DeviceProxy::get_tango_lib_version()
                 }
             }
 #else
-                                                                                                                                    vector<CommandInfo>::iterator pos,pos_end;
-		for (pos = (*cmd_list).begin(), pos_end = (*cmd_list).end();pos != pos_end;++pos)
-		{
-			if (pos->cmd_name == "EventConfirmSubscription")
-			{
-				ecs = true;
-				break;
-			}
+            vector<CommandInfo>::iterator pos, pos_end;
+            for (pos = (*cmd_list).begin(), pos_end = (*cmd_list).end(); pos != pos_end; ++pos)
+            {
+                if (pos->cmd_name == "EventConfirmSubscription")
+                {
+                    ecs = true;
+                    break;
+                }
 
-			if  (pos->cmd_name == "ZmqEventSubscriptionChange")
-				zesc = true;
-		}
+                if (pos->cmd_name == "ZmqEventSubscriptionChange")
+                {
+                    zesc = true;
+                }
+            }
 #endif
             if (ecs == true)
             {

--- a/cppapi/client/devapi_data.cpp
+++ b/cppapi/client/devapi_data.cpp
@@ -45,19 +45,20 @@ namespace Tango
 //
 //-----------------------------------------------------------------------------
 
-DeviceData::DeviceData():ext(new DeviceDataExt)
+DeviceData::DeviceData()
+    : ext(new DeviceDataExt)
 {
 //
 // For omniORB, it is necessary to do the ORB::init before creating the Any.
 // Otherwise, string insertion into the Any will not be possible
 //
 
-	ApiUtil *au = ApiUtil::instance();
-	if (CORBA::is_nil(au->get_orb()) == true)
-		au->create_orb();
+    ApiUtil *au = ApiUtil::instance();
+    if (CORBA::is_nil(au->get_orb()) == true)
+        au->create_orb();
 
-	any = new CORBA::Any();
-	exceptions_flags.set(isempty_flag);
+    any = new CORBA::Any();
+    exceptions_flags.set(isempty_flag);
 }
 
 //-----------------------------------------------------------------------------
@@ -66,13 +67,13 @@ DeviceData::DeviceData():ext(new DeviceDataExt)
 //
 //-----------------------------------------------------------------------------
 
-DeviceData::DeviceData(const DeviceData & source)
+DeviceData::DeviceData(const DeviceData &source)
 {
-	exceptions_flags = source.exceptions_flags;
+    exceptions_flags = source.exceptions_flags;
 #ifdef HAS_RVALUE
-	any = source.any;
+    any = source.any;
 #else
-	any = const_cast<DeviceData &>(source).any._retn();
+    any = const_cast<DeviceData &>(source).any._retn();
 #endif
 
 #ifdef HAS_UNIQUE_PTR
@@ -82,13 +83,13 @@ DeviceData::DeviceData(const DeviceData & source)
         *(ext.get()) = *(source.ext.get());
     }
 #else
-	if (source.ext != NULL)
-	{
-		ext = new DeviceDataExt();
-		*ext = *(source.ext);
-	}
-	else
-		ext = NULL;
+    if (source.ext != NULL)
+    {
+        ext = new DeviceDataExt();
+        *ext = *(source.ext);
+    }
+    else
+        ext = NULL;
 #endif
 }
 
@@ -99,10 +100,11 @@ DeviceData::DeviceData(const DeviceData & source)
 //-----------------------------------------------------------------------------
 
 #ifdef HAS_RVALUE
-DeviceData::DeviceData(DeviceData &&source):ext(new DeviceDataExt)
+DeviceData::DeviceData(DeviceData &&source)
+    : ext(new DeviceDataExt)
 {
-	exceptions_flags = source.exceptions_flags;
-	any = source.any._retn();
+    exceptions_flags = source.exceptions_flags;
+    any = source.any._retn();
 
     if (source.ext.get() != NULL)
         ext = move(source.ext);
@@ -115,7 +117,7 @@ DeviceData::DeviceData(DeviceData &&source):ext(new DeviceDataExt)
 //
 //-----------------------------------------------------------------------------
 
-DeviceData & DeviceData::operator=(const DeviceData &rval)
+DeviceData &DeviceData::operator=(const DeviceData &rval)
 {
     if (this != &rval)
     {
@@ -146,7 +148,7 @@ DeviceData & DeviceData::operator=(const DeviceData &rval)
             ext = NULL;
 #endif
     }
-	return *this;
+    return *this;
 }
 
 //-----------------------------------------------------------------------------
@@ -156,17 +158,17 @@ DeviceData & DeviceData::operator=(const DeviceData &rval)
 //-----------------------------------------------------------------------------
 
 #ifdef HAS_RVALUE
-DeviceData & DeviceData::operator=(DeviceData &&rval)
+DeviceData &DeviceData::operator=(DeviceData &&rval)
 {
-	exceptions_flags = rval.exceptions_flags;
-	any = rval.any._retn();
+    exceptions_flags = rval.exceptions_flags;
+    any = rval.any._retn();
 
     if (rval.ext.get() != NULL)
         ext = move(rval.ext);
     else
         ext.reset();
 
-	return *this;
+    return *this;
 }
 #endif
 
@@ -191,8 +193,8 @@ DeviceData::~DeviceData()
 
 bool DeviceData::is_empty()
 {
-	bool ret = any_is_null();
-	return(ret);
+    bool ret = any_is_null();
+    return (ret);
 }
 
 //-----------------------------------------------------------------------------
@@ -204,23 +206,23 @@ bool DeviceData::is_empty()
 bool DeviceData::any_is_null()
 {
     ext->ext_state.reset(isempty_flag);
-	CORBA::TypeCode_ptr tc;
+    CORBA::TypeCode_ptr tc;
 
-	tc = any->type();
-	if (tc->equal(CORBA::_tc_null))
-	{
-	    ext->ext_state.set(isempty_flag);
-		if (exceptions_flags.test(isempty_flag))
-		{
-			ApiDataExcept::throw_exception((const char*)"API_EmptyDeviceData",
-					        (const char*)"Cannot extract, no data in DeviceData object ",
-					        (const char*)"DeviceData::any_is_null");
-		}
-		return(true);
-	}
-	CORBA::release(tc);
+    tc = any->type();
+    if (tc->equal(CORBA::_tc_null))
+    {
+        ext->ext_state.set(isempty_flag);
+        if (exceptions_flags.test(isempty_flag))
+        {
+            ApiDataExcept::throw_exception((const char *) "API_EmptyDeviceData",
+                                           (const char *) "Cannot extract, no data in DeviceData object ",
+                                           (const char *) "DeviceData::any_is_null");
+        }
+        return (true);
+    }
+    CORBA::release(tc);
 
-	return(false);
+    return (false);
 }
 
 
@@ -232,158 +234,158 @@ bool DeviceData::any_is_null()
 
 int DeviceData::get_type()
 {
-	int data_type = 0;
+    int data_type = 0;
 
-	if (any_is_null() == true)
-		return -1;
-	else
-	{
-		CORBA::TypeCode_ptr tc;
-		CORBA::TypeCode_var tc_al;
-		CORBA::TypeCode_var tc_seq;
-		CORBA::TypeCode_var tc_field;
+    if (any_is_null() == true)
+        return -1;
+    else
+    {
+        CORBA::TypeCode_ptr tc;
+        CORBA::TypeCode_var tc_al;
+        CORBA::TypeCode_var tc_seq;
+        CORBA::TypeCode_var tc_field;
 
-		tc = any->type();
-		switch(tc->kind())
-		{
-		case CORBA::tk_boolean:
-			data_type = Tango::DEV_BOOLEAN;
-			break;
+        tc = any->type();
+        switch (tc->kind())
+        {
+            case CORBA::tk_boolean:
+                data_type = Tango::DEV_BOOLEAN;
+                break;
 
-		case CORBA::tk_short:
-			data_type = Tango::DEV_SHORT;
-			break;
+            case CORBA::tk_short:
+                data_type = Tango::DEV_SHORT;
+                break;
 
-		case CORBA::tk_long:
-			data_type = Tango::DEV_LONG;
-			break;
+            case CORBA::tk_long:
+                data_type = Tango::DEV_LONG;
+                break;
 
-		case CORBA::tk_longlong:
-			data_type = Tango::DEV_LONG64;
-			break;
+            case CORBA::tk_longlong:
+                data_type = Tango::DEV_LONG64;
+                break;
 
-		case CORBA::tk_float:
-			data_type = Tango::DEV_FLOAT;
-			break;
+            case CORBA::tk_float:
+                data_type = Tango::DEV_FLOAT;
+                break;
 
-		case CORBA::tk_double:
-			data_type = Tango::DEV_DOUBLE;
-			break;
+            case CORBA::tk_double:
+                data_type = Tango::DEV_DOUBLE;
+                break;
 
-		case CORBA::tk_ushort:
-			data_type = Tango::DEV_USHORT;
-			break;
+            case CORBA::tk_ushort:
+                data_type = Tango::DEV_USHORT;
+                break;
 
-		case CORBA::tk_ulong:
-			data_type = Tango::DEV_ULONG;
-			break;
+            case CORBA::tk_ulong:
+                data_type = Tango::DEV_ULONG;
+                break;
 
-		case CORBA::tk_ulonglong:
-			data_type = Tango::DEV_ULONG64;
-			break;
+            case CORBA::tk_ulonglong:
+                data_type = Tango::DEV_ULONG64;
+                break;
 
-		case CORBA::tk_string:
-			data_type = Tango::DEV_STRING;
-			break;
+            case CORBA::tk_string:
+                data_type = Tango::DEV_STRING;
+                break;
 
-		case CORBA::tk_alias:
-			tc_al = tc->content_type();
-			tc_seq = tc_al->content_type();
-			switch (tc_seq->kind())
-			{
-			case CORBA::tk_boolean:
-				data_type = Tango::DEVVAR_BOOLEANARRAY;
-				break;
+            case CORBA::tk_alias:
+                tc_al = tc->content_type();
+                tc_seq = tc_al->content_type();
+                switch (tc_seq->kind())
+                {
+                    case CORBA::tk_boolean:
+                        data_type = Tango::DEVVAR_BOOLEANARRAY;
+                        break;
 
-			case CORBA::tk_octet:
-				data_type = Tango::DEVVAR_CHARARRAY;
-				break;
+                    case CORBA::tk_octet:
+                        data_type = Tango::DEVVAR_CHARARRAY;
+                        break;
 
-			case CORBA::tk_short:
-				data_type = Tango::DEVVAR_SHORTARRAY;
-				break;
+                    case CORBA::tk_short:
+                        data_type = Tango::DEVVAR_SHORTARRAY;
+                        break;
 
-			case CORBA::tk_long:
-				data_type = Tango::DEVVAR_LONGARRAY;
-				break;
-
-			case CORBA::tk_longlong:
-				data_type = Tango::DEVVAR_LONG64ARRAY;
-				break;
-
-			case CORBA::tk_float:
-				data_type = Tango::DEVVAR_FLOATARRAY;
-				break;
-
-			case CORBA::tk_double:
-				data_type = Tango::DEVVAR_DOUBLEARRAY;
-				break;
-
-			case CORBA::tk_ushort:
-				data_type = Tango::DEVVAR_USHORTARRAY;
-				break;
-
-			case CORBA::tk_ulong:
-				data_type = Tango::DEVVAR_ULONGARRAY;
-				break;
-
-			case CORBA::tk_ulonglong:
-				data_type = Tango::DEVVAR_ULONG64ARRAY;
-				break;
-
-			case CORBA::tk_string:
-				data_type = Tango::DEVVAR_STRINGARRAY;
-				break;
-
-			default:
-				break;
-			}
-			break;
-
-		case CORBA::tk_struct:
-			tc_field = tc->member_type(0);
-			tc_al = tc_field->content_type();
-            switch (tc_al->kind())
-            {
-                case CORBA::tk_sequence:
-                    tc_seq = tc_al->content_type();
-                    switch (tc_seq->kind())
-                    {
                     case CORBA::tk_long:
-                        data_type = Tango::DEVVAR_LONGSTRINGARRAY;
+                        data_type = Tango::DEVVAR_LONGARRAY;
+                        break;
+
+                    case CORBA::tk_longlong:
+                        data_type = Tango::DEVVAR_LONG64ARRAY;
+                        break;
+
+                    case CORBA::tk_float:
+                        data_type = Tango::DEVVAR_FLOATARRAY;
                         break;
 
                     case CORBA::tk_double:
-                        data_type = Tango::DEVVAR_DOUBLESTRINGARRAY;
+                        data_type = Tango::DEVVAR_DOUBLEARRAY;
+                        break;
+
+                    case CORBA::tk_ushort:
+                        data_type = Tango::DEVVAR_USHORTARRAY;
+                        break;
+
+                    case CORBA::tk_ulong:
+                        data_type = Tango::DEVVAR_ULONGARRAY;
+                        break;
+
+                    case CORBA::tk_ulonglong:
+                        data_type = Tango::DEVVAR_ULONG64ARRAY;
+                        break;
+
+                    case CORBA::tk_string:
+                        data_type = Tango::DEVVAR_STRINGARRAY;
                         break;
 
                     default:
                         break;
-                    }
-                    break;
+                }
+                break;
 
-                case CORBA::tk_string:
-                    data_type = Tango::DEV_ENCODED;
-                    break;
+            case CORBA::tk_struct:
+                tc_field = tc->member_type(0);
+                tc_al = tc_field->content_type();
+                switch (tc_al->kind())
+                {
+                    case CORBA::tk_sequence:
+                        tc_seq = tc_al->content_type();
+                        switch (tc_seq->kind())
+                        {
+                            case CORBA::tk_long:
+                                data_type = Tango::DEVVAR_LONGSTRINGARRAY;
+                                break;
 
-                default:
-                    break;
-            }
-			break;
+                            case CORBA::tk_double:
+                                data_type = Tango::DEVVAR_DOUBLESTRINGARRAY;
+                                break;
 
-		case CORBA::tk_enum:
-			data_type = Tango::DEV_STATE;
-			break;
+                            default:
+                                break;
+                        }
+                        break;
 
-		default:
-			break;
+                    case CORBA::tk_string:
+                        data_type = Tango::DEV_ENCODED;
+                        break;
 
-		}
+                    default:
+                        break;
+                }
+                break;
 
-		CORBA::release(tc);
-	}
+            case CORBA::tk_enum:
+                data_type = Tango::DEV_STATE;
+                break;
 
-	return data_type;
+            default:
+                break;
+
+        }
+
+        CORBA::release(tc);
+    }
+
+    return data_type;
 }
 
 
@@ -393,25 +395,25 @@ int DeviceData::get_type()
 //
 //-----------------------------------------------------------------------------
 
-bool DeviceData::operator >> (bool& datum)
+bool DeviceData::operator>>(bool &datum)
 {
     ext->ext_state.reset();
 
-	bool ret = any >>= CORBA::Any::to_boolean(datum);
-	if (ret == false)
-	{
+    bool ret = any >>= CORBA::Any::to_boolean(datum);
+    if (ret == false)
+    {
         if (any_is_null())
             return ret;
 
         ext->ext_state.set(wrongtype_flag);
-		if (exceptions_flags.test(wrongtype_flag))
-		{
-			ApiDataExcept::throw_exception((const char*)API_IncompatibleCmdArgumentType,
-					       	(const char*)"Cannot extract, data in DeviceData object is not a boolean",
-					        (const char*)"DeviceData::operator>>");
-		}
-	}
-	return ret;
+        if (exceptions_flags.test(wrongtype_flag))
+        {
+            ApiDataExcept::throw_exception((const char *) API_IncompatibleCmdArgumentType,
+                                           (const char *) "Cannot extract, data in DeviceData object is not a boolean",
+                                           (const char *) "DeviceData::operator>>");
+        }
+    }
+    return ret;
 }
 
 //-----------------------------------------------------------------------------
@@ -420,25 +422,25 @@ bool DeviceData::operator >> (bool& datum)
 //
 //-----------------------------------------------------------------------------
 
-bool DeviceData::operator >> (short& datum)
+bool DeviceData::operator>>(short &datum)
 {
     ext->ext_state.reset();
 
-	bool ret = any >>= datum;
-	if (ret == false)
-	{
+    bool ret = any >>= datum;
+    if (ret == false)
+    {
         if (any_is_null())
             return ret;
 
         ext->ext_state.set(wrongtype_flag);
-		if (exceptions_flags.test(wrongtype_flag))
-		{
-			ApiDataExcept::throw_exception((const char*)API_IncompatibleCmdArgumentType,
-					       	(const char*)"Cannot extract, data in DeviceData object is not a short",
-					        (const char*)"DeviceData::operator>>");
-		}
-	}
-	return ret;
+        if (exceptions_flags.test(wrongtype_flag))
+        {
+            ApiDataExcept::throw_exception((const char *) API_IncompatibleCmdArgumentType,
+                                           (const char *) "Cannot extract, data in DeviceData object is not a short",
+                                           (const char *) "DeviceData::operator>>");
+        }
+    }
+    return ret;
 }
 
 
@@ -448,25 +450,25 @@ bool DeviceData::operator >> (short& datum)
 //
 //-----------------------------------------------------------------------------
 
-bool DeviceData::operator >> (unsigned short& datum)
+bool DeviceData::operator>>(unsigned short &datum)
 {
     ext->ext_state.reset();
 
-	bool ret = any >>= datum;
-	if (ret == false)
-	{
+    bool ret = any >>= datum;
+    if (ret == false)
+    {
         if (any_is_null())
             return ret;
 
         ext->ext_state.set(wrongtype_flag);
-		if (exceptions_flags.test(wrongtype_flag))
-		{
-			ApiDataExcept::throw_exception((const char*)API_IncompatibleCmdArgumentType,
-					       	(const char*)"Cannot extract, data in DeviceData object is not an unsigned short",
-					        (const char*)"DeviceData::operator>>");
-		}
-	}
-	return ret;
+        if (exceptions_flags.test(wrongtype_flag))
+        {
+            ApiDataExcept::throw_exception((const char *) API_IncompatibleCmdArgumentType,
+                                           (const char *) "Cannot extract, data in DeviceData object is not an unsigned short",
+                                           (const char *) "DeviceData::operator>>");
+        }
+    }
+    return ret;
 }
 
 //-----------------------------------------------------------------------------
@@ -475,25 +477,25 @@ bool DeviceData::operator >> (unsigned short& datum)
 //
 //-----------------------------------------------------------------------------
 
-bool DeviceData::operator >> (DevLong& datum)
+bool DeviceData::operator>>(DevLong &datum)
 {
     ext->ext_state.reset();
 
-	bool ret = (any >>= datum);
-	if (ret == false)
-	{
+    bool ret = (any >>= datum);
+    if (ret == false)
+    {
         if (any_is_null())
             return ret;
 
         ext->ext_state.set(wrongtype_flag);
-		if (exceptions_flags.test(wrongtype_flag))
-		{
-			ApiDataExcept::throw_exception((const char*)API_IncompatibleCmdArgumentType,
-					       	(const char*)"Cannot extract, data in DeviceData object is not a DevLong (long 32 bits)",
-					        (const char*)"DeviceData::operator>>");
-		}
-	}
-	return ret;
+        if (exceptions_flags.test(wrongtype_flag))
+        {
+            ApiDataExcept::throw_exception((const char *) API_IncompatibleCmdArgumentType,
+                                           (const char *) "Cannot extract, data in DeviceData object is not a DevLong (long 32 bits)",
+                                           (const char *) "DeviceData::operator>>");
+        }
+    }
+    return ret;
 }
 
 //-----------------------------------------------------------------------------
@@ -502,25 +504,25 @@ bool DeviceData::operator >> (DevLong& datum)
 //
 //-----------------------------------------------------------------------------
 
-bool DeviceData::operator >> (DevULong& datum)
+bool DeviceData::operator>>(DevULong &datum)
 {
     ext->ext_state.reset();
 
-	bool ret = any >>= datum;
-	if (ret == false)
-	{
+    bool ret = any >>= datum;
+    if (ret == false)
+    {
         if (any_is_null())
             return ret;
 
         ext->ext_state.set(wrongtype_flag);
-		if (exceptions_flags.test(wrongtype_flag))
-		{
-			ApiDataExcept::throw_exception((const char*)API_IncompatibleCmdArgumentType,
-					       	(const char*)"Cannot extract, data in DeviceData object is not an DevULong (unsigned long 32 bits)",
-					        (const char*)"DeviceData::operator>>");
-		}
-	}
-	return ret;
+        if (exceptions_flags.test(wrongtype_flag))
+        {
+            ApiDataExcept::throw_exception((const char *) API_IncompatibleCmdArgumentType,
+                                           (const char *) "Cannot extract, data in DeviceData object is not an DevULong (unsigned long 32 bits)",
+                                           (const char *) "DeviceData::operator>>");
+        }
+    }
+    return ret;
 }
 
 //-----------------------------------------------------------------------------
@@ -529,25 +531,25 @@ bool DeviceData::operator >> (DevULong& datum)
 //
 //-----------------------------------------------------------------------------
 
-bool DeviceData::operator >> (DevLong64 & datum)
+bool DeviceData::operator>>(DevLong64 &datum)
 {
     ext->ext_state.reset();
 
-	bool ret = any >>= datum;
-	if (ret == false)
-	{
+    bool ret = any >>= datum;
+    if (ret == false)
+    {
         if (any_is_null())
             return ret;
 
         ext->ext_state.set(wrongtype_flag);
-		if (exceptions_flags.test(wrongtype_flag))
-		{
-			ApiDataExcept::throw_exception((const char*)API_IncompatibleCmdArgumentType,
-					       	(const char*)"Cannot extract, data in DeviceData object is not a DevLong64 (64 bits long)",
-					        (const char*)"DeviceData::operator>>");
-		}
-	}
-	return ret;
+        if (exceptions_flags.test(wrongtype_flag))
+        {
+            ApiDataExcept::throw_exception((const char *) API_IncompatibleCmdArgumentType,
+                                           (const char *) "Cannot extract, data in DeviceData object is not a DevLong64 (64 bits long)",
+                                           (const char *) "DeviceData::operator>>");
+        }
+    }
+    return ret;
 }
 
 //-----------------------------------------------------------------------------
@@ -556,25 +558,25 @@ bool DeviceData::operator >> (DevLong64 & datum)
 //
 //-----------------------------------------------------------------------------
 
-bool DeviceData::operator >> (DevULong64 & datum)
+bool DeviceData::operator>>(DevULong64 &datum)
 {
     ext->ext_state.reset();
 
-	bool ret = any >>= datum;
-	if (ret == false)
-	{
+    bool ret = any >>= datum;
+    if (ret == false)
+    {
         if (any_is_null())
             return ret;
 
         ext->ext_state.set(wrongtype_flag);
-		if (exceptions_flags.test(wrongtype_flag))
-		{
-			ApiDataExcept::throw_exception((const char*)API_IncompatibleCmdArgumentType,
-					       	(const char*)"Cannot extract, data in DeviceData object is not a DevULong64 (unsigned 64 bits long)",
-					        (const char*)"DeviceData::operator>>");
-		}
-	}
-	return ret;
+        if (exceptions_flags.test(wrongtype_flag))
+        {
+            ApiDataExcept::throw_exception((const char *) API_IncompatibleCmdArgumentType,
+                                           (const char *) "Cannot extract, data in DeviceData object is not a DevULong64 (unsigned 64 bits long)",
+                                           (const char *) "DeviceData::operator>>");
+        }
+    }
+    return ret;
 }
 
 //-----------------------------------------------------------------------------
@@ -583,25 +585,25 @@ bool DeviceData::operator >> (DevULong64 & datum)
 //
 //-----------------------------------------------------------------------------
 
-bool DeviceData::operator >> (float& datum)
+bool DeviceData::operator>>(float &datum)
 {
     ext->ext_state.reset();
 
-	bool ret = any >>= datum;
-	if (ret == false)
-	{
+    bool ret = any >>= datum;
+    if (ret == false)
+    {
         if (any_is_null())
             return ret;
 
         ext->ext_state.set(wrongtype_flag);
-		if (exceptions_flags.test(wrongtype_flag))
-		{
-			ApiDataExcept::throw_exception((const char*)API_IncompatibleCmdArgumentType,
-				     		(const char*)"Cannot extract, data in DeviceData object is not a float",
-				        	(const char*)"DeviceData::operator>>");
-		}
-	}
-	return ret;
+        if (exceptions_flags.test(wrongtype_flag))
+        {
+            ApiDataExcept::throw_exception((const char *) API_IncompatibleCmdArgumentType,
+                                           (const char *) "Cannot extract, data in DeviceData object is not a float",
+                                           (const char *) "DeviceData::operator>>");
+        }
+    }
+    return ret;
 }
 
 
@@ -611,25 +613,25 @@ bool DeviceData::operator >> (float& datum)
 //
 //-----------------------------------------------------------------------------
 
-bool DeviceData::operator >> (double& datum)
+bool DeviceData::operator>>(double &datum)
 {
     ext->ext_state.reset();
 
-	bool ret = any >>= datum;
-	if (ret == false)
-	{
+    bool ret = any >>= datum;
+    if (ret == false)
+    {
         if (any_is_null())
             return ret;
 
         ext->ext_state.set(wrongtype_flag);
-		if (exceptions_flags.test(wrongtype_flag))
-		{
-			ApiDataExcept::throw_exception((const char*)API_IncompatibleCmdArgumentType,
-				       		(const char*)"Cannot extract, data in DeviceData object is not a double",
-				        	(const char*)"DeviceData::operator>>");
-		}
-	}
-	return ret;
+        if (exceptions_flags.test(wrongtype_flag))
+        {
+            ApiDataExcept::throw_exception((const char *) API_IncompatibleCmdArgumentType,
+                                           (const char *) "Cannot extract, data in DeviceData object is not a double",
+                                           (const char *) "DeviceData::operator>>");
+        }
+    }
+    return ret;
 }
 
 //-----------------------------------------------------------------------------
@@ -638,30 +640,30 @@ bool DeviceData::operator >> (double& datum)
 //
 //-----------------------------------------------------------------------------
 
-bool DeviceData::operator >> (string& datum)
+bool DeviceData::operator>>(string &datum)
 {
     ext->ext_state.reset();
 
-	const char *c_string = NULL;
-	bool ret = (any >>= c_string);
-	if (ret == false)
-	{
+    const char *c_string = NULL;
+    bool ret = (any >>= c_string);
+    if (ret == false)
+    {
         if (any_is_null())
             return ret;
 
         ext->ext_state.set(wrongtype_flag);
-		if (exceptions_flags.test(wrongtype_flag))
-		{
-			ApiDataExcept::throw_exception((const char*)API_IncompatibleCmdArgumentType,
-				       		(const char*)"Cannot extract, data in DeviceData object is not a string",
-				        	(const char*)"DeviceData::operator>>");
-		}
-	}
-	else
-	{
-		datum = c_string;
-	}
-	return ret;
+        if (exceptions_flags.test(wrongtype_flag))
+        {
+            ApiDataExcept::throw_exception((const char *) API_IncompatibleCmdArgumentType,
+                                           (const char *) "Cannot extract, data in DeviceData object is not a string",
+                                           (const char *) "DeviceData::operator>>");
+        }
+    }
+    else
+    {
+        datum = c_string;
+    }
+    return ret;
 }
 
 //-----------------------------------------------------------------------------
@@ -670,25 +672,25 @@ bool DeviceData::operator >> (string& datum)
 //
 //-----------------------------------------------------------------------------
 
-bool DeviceData::operator >> (const char*& datum)
+bool DeviceData::operator>>(const char *&datum)
 {
     ext->ext_state.reset();
 
-	bool ret = any >>= datum;
-	if (ret == false)
-	{
+    bool ret = any >>= datum;
+    if (ret == false)
+    {
         if (any_is_null())
             return ret;
 
         ext->ext_state.set(wrongtype_flag);
-		if (exceptions_flags.test(wrongtype_flag))
-		{
-			ApiDataExcept::throw_exception((const char*)API_IncompatibleCmdArgumentType,
-				       		(const char*)"Cannot extract, data in DeviceData object is not an array of char",
-				        	(const char*)"DeviceData::operator>>");
-		}
-	}
-	return ret;
+        if (exceptions_flags.test(wrongtype_flag))
+        {
+            ApiDataExcept::throw_exception((const char *) API_IncompatibleCmdArgumentType,
+                                           (const char *) "Cannot extract, data in DeviceData object is not an array of char",
+                                           (const char *) "DeviceData::operator>>");
+        }
+    }
+    return ret;
 }
 
 //-----------------------------------------------------------------------------
@@ -697,25 +699,25 @@ bool DeviceData::operator >> (const char*& datum)
 //
 //-----------------------------------------------------------------------------
 
-bool DeviceData::operator >> (DevState& datum)
+bool DeviceData::operator>>(DevState &datum)
 {
     ext->ext_state.reset();
 
-	bool ret = (any.inout() >>= datum);
-	if (ret == false)
-	{
+    bool ret = (any.inout() >>= datum);
+    if (ret == false)
+    {
         if (any_is_null())
             return ret;
 
         ext->ext_state.set(wrongtype_flag);
-		if (exceptions_flags.test(wrongtype_flag))
-		{
-			ApiDataExcept::throw_exception((const char*)API_IncompatibleCmdArgumentType,
-				       		(const char*)"Cannot extract, data in DeviceData object is not a DevState",
-				        	(const char*)"DeviceData::operator>>");
-		}
-	}
-	return ret;
+        if (exceptions_flags.test(wrongtype_flag))
+        {
+            ApiDataExcept::throw_exception((const char *) API_IncompatibleCmdArgumentType,
+                                           (const char *) "Cannot extract, data in DeviceData object is not a DevState",
+                                           (const char *) "DeviceData::operator>>");
+        }
+    }
+    return ret;
 }
 
 //-----------------------------------------------------------------------------
@@ -726,40 +728,44 @@ bool DeviceData::operator >> (DevState& datum)
 //	@throws ApiDataExcept in case underlying value is not a boolean array
 //-----------------------------------------------------------------------------
 
-bool DeviceData::operator >> (vector<bool>& datum)
+bool DeviceData::operator>>(vector<bool> &datum)
 {
     ext->ext_state.reset();
 
-	const DevVarBooleanArray *bool_array = NULL;
-	bool ret = (any.inout() >>= bool_array);
+    const DevVarBooleanArray *bool_array = NULL;
+    bool ret = (any.inout() >>= bool_array);
 
     bool success = ret && bool_array != NULL;
 
-    if(success){
+    if (success)
+    {
         datum.resize(bool_array->length());
-        for (size_t i=0; i<bool_array->length(); i++)
+        for (size_t i = 0; i < bool_array->length(); i++)
         {
             datum[i] = (*bool_array)[i];
         }
 
         return true;
-    } else {
+    }
+    else
+    {
         if (any_is_null())
             return false;
 
-        if(bool_array == NULL){
+        if (bool_array == NULL)
+        {
             ext->ext_state.set(wrongtype_flag);
-            ApiDataExcept::throw_exception((const char *)API_IncoherentDevData,
-                                           (const char *)"Incoherent data received from server",
-                                           (const char *)"DeviceData::operator>>");
+            ApiDataExcept::throw_exception((const char *) API_IncoherentDevData,
+                                           (const char *) "Incoherent data received from server",
+                                           (const char *) "DeviceData::operator>>");
         }
 
         ext->ext_state.set(wrongtype_flag);
         if (exceptions_flags.test(wrongtype_flag))
         {
-            ApiDataExcept::throw_exception((const char*)API_IncompatibleCmdArgumentType,
-                                           (const char*)"Cannot extract, data in DeviceData object is not an array of boolean",
-                                           (const char*)"DeviceData::operator>>");
+            ApiDataExcept::throw_exception((const char *) API_IncompatibleCmdArgumentType,
+                                           (const char *) "Cannot extract, data in DeviceData object is not an array of boolean",
+                                           (const char *) "DeviceData::operator>>");
         }
 
         return false;
@@ -772,26 +778,26 @@ bool DeviceData::operator >> (vector<bool>& datum)
 //
 //-----------------------------------------------------------------------------
 
-bool DeviceData::operator >> (const DevVarBooleanArray* &datum)
+bool DeviceData::operator>>(const DevVarBooleanArray *&datum)
 {
     ext->ext_state.reset();
 
-	bool ret = (any.inout() >>= datum);
+    bool ret = (any.inout() >>= datum);
 
-	if (ret == false)
-	{
+    if (ret == false)
+    {
         if (any_is_null())
             return ret;
 
         ext->ext_state.set(wrongtype_flag);
-		if (exceptions_flags.test(wrongtype_flag))
-		{
-			ApiDataExcept::throw_exception((const char*)API_IncompatibleCmdArgumentType,
-				       		(const char*)"Cannot extract, data in DeviceData object is not an array of boolean",
-				        	(const char*)"DeviceData::operator>>");
-		}
-	}
-	return ret;
+        if (exceptions_flags.test(wrongtype_flag))
+        {
+            ApiDataExcept::throw_exception((const char *) API_IncompatibleCmdArgumentType,
+                                           (const char *) "Cannot extract, data in DeviceData object is not an array of boolean",
+                                           (const char *) "DeviceData::operator>>");
+        }
+    }
+    return ret;
 }
 
 //-----------------------------------------------------------------------------
@@ -800,44 +806,44 @@ bool DeviceData::operator >> (const DevVarBooleanArray* &datum)
 //
 //-----------------------------------------------------------------------------
 
-bool DeviceData::operator >> (vector<unsigned char>& datum)
+bool DeviceData::operator>>(vector<unsigned char> &datum)
 {
     ext->ext_state.reset();
 
-	const DevVarCharArray *char_array = NULL;
-	bool ret = (any.inout() >>= char_array);
-	if (ret == false)
-	{
+    const DevVarCharArray *char_array = NULL;
+    bool ret = (any.inout() >>= char_array);
+    if (ret == false)
+    {
         if (any_is_null())
             return ret;
 
         ext->ext_state.set(wrongtype_flag);
-		if (exceptions_flags.test(wrongtype_flag))
-		{
-			ApiDataExcept::throw_exception((const char*)API_IncompatibleCmdArgumentType,
-				       		(const char*)"Cannot extract, data in DeviceData object is not an array of char",
-				        	(const char*)"DeviceData::operator>>");
-		}
-	}
-	else
-	{
-	    if (char_array == NULL)
-	    {
+        if (exceptions_flags.test(wrongtype_flag))
+        {
+            ApiDataExcept::throw_exception((const char *) API_IncompatibleCmdArgumentType,
+                                           (const char *) "Cannot extract, data in DeviceData object is not an array of char",
+                                           (const char *) "DeviceData::operator>>");
+        }
+    }
+    else
+    {
+        if (char_array == NULL)
+        {
             ext->ext_state.set(wrongtype_flag);
-            ApiDataExcept::throw_exception((const char *)API_IncoherentDevData,
-                                       (const char *)"Incoherent data received from server",
-                                       (const char *)"DeviceData::operator>>");
-	    }
+            ApiDataExcept::throw_exception((const char *) API_IncoherentDevData,
+                                           (const char *) "Incoherent data received from server",
+                                           (const char *) "DeviceData::operator>>");
+        }
         else
         {
             datum.resize(char_array->length());
-            for (unsigned int i=0; i<char_array->length(); i++)
+            for (unsigned int i = 0; i < char_array->length(); i++)
             {
                 datum[i] = (*char_array)[i];
             }
         }
-	}
-	return ret;
+    }
+    return ret;
 }
 
 
@@ -848,25 +854,25 @@ bool DeviceData::operator >> (vector<unsigned char>& datum)
 //-----------------------------------------------------------------------------
 
 
-bool DeviceData::operator >> (const DevVarCharArray* &datum)
+bool DeviceData::operator>>(const DevVarCharArray *&datum)
 {
     ext->ext_state.reset();
 
-	bool ret = (any.inout() >>= datum);
-	if (ret == false)
-	{
+    bool ret = (any.inout() >>= datum);
+    if (ret == false)
+    {
         if (any_is_null())
             return ret;
 
         ext->ext_state.set(wrongtype_flag);
-		if (exceptions_flags.test(wrongtype_flag))
-		{
-			ApiDataExcept::throw_exception((const char*)API_IncompatibleCmdArgumentType,
-				       		(const char*)"Cannot extract, data in DeviceData object is not an array of char",
-				        	(const char*)"DeviceData::operator>>");
-		}
-	}
-	return ret;
+        if (exceptions_flags.test(wrongtype_flag))
+        {
+            ApiDataExcept::throw_exception((const char *) API_IncompatibleCmdArgumentType,
+                                           (const char *) "Cannot extract, data in DeviceData object is not an array of char",
+                                           (const char *) "DeviceData::operator>>");
+        }
+    }
+    return ret;
 }
 
 //-----------------------------------------------------------------------------
@@ -875,44 +881,44 @@ bool DeviceData::operator >> (const DevVarCharArray* &datum)
 //
 //-----------------------------------------------------------------------------
 
-bool DeviceData::operator >> (vector<short>& datum)
+bool DeviceData::operator>>(vector<short> &datum)
 {
     ext->ext_state.reset();
 
-	const DevVarShortArray *short_array = NULL;
-	bool ret = (any.inout() >>= short_array);
-	if (ret == false)
-	{
+    const DevVarShortArray *short_array = NULL;
+    bool ret = (any.inout() >>= short_array);
+    if (ret == false)
+    {
         if (any_is_null())
             return ret;
 
         ext->ext_state.set(wrongtype_flag);
-		if (exceptions_flags.test(wrongtype_flag))
-		{
-			ApiDataExcept::throw_exception((const char*)API_IncompatibleCmdArgumentType,
-				       		(const char*)"Cannot extract, data in DeviceData object is not an array of short",
-				        	(const char*)"DeviceData::operator>>");
-		}
-	}
-	else
-	{
-	    if (short_array == NULL)
-	    {
+        if (exceptions_flags.test(wrongtype_flag))
+        {
+            ApiDataExcept::throw_exception((const char *) API_IncompatibleCmdArgumentType,
+                                           (const char *) "Cannot extract, data in DeviceData object is not an array of short",
+                                           (const char *) "DeviceData::operator>>");
+        }
+    }
+    else
+    {
+        if (short_array == NULL)
+        {
             ext->ext_state.set(wrongtype_flag);
-            ApiDataExcept::throw_exception((const char *)API_IncoherentDevData,
-                                       (const char *)"Incoherent data received from server",
-                                       (const char *)"DeviceData::operator>>");
-	    }
+            ApiDataExcept::throw_exception((const char *) API_IncoherentDevData,
+                                           (const char *) "Incoherent data received from server",
+                                           (const char *) "DeviceData::operator>>");
+        }
         else
         {
             datum.resize(short_array->length());
-            for (unsigned int i=0; i<short_array->length(); i++)
+            for (unsigned int i = 0; i < short_array->length(); i++)
             {
                 datum[i] = (*short_array)[i];
             }
         }
-	}
-	return ret;
+    }
+    return ret;
 }
 
 
@@ -923,26 +929,26 @@ bool DeviceData::operator >> (vector<short>& datum)
 //-----------------------------------------------------------------------------
 
 
-bool DeviceData::operator >> (const DevVarShortArray* &datum)
+bool DeviceData::operator>>(const DevVarShortArray *&datum)
 {
     ext->ext_state.reset();
 
-	bool ret = (any.inout() >>= datum);
+    bool ret = (any.inout() >>= datum);
 
-	if (ret == false)
-	{
+    if (ret == false)
+    {
         if (any_is_null())
             return ret;
 
         ext->ext_state.set(wrongtype_flag);
-		if (exceptions_flags.test(wrongtype_flag))
-		{
-			ApiDataExcept::throw_exception((const char*)API_IncompatibleCmdArgumentType,
-				       		(const char*)"Cannot extract, data in DeviceData object is not an array of short",
-				        	(const char*)"DeviceData::operator>>");
-		}
-	}
-	return ret;
+        if (exceptions_flags.test(wrongtype_flag))
+        {
+            ApiDataExcept::throw_exception((const char *) API_IncompatibleCmdArgumentType,
+                                           (const char *) "Cannot extract, data in DeviceData object is not an array of short",
+                                           (const char *) "DeviceData::operator>>");
+        }
+    }
+    return ret;
 }
 
 //-----------------------------------------------------------------------------
@@ -951,44 +957,44 @@ bool DeviceData::operator >> (const DevVarShortArray* &datum)
 //
 //-----------------------------------------------------------------------------
 
-bool DeviceData::operator >> (vector<unsigned short>& datum)
+bool DeviceData::operator>>(vector<unsigned short> &datum)
 {
     ext->ext_state.reset();
 
-	const DevVarUShortArray *ushort_array = NULL;
-	bool ret = (any.inout() >>= ushort_array);
-	if (ret == false)
-	{
+    const DevVarUShortArray *ushort_array = NULL;
+    bool ret = (any.inout() >>= ushort_array);
+    if (ret == false)
+    {
         if (any_is_null())
             return ret;
 
         ext->ext_state.set(wrongtype_flag);
-		if (exceptions_flags.test(wrongtype_flag))
-		{
-			ApiDataExcept::throw_exception((const char*)API_IncompatibleCmdArgumentType,
-				       		(const char*)"Cannot extract, data in DeviceData object is not an array of unsigned short",
-				        	(const char*)"DeviceData::operator>>");
-		}
-	}
-	else
-	{
-	    if (ushort_array == NULL)
-	    {
+        if (exceptions_flags.test(wrongtype_flag))
+        {
+            ApiDataExcept::throw_exception((const char *) API_IncompatibleCmdArgumentType,
+                                           (const char *) "Cannot extract, data in DeviceData object is not an array of unsigned short",
+                                           (const char *) "DeviceData::operator>>");
+        }
+    }
+    else
+    {
+        if (ushort_array == NULL)
+        {
             ext->ext_state.set(wrongtype_flag);
-            ApiDataExcept::throw_exception((const char *)API_IncoherentDevData,
-                                       (const char *)"Incoherent data received from server",
-                                       (const char *)"DeviceData::operator>>");
-	    }
+            ApiDataExcept::throw_exception((const char *) API_IncoherentDevData,
+                                           (const char *) "Incoherent data received from server",
+                                           (const char *) "DeviceData::operator>>");
+        }
         else
         {
             datum.resize(ushort_array->length());
-            for (unsigned int i=0; i<ushort_array->length(); i++)
+            for (unsigned int i = 0; i < ushort_array->length(); i++)
             {
                 datum[i] = (*ushort_array)[i];
             }
         }
-	}
-	return ret;
+    }
+    return ret;
 }
 
 
@@ -999,25 +1005,25 @@ bool DeviceData::operator >> (vector<unsigned short>& datum)
 //-----------------------------------------------------------------------------
 
 
-bool DeviceData::operator >> (const DevVarUShortArray* &datum)
+bool DeviceData::operator>>(const DevVarUShortArray *&datum)
 {
     ext->ext_state.reset();
 
-	bool ret = (any.inout() >>= datum);
-	if (ret == false)
-	{
+    bool ret = (any.inout() >>= datum);
+    if (ret == false)
+    {
         if (any_is_null())
             return ret;
 
         ext->ext_state.set(wrongtype_flag);
-		if (exceptions_flags.test(wrongtype_flag))
-		{
-			ApiDataExcept::throw_exception((const char*)API_IncompatibleCmdArgumentType,
-				       		(const char*)"Cannot extract, data in DeviceData object is not an array of unusigned short",
-				        	(const char*)"DeviceData::operator>>");
-		}
-	}
-	return ret;
+        if (exceptions_flags.test(wrongtype_flag))
+        {
+            ApiDataExcept::throw_exception((const char *) API_IncompatibleCmdArgumentType,
+                                           (const char *) "Cannot extract, data in DeviceData object is not an array of unusigned short",
+                                           (const char *) "DeviceData::operator>>");
+        }
+    }
+    return ret;
 }
 
 //-----------------------------------------------------------------------------
@@ -1026,44 +1032,44 @@ bool DeviceData::operator >> (const DevVarUShortArray* &datum)
 //
 //-----------------------------------------------------------------------------
 
-bool DeviceData::operator >> (vector<DevLong>& datum)
+bool DeviceData::operator>>(vector<DevLong> &datum)
 {
     ext->ext_state.reset();
-	const DevVarLongArray *long_array = NULL;
+    const DevVarLongArray *long_array = NULL;
 
-	bool ret = (any.inout() >>= long_array);
-	if (ret == false)
-	{
+    bool ret = (any.inout() >>= long_array);
+    if (ret == false)
+    {
         if (any_is_null())
             return ret;
 
         ext->ext_state.set(wrongtype_flag);
-		if (exceptions_flags.test(wrongtype_flag))
-		{
-			ApiDataExcept::throw_exception((const char*)API_IncompatibleCmdArgumentType,
-				       		(const char*)"Cannot extract, data in DeviceData object is not an array of DevLong (long 32 bits)",
-				        	(const char*)"DeviceData::operator>>");
-		}
-	}
-	else
-	{
-	    if (long_array == NULL)
-	    {
+        if (exceptions_flags.test(wrongtype_flag))
+        {
+            ApiDataExcept::throw_exception((const char *) API_IncompatibleCmdArgumentType,
+                                           (const char *) "Cannot extract, data in DeviceData object is not an array of DevLong (long 32 bits)",
+                                           (const char *) "DeviceData::operator>>");
+        }
+    }
+    else
+    {
+        if (long_array == NULL)
+        {
             ext->ext_state.set(wrongtype_flag);
-            ApiDataExcept::throw_exception((const char *)API_IncoherentDevData,
-                                       (const char *)"Incoherent data received from server",
-                                       (const char *)"DeviceData::operator>>");
-	    }
+            ApiDataExcept::throw_exception((const char *) API_IncoherentDevData,
+                                           (const char *) "Incoherent data received from server",
+                                           (const char *) "DeviceData::operator>>");
+        }
         else
         {
             datum.resize(long_array->length());
-            for (unsigned int i=0; i<long_array->length(); i++)
+            for (unsigned int i = 0; i < long_array->length(); i++)
             {
                 datum[i] = (*long_array)[i];
             }
         }
-	}
-	return ret;
+    }
+    return ret;
 }
 
 
@@ -1074,25 +1080,25 @@ bool DeviceData::operator >> (vector<DevLong>& datum)
 //-----------------------------------------------------------------------------
 
 
-bool DeviceData::operator >> (const DevVarLongArray* &datum)
+bool DeviceData::operator>>(const DevVarLongArray *&datum)
 {
     ext->ext_state.reset();
 
-	bool ret = (any.inout() >>= datum);
-	if (ret == false)
-	{
+    bool ret = (any.inout() >>= datum);
+    if (ret == false)
+    {
         if (any_is_null())
             return ret;
 
         ext->ext_state.set(wrongtype_flag);
-		if (exceptions_flags.test(wrongtype_flag))
-		{
-			ApiDataExcept::throw_exception((const char*)API_IncompatibleCmdArgumentType,
-				       		(const char*)"Cannot extract, data in DeviceData object is not an array of long (32 bits)",
-				        	(const char*)"DeviceData::operator>>");
-		}
-	}
-	return ret;
+        if (exceptions_flags.test(wrongtype_flag))
+        {
+            ApiDataExcept::throw_exception((const char *) API_IncompatibleCmdArgumentType,
+                                           (const char *) "Cannot extract, data in DeviceData object is not an array of long (32 bits)",
+                                           (const char *) "DeviceData::operator>>");
+        }
+    }
+    return ret;
 }
 
 //-----------------------------------------------------------------------------
@@ -1101,45 +1107,45 @@ bool DeviceData::operator >> (const DevVarLongArray* &datum)
 //
 //-----------------------------------------------------------------------------
 
-bool DeviceData::operator >> (vector<DevULong>& datum)
+bool DeviceData::operator>>(vector<DevULong> &datum)
 {
     ext->ext_state.reset();
 
-	const DevVarULongArray *ulong_array = NULL;
+    const DevVarULongArray *ulong_array = NULL;
 
-	bool ret = (any.inout() >>= ulong_array);
-	if (ret == false)
-	{
+    bool ret = (any.inout() >>= ulong_array);
+    if (ret == false)
+    {
         if (any_is_null())
             return ret;
 
         ext->ext_state.set(wrongtype_flag);
-		if (exceptions_flags.test(wrongtype_flag))
-		{
-			ApiDataExcept::throw_exception((const char*)API_IncompatibleCmdArgumentType,
-				       		(const char*)"Cannot extract, data in DeviceData object is not an array of DevULong (unsigned long 32 bits)",
-				        	(const char*)"DeviceData::operator>>");
-		}
-	}
-	else
-	{
-	    if (ulong_array == NULL)
-	    {
+        if (exceptions_flags.test(wrongtype_flag))
+        {
+            ApiDataExcept::throw_exception((const char *) API_IncompatibleCmdArgumentType,
+                                           (const char *) "Cannot extract, data in DeviceData object is not an array of DevULong (unsigned long 32 bits)",
+                                           (const char *) "DeviceData::operator>>");
+        }
+    }
+    else
+    {
+        if (ulong_array == NULL)
+        {
             ext->ext_state.set(wrongtype_flag);
-            ApiDataExcept::throw_exception((const char *)API_IncoherentDevData,
-                                       (const char *)"Incoherent data received from server",
-                                       (const char *)"DeviceData::operator>>");
-	    }
+            ApiDataExcept::throw_exception((const char *) API_IncoherentDevData,
+                                           (const char *) "Incoherent data received from server",
+                                           (const char *) "DeviceData::operator>>");
+        }
         else
         {
             datum.resize(ulong_array->length());
-            for (unsigned int i=0; i<ulong_array->length(); i++)
+            for (unsigned int i = 0; i < ulong_array->length(); i++)
             {
                 datum[i] = (*ulong_array)[i];
             }
         }
-	}
-	return ret;
+    }
+    return ret;
 }
 
 
@@ -1150,25 +1156,25 @@ bool DeviceData::operator >> (vector<DevULong>& datum)
 //-----------------------------------------------------------------------------
 
 
-bool DeviceData::operator >> (const DevVarULongArray* &datum)
+bool DeviceData::operator>>(const DevVarULongArray *&datum)
 {
     ext->ext_state.reset();
 
-	bool ret = (any.inout() >>= datum);
-	if (ret == false)
-	{
+    bool ret = (any.inout() >>= datum);
+    if (ret == false)
+    {
         if (any_is_null())
             return ret;
 
         ext->ext_state.set(wrongtype_flag);
-		if (exceptions_flags.test(wrongtype_flag))
-		{
-			ApiDataExcept::throw_exception((const char*)API_IncompatibleCmdArgumentType,
-				       		(const char*)"Cannot extract, data in DeviceData object is not an array of unsigned long (32 bits)",
-				        	(const char*)"DeviceData::operator>>");
-		}
-	}
-	return ret;
+        if (exceptions_flags.test(wrongtype_flag))
+        {
+            ApiDataExcept::throw_exception((const char *) API_IncompatibleCmdArgumentType,
+                                           (const char *) "Cannot extract, data in DeviceData object is not an array of unsigned long (32 bits)",
+                                           (const char *) "DeviceData::operator>>");
+        }
+    }
+    return ret;
 }
 
 
@@ -1179,25 +1185,25 @@ bool DeviceData::operator >> (const DevVarULongArray* &datum)
 //-----------------------------------------------------------------------------
 
 
-bool DeviceData::operator >> (const DevVarLong64Array* &datum)
+bool DeviceData::operator>>(const DevVarLong64Array *&datum)
 {
     ext->ext_state.reset();
 
-	bool ret = (any.inout() >>= datum);
-	if (ret == false)
-	{
+    bool ret = (any.inout() >>= datum);
+    if (ret == false)
+    {
         if (any_is_null())
             return ret;
 
         ext->ext_state.set(wrongtype_flag);
-		if (exceptions_flags.test(wrongtype_flag))
-		{
-			ApiDataExcept::throw_exception((const char*)API_IncompatibleCmdArgumentType,
-				       		(const char*)"Cannot extract, data in DeviceData object is not an array of long (64 bits)",
-				        	(const char*)"DeviceData::operator>>");
-		}
-	}
-	return ret;
+        if (exceptions_flags.test(wrongtype_flag))
+        {
+            ApiDataExcept::throw_exception((const char *) API_IncompatibleCmdArgumentType,
+                                           (const char *) "Cannot extract, data in DeviceData object is not an array of long (64 bits)",
+                                           (const char *) "DeviceData::operator>>");
+        }
+    }
+    return ret;
 }
 
 //-----------------------------------------------------------------------------
@@ -1207,25 +1213,25 @@ bool DeviceData::operator >> (const DevVarLong64Array* &datum)
 //-----------------------------------------------------------------------------
 
 
-bool DeviceData::operator >> (const DevVarULong64Array* &datum)
+bool DeviceData::operator>>(const DevVarULong64Array *&datum)
 {
     ext->ext_state.reset();
 
-	bool ret = (any.inout() >>= datum);
-	if (ret == false)
-	{
+    bool ret = (any.inout() >>= datum);
+    if (ret == false)
+    {
         if (any_is_null())
             return ret;
 
         ext->ext_state.set(wrongtype_flag);
-		if (exceptions_flags.test(wrongtype_flag))
-		{
-			ApiDataExcept::throw_exception((const char*)API_IncompatibleCmdArgumentType,
-				       		(const char*)"Cannot extract, data in DeviceData object is not an array of unsigned long (64 bits)",
-				        	(const char*)"DeviceData::operator>>");
-		}
-	}
-	return ret;
+        if (exceptions_flags.test(wrongtype_flag))
+        {
+            ApiDataExcept::throw_exception((const char *) API_IncompatibleCmdArgumentType,
+                                           (const char *) "Cannot extract, data in DeviceData object is not an array of unsigned long (64 bits)",
+                                           (const char *) "DeviceData::operator>>");
+        }
+    }
+    return ret;
 }
 
 //-----------------------------------------------------------------------------
@@ -1234,44 +1240,44 @@ bool DeviceData::operator >> (const DevVarULong64Array* &datum)
 //
 //-----------------------------------------------------------------------------
 
-bool DeviceData::operator >> (vector<DevLong64>& datum)
+bool DeviceData::operator>>(vector<DevLong64> &datum)
 {
     ext->ext_state.reset();
 
-	const DevVarLong64Array *ll_array = NULL;
-	bool ret = (any.inout() >>= ll_array);
-	if (ret == false)
-	{
+    const DevVarLong64Array *ll_array = NULL;
+    bool ret = (any.inout() >>= ll_array);
+    if (ret == false)
+    {
         if (any_is_null())
             return ret;
 
         ext->ext_state.set(wrongtype_flag);
-		if (exceptions_flags.test(wrongtype_flag))
-		{
-			ApiDataExcept::throw_exception((const char*)API_IncompatibleCmdArgumentType,
-				       		(const char*)"Cannot extract, data in DeviceData object is not an array of DevLong64 (64 bits long)",
-				        	(const char*)"DeviceData::operator>>");
-		}
-	}
-	else
-	{
-	    if (ll_array == NULL)
-	    {
+        if (exceptions_flags.test(wrongtype_flag))
+        {
+            ApiDataExcept::throw_exception((const char *) API_IncompatibleCmdArgumentType,
+                                           (const char *) "Cannot extract, data in DeviceData object is not an array of DevLong64 (64 bits long)",
+                                           (const char *) "DeviceData::operator>>");
+        }
+    }
+    else
+    {
+        if (ll_array == NULL)
+        {
             ext->ext_state.set(wrongtype_flag);
-            ApiDataExcept::throw_exception((const char *)API_IncoherentDevData,
-                                       (const char *)"Incoherent data received from server",
-                                       (const char *)"DeviceData::operator>>");
-	    }
+            ApiDataExcept::throw_exception((const char *) API_IncoherentDevData,
+                                           (const char *) "Incoherent data received from server",
+                                           (const char *) "DeviceData::operator>>");
+        }
         else
         {
             datum.resize(ll_array->length());
-            for (unsigned int i=0; i<ll_array->length(); i++)
+            for (unsigned int i = 0; i < ll_array->length(); i++)
             {
                 datum[i] = (*ll_array)[i];
             }
         }
-	}
-	return ret;
+    }
+    return ret;
 }
 
 //-----------------------------------------------------------------------------
@@ -1280,44 +1286,44 @@ bool DeviceData::operator >> (vector<DevLong64>& datum)
 //
 //-----------------------------------------------------------------------------
 
-bool DeviceData::operator >> (vector<DevULong64>& datum)
+bool DeviceData::operator>>(vector<DevULong64> &datum)
 {
     ext->ext_state.reset();
 
-	const DevVarULong64Array *ull_array = NULL;
-	bool ret = (any.inout() >>= ull_array);
-	if (ret == false)
-	{
+    const DevVarULong64Array *ull_array = NULL;
+    bool ret = (any.inout() >>= ull_array);
+    if (ret == false)
+    {
         if (any_is_null())
-            return  ret;
+            return ret;
 
         ext->ext_state.set(wrongtype_flag);
-		if (exceptions_flags.test(wrongtype_flag))
-		{
-			ApiDataExcept::throw_exception((const char*)API_IncompatibleCmdArgumentType,
-				       		(const char*)"Cannot extract, data in DeviceData object is not an array of DevULong64 (unsigned 64 bits long)",
-				        	(const char*)"DeviceData::operator>>");
-		}
-	}
-	else
-	{
-	    if (ull_array == NULL)
-	    {
+        if (exceptions_flags.test(wrongtype_flag))
+        {
+            ApiDataExcept::throw_exception((const char *) API_IncompatibleCmdArgumentType,
+                                           (const char *) "Cannot extract, data in DeviceData object is not an array of DevULong64 (unsigned 64 bits long)",
+                                           (const char *) "DeviceData::operator>>");
+        }
+    }
+    else
+    {
+        if (ull_array == NULL)
+        {
             ext->ext_state.set(wrongtype_flag);
-            ApiDataExcept::throw_exception((const char *)API_IncoherentDevData,
-                                       (const char *)"Incoherent data received from server",
-                                       (const char *)"DeviceData::operator>>");
-	    }
+            ApiDataExcept::throw_exception((const char *) API_IncoherentDevData,
+                                           (const char *) "Incoherent data received from server",
+                                           (const char *) "DeviceData::operator>>");
+        }
         else
         {
             datum.resize(ull_array->length());
-            for (unsigned int i=0; i<ull_array->length(); i++)
+            for (unsigned int i = 0; i < ull_array->length(); i++)
             {
                 datum[i] = (*ull_array)[i];
             }
         }
-	}
-	return ret;
+    }
+    return ret;
 }
 
 //-----------------------------------------------------------------------------
@@ -1326,44 +1332,44 @@ bool DeviceData::operator >> (vector<DevULong64>& datum)
 //
 //-----------------------------------------------------------------------------
 
-bool DeviceData::operator >> (vector<float>& datum)
+bool DeviceData::operator>>(vector<float> &datum)
 {
     ext->ext_state.reset();
 
-	const DevVarFloatArray *float_array = NULL;
-	bool ret = (any.inout() >>= float_array);
-	if (ret == false)
-	{
+    const DevVarFloatArray *float_array = NULL;
+    bool ret = (any.inout() >>= float_array);
+    if (ret == false)
+    {
         if (any_is_null())
             return ret;
 
         ext->ext_state.set(wrongtype_flag);
-		if (exceptions_flags.test(wrongtype_flag))
-		{
-			ApiDataExcept::throw_exception((const char*)API_IncompatibleCmdArgumentType,
-				       		(const char*)"Cannot extract, data in DeviceData object is not an array of float",
-				        	(const char*)"DeviceData::operator>>");
-		}
-	}
-	else
-	{
-	    if (float_array == NULL)
-	    {
+        if (exceptions_flags.test(wrongtype_flag))
+        {
+            ApiDataExcept::throw_exception((const char *) API_IncompatibleCmdArgumentType,
+                                           (const char *) "Cannot extract, data in DeviceData object is not an array of float",
+                                           (const char *) "DeviceData::operator>>");
+        }
+    }
+    else
+    {
+        if (float_array == NULL)
+        {
             ext->ext_state.set(wrongtype_flag);
-            ApiDataExcept::throw_exception((const char *)API_IncoherentDevData,
-                                       (const char *)"Incoherent data received from server",
-                                       (const char *)"DeviceData::operator>>");
-	    }
+            ApiDataExcept::throw_exception((const char *) API_IncoherentDevData,
+                                           (const char *) "Incoherent data received from server",
+                                           (const char *) "DeviceData::operator>>");
+        }
         else
         {
             datum.resize(float_array->length());
-            for (unsigned int i=0; i<float_array->length(); i++)
+            for (unsigned int i = 0; i < float_array->length(); i++)
             {
                 datum[i] = (*float_array)[i];
             }
         }
-	}
-	return ret;
+    }
+    return ret;
 }
 
 
@@ -1374,25 +1380,25 @@ bool DeviceData::operator >> (vector<float>& datum)
 //-----------------------------------------------------------------------------
 
 
-bool DeviceData::operator >> (const DevVarFloatArray* &datum)
+bool DeviceData::operator>>(const DevVarFloatArray *&datum)
 {
     ext->ext_state.reset();
 
-	bool ret = (any.inout() >>= datum);
-	if (ret == false)
-	{
+    bool ret = (any.inout() >>= datum);
+    if (ret == false)
+    {
         if (any_is_null())
             return ret;
 
         ext->ext_state.set(wrongtype_flag);
-		if (exceptions_flags.test(wrongtype_flag))
-		{
-			ApiDataExcept::throw_exception((const char*)API_IncompatibleCmdArgumentType,
-				       		(const char*)"Cannot extract, data in DeviceData object is not an array of float",
-				        	(const char*)"DeviceData::operator>>");
-		}
-	}
-	return ret;
+        if (exceptions_flags.test(wrongtype_flag))
+        {
+            ApiDataExcept::throw_exception((const char *) API_IncompatibleCmdArgumentType,
+                                           (const char *) "Cannot extract, data in DeviceData object is not an array of float",
+                                           (const char *) "DeviceData::operator>>");
+        }
+    }
+    return ret;
 }
 
 //-----------------------------------------------------------------------------
@@ -1401,45 +1407,45 @@ bool DeviceData::operator >> (const DevVarFloatArray* &datum)
 //
 //-----------------------------------------------------------------------------
 
-bool DeviceData::operator >> (vector<double>& datum)
+bool DeviceData::operator>>(vector<double> &datum)
 {
     ext->ext_state.reset();
 
-	const DevVarDoubleArray *double_array = NULL;
+    const DevVarDoubleArray *double_array = NULL;
 
-	bool ret = (any.inout() >>= double_array);
-	if (ret == false)
-	{
+    bool ret = (any.inout() >>= double_array);
+    if (ret == false)
+    {
         if (any_is_null())
             return ret;
 
         ext->ext_state.set(wrongtype_flag);
-		if (exceptions_flags.test(wrongtype_flag))
-		{
-			ApiDataExcept::throw_exception((const char*)API_IncompatibleCmdArgumentType,
-				       		(const char*)"Cannot extract, data in DeviceData object is not an array of double",
-				        	(const char*)"DeviceData::operator>>");
-		}
-	}
-	else
-	{
-	    if (double_array == NULL)
-	    {
+        if (exceptions_flags.test(wrongtype_flag))
+        {
+            ApiDataExcept::throw_exception((const char *) API_IncompatibleCmdArgumentType,
+                                           (const char *) "Cannot extract, data in DeviceData object is not an array of double",
+                                           (const char *) "DeviceData::operator>>");
+        }
+    }
+    else
+    {
+        if (double_array == NULL)
+        {
             ext->ext_state.set(wrongtype_flag);
-            ApiDataExcept::throw_exception((const char *)API_IncoherentDevData,
-                                       (const char *)"Incoherent data received from server",
-                                       (const char *)"DeviceData::operator>>");
-	    }
+            ApiDataExcept::throw_exception((const char *) API_IncoherentDevData,
+                                           (const char *) "Incoherent data received from server",
+                                           (const char *) "DeviceData::operator>>");
+        }
         else
         {
             datum.resize(double_array->length());
-            for (unsigned int i=0; i<double_array->length(); i++)
+            for (unsigned int i = 0; i < double_array->length(); i++)
             {
                 datum[i] = (*double_array)[i];
             }
         }
-	}
-	return ret;
+    }
+    return ret;
 }
 
 
@@ -1450,25 +1456,25 @@ bool DeviceData::operator >> (vector<double>& datum)
 //-----------------------------------------------------------------------------
 
 
-bool DeviceData::operator >> (const DevVarDoubleArray* &datum)
+bool DeviceData::operator>>(const DevVarDoubleArray *&datum)
 {
     ext->ext_state.reset();
 
-	bool ret = (any.inout() >>= datum);
-	if (ret == false)
-	{
+    bool ret = (any.inout() >>= datum);
+    if (ret == false)
+    {
         if (any_is_null())
             return ret;
 
         ext->ext_state.set(wrongtype_flag);
-		if (exceptions_flags.test(wrongtype_flag))
-		{
-			ApiDataExcept::throw_exception((const char*)API_IncompatibleCmdArgumentType,
-				       		(const char*)"Cannot extract, data in DeviceData object is not an array of double",
-				        	(const char*)"DeviceData::operator>>");
-		}
-	}
-	return ret;
+        if (exceptions_flags.test(wrongtype_flag))
+        {
+            ApiDataExcept::throw_exception((const char *) API_IncompatibleCmdArgumentType,
+                                           (const char *) "Cannot extract, data in DeviceData object is not an array of double",
+                                           (const char *) "DeviceData::operator>>");
+        }
+    }
+    return ret;
 }
 
 //-----------------------------------------------------------------------------
@@ -1477,45 +1483,45 @@ bool DeviceData::operator >> (const DevVarDoubleArray* &datum)
 //
 //-----------------------------------------------------------------------------
 
-bool DeviceData::operator >> (vector<string>& datum)
+bool DeviceData::operator>>(vector<string> &datum)
 {
     ext->ext_state.reset();
 
-	const DevVarStringArray *string_array = NULL;
+    const DevVarStringArray *string_array = NULL;
 
-	bool ret = (any.inout() >>= string_array);
-	if (ret == false)
-	{
+    bool ret = (any.inout() >>= string_array);
+    if (ret == false)
+    {
         if (any_is_null())
             return ret;
 
         ext->ext_state.set(wrongtype_flag);
-		if (exceptions_flags.test(wrongtype_flag))
-		{
-			ApiDataExcept::throw_exception((const char*)API_IncompatibleCmdArgumentType,
-				       		(const char*)"Cannot extract, data in DeviceData object is not an array of string",
-				        	(const char*)"DeviceData::operator>>");
-		}
-	}
-	else
-	{
-	    if (string_array == NULL)
-	    {
+        if (exceptions_flags.test(wrongtype_flag))
+        {
+            ApiDataExcept::throw_exception((const char *) API_IncompatibleCmdArgumentType,
+                                           (const char *) "Cannot extract, data in DeviceData object is not an array of string",
+                                           (const char *) "DeviceData::operator>>");
+        }
+    }
+    else
+    {
+        if (string_array == NULL)
+        {
             ext->ext_state.set(wrongtype_flag);
-            ApiDataExcept::throw_exception((const char *)API_IncoherentDevData,
-                                       (const char *)"Incoherent data received from server",
-                                       (const char *)"DeviceData::operator>>");
-	    }
+            ApiDataExcept::throw_exception((const char *) API_IncoherentDevData,
+                                           (const char *) "Incoherent data received from server",
+                                           (const char *) "DeviceData::operator>>");
+        }
         else
         {
             datum.resize(string_array->length());
-            for (unsigned int i=0; i<string_array->length(); i++)
+            for (unsigned int i = 0; i < string_array->length(); i++)
             {
                 datum[i] = (*string_array)[i];
             }
         }
-	}
-	return ret;
+    }
+    return ret;
 }
 
 
@@ -1525,25 +1531,25 @@ bool DeviceData::operator >> (vector<string>& datum)
 //
 //-----------------------------------------------------------------------------
 
-bool DeviceData::operator >> (const DevVarStringArray* &datum)
+bool DeviceData::operator>>(const DevVarStringArray *&datum)
 {
     ext->ext_state.reset();
 
-	bool ret = (any.inout() >>= datum);
-	if (ret == false)
-	{
+    bool ret = (any.inout() >>= datum);
+    if (ret == false)
+    {
         if (any_is_null())
             return ret;
 
         ext->ext_state.set(wrongtype_flag);
-		if (exceptions_flags.test(wrongtype_flag))
-		{
-			ApiDataExcept::throw_exception((const char*)API_IncompatibleCmdArgumentType,
-				       		(const char*)"Cannot extract, data in DeviceData object is not an array of string",
-				        	(const char*)"DeviceData::operator>>");
-		}
-	}
-	return ret;
+        if (exceptions_flags.test(wrongtype_flag))
+        {
+            ApiDataExcept::throw_exception((const char *) API_IncompatibleCmdArgumentType,
+                                           (const char *) "Cannot extract, data in DeviceData object is not an array of string",
+                                           (const char *) "DeviceData::operator>>");
+        }
+    }
+    return ret;
 }
 
 //-----------------------------------------------------------------------------
@@ -1553,25 +1559,25 @@ bool DeviceData::operator >> (const DevVarStringArray* &datum)
 //
 //-----------------------------------------------------------------------------
 
-bool DeviceData::operator >> (const DevEncoded* &datum)
+bool DeviceData::operator>>(const DevEncoded *&datum)
 {
     ext->ext_state.reset();
 
-	bool ret = (any.inout() >>= datum);
-	if (ret == false)
-	{
+    bool ret = (any.inout() >>= datum);
+    if (ret == false)
+    {
         if (any_is_null())
             return ret;
 
         ext->ext_state.set(wrongtype_flag);
-		if (exceptions_flags.test(wrongtype_flag))
-		{
-			ApiDataExcept::throw_exception((const char*)API_IncompatibleCmdArgumentType,
-				       		(const char*)"Cannot extract, data in DeviceData object is not a DevEncoded",
-				        	(const char*)"DeviceData::operator>>");
-		}
-	}
-	return ret;
+        if (exceptions_flags.test(wrongtype_flag))
+        {
+            ApiDataExcept::throw_exception((const char *) API_IncompatibleCmdArgumentType,
+                                           (const char *) "Cannot extract, data in DeviceData object is not a DevEncoded",
+                                           (const char *) "DeviceData::operator>>");
+        }
+    }
+    return ret;
 }
 
 //-----------------------------------------------------------------------------
@@ -1581,45 +1587,45 @@ bool DeviceData::operator >> (const DevEncoded* &datum)
 //
 //-----------------------------------------------------------------------------
 
-bool DeviceData::operator >> (DevEncoded &datum)
+bool DeviceData::operator>>(DevEncoded &datum)
 {
     ext->ext_state.reset();
 
     const DevEncoded *tmp_enc = NULL;
-	bool ret = (any.inout() >>= tmp_enc);
-	if (ret == false)
-	{
+    bool ret = (any.inout() >>= tmp_enc);
+    if (ret == false)
+    {
         if (any_is_null())
             return ret;
 
         ext->ext_state.set(wrongtype_flag);
-		if (exceptions_flags.test(wrongtype_flag))
-		{
-			ApiDataExcept::throw_exception((const char*)API_IncompatibleCmdArgumentType,
-				       		(const char*)"Cannot extract, data in DeviceData object is not a DevEncoded",
-				        	(const char*)"DeviceData::operator>>");
-		}
-	}
-	else
-	{
-	    if (tmp_enc == NULL)
-	    {
+        if (exceptions_flags.test(wrongtype_flag))
+        {
+            ApiDataExcept::throw_exception((const char *) API_IncompatibleCmdArgumentType,
+                                           (const char *) "Cannot extract, data in DeviceData object is not a DevEncoded",
+                                           (const char *) "DeviceData::operator>>");
+        }
+    }
+    else
+    {
+        if (tmp_enc == NULL)
+        {
             ext->ext_state.set(wrongtype_flag);
-            ApiDataExcept::throw_exception((const char *)API_IncoherentDevData,
-                                       (const char *)"Incoherent data received from server",
-                                       (const char *)"DeviceData::operator>>");
-	    }
+            ApiDataExcept::throw_exception((const char *) API_IncoherentDevData,
+                                           (const char *) "Incoherent data received from server",
+                                           (const char *) "DeviceData::operator>>");
+        }
         else
         {
             datum.encoded_data.length(tmp_enc->encoded_data.length());
-            for (unsigned int i=0; i<tmp_enc->encoded_data.length(); i++)
+            for (unsigned int i = 0; i < tmp_enc->encoded_data.length(); i++)
             {
                 datum.encoded_data[i] = tmp_enc->encoded_data[i];
             }
             datum.encoded_format = CORBA::string_dup(tmp_enc->encoded_format);
         }
-	}
-	return ret;
+    }
+    return ret;
 }
 
 //-----------------------------------------------------------------------------
@@ -1628,15 +1634,15 @@ bool DeviceData::operator >> (DevEncoded &datum)
 //
 //-----------------------------------------------------------------------------
 
-void DeviceData::operator << (vector<bool>& datum)
+void DeviceData::operator<<(vector<bool> &datum)
 {
-	DevVarBooleanArray *bool_array = new DevVarBooleanArray();
-	bool_array->length(datum.size());
-	for (unsigned int i=0; i<datum.size(); i++)
-	{
-		(*bool_array)[i] = datum[i];
-	}
-	any.inout() <<= bool_array;
+    DevVarBooleanArray *bool_array = new DevVarBooleanArray();
+    bool_array->length(datum.size());
+    for (unsigned int i = 0; i < datum.size(); i++)
+    {
+        (*bool_array)[i] = datum[i];
+    }
+    any.inout() <<= bool_array;
 }
 
 //-----------------------------------------------------------------------------
@@ -1645,15 +1651,15 @@ void DeviceData::operator << (vector<bool>& datum)
 //
 //-----------------------------------------------------------------------------
 
-void DeviceData::operator << (vector<unsigned char>& datum)
+void DeviceData::operator<<(vector<unsigned char> &datum)
 {
-	DevVarCharArray *char_array = new DevVarCharArray();
-	char_array->length(datum.size());
-	for (unsigned int i=0; i<datum.size(); i++)
-	{
-		(*char_array)[i] = datum[i];
-	}
-	any.inout() <<= char_array;
+    DevVarCharArray *char_array = new DevVarCharArray();
+    char_array->length(datum.size());
+    for (unsigned int i = 0; i < datum.size(); i++)
+    {
+        (*char_array)[i] = datum[i];
+    }
+    any.inout() <<= char_array;
 }
 
 //-----------------------------------------------------------------------------
@@ -1662,15 +1668,15 @@ void DeviceData::operator << (vector<unsigned char>& datum)
 //
 //-----------------------------------------------------------------------------
 
-void DeviceData::operator << (vector<short>& datum)
+void DeviceData::operator<<(vector<short> &datum)
 {
-	DevVarShortArray *short_array = new DevVarShortArray();
-	short_array->length(datum.size());
-	for (unsigned int i=0; i<datum.size(); i++)
-	{
-		(*short_array)[i] = datum[i];
-	}
-	any.inout() <<= short_array;
+    DevVarShortArray *short_array = new DevVarShortArray();
+    short_array->length(datum.size());
+    for (unsigned int i = 0; i < datum.size(); i++)
+    {
+        (*short_array)[i] = datum[i];
+    }
+    any.inout() <<= short_array;
 }
 
 //-----------------------------------------------------------------------------
@@ -1679,15 +1685,15 @@ void DeviceData::operator << (vector<short>& datum)
 //
 //-----------------------------------------------------------------------------
 
-void DeviceData::operator << (vector<unsigned short>& datum)
+void DeviceData::operator<<(vector<unsigned short> &datum)
 {
-	DevVarUShortArray *ushort_array = new DevVarUShortArray();
-	ushort_array->length(datum.size());
-	for (unsigned int i=0; i<datum.size(); i++)
-	{
-		(*ushort_array)[i] = datum[i];
-	}
-	any.inout() <<= ushort_array;
+    DevVarUShortArray *ushort_array = new DevVarUShortArray();
+    ushort_array->length(datum.size());
+    for (unsigned int i = 0; i < datum.size(); i++)
+    {
+        (*ushort_array)[i] = datum[i];
+    }
+    any.inout() <<= ushort_array;
 }
 
 
@@ -1697,15 +1703,15 @@ void DeviceData::operator << (vector<unsigned short>& datum)
 //
 //-----------------------------------------------------------------------------
 
-void DeviceData::operator << (vector<DevLong>& datum)
+void DeviceData::operator<<(vector<DevLong> &datum)
 {
-	DevVarLongArray *long_array = new DevVarLongArray();
-	long_array->length(datum.size());
-	for (unsigned int i=0; i<datum.size(); i++)
-	{
-		(*long_array)[i] = datum[i];
-	}
-	any.inout() <<= long_array;
+    DevVarLongArray *long_array = new DevVarLongArray();
+    long_array->length(datum.size());
+    for (unsigned int i = 0; i < datum.size(); i++)
+    {
+        (*long_array)[i] = datum[i];
+    }
+    any.inout() <<= long_array;
 }
 
 
@@ -1715,15 +1721,15 @@ void DeviceData::operator << (vector<DevLong>& datum)
 //
 //-----------------------------------------------------------------------------
 
-void DeviceData::operator << (vector<DevULong>& datum)
+void DeviceData::operator<<(vector<DevULong> &datum)
 {
-	DevVarULongArray *ulong_array = new DevVarULongArray();
-	ulong_array->length(datum.size());
-	for (unsigned int i=0; i<datum.size(); i++)
-	{
-		(*ulong_array)[i] = datum[i];
-	}
-	any.inout() <<= ulong_array;
+    DevVarULongArray *ulong_array = new DevVarULongArray();
+    ulong_array->length(datum.size());
+    for (unsigned int i = 0; i < datum.size(); i++)
+    {
+        (*ulong_array)[i] = datum[i];
+    }
+    any.inout() <<= ulong_array;
 }
 
 //-----------------------------------------------------------------------------
@@ -1732,15 +1738,15 @@ void DeviceData::operator << (vector<DevULong>& datum)
 //
 //-----------------------------------------------------------------------------
 
-void DeviceData::operator << (vector<float>& datum)
+void DeviceData::operator<<(vector<float> &datum)
 {
-	DevVarFloatArray *float_array = new DevVarFloatArray();
-	float_array->length(datum.size());
-	for (unsigned int i=0; i<datum.size(); i++)
-	{
-		(*float_array)[i] = datum[i];
-	}
-	any.inout() <<= float_array;
+    DevVarFloatArray *float_array = new DevVarFloatArray();
+    float_array->length(datum.size());
+    for (unsigned int i = 0; i < datum.size(); i++)
+    {
+        (*float_array)[i] = datum[i];
+    }
+    any.inout() <<= float_array;
 }
 
 //-----------------------------------------------------------------------------
@@ -1749,15 +1755,15 @@ void DeviceData::operator << (vector<float>& datum)
 //
 //-----------------------------------------------------------------------------
 
-void DeviceData::operator << (vector<double>& datum)
+void DeviceData::operator<<(vector<double> &datum)
 {
-	DevVarDoubleArray *double_array = new DevVarDoubleArray();
-	double_array->length(datum.size());
-	for (unsigned int i=0; i<datum.size(); i++)
-	{
-		(*double_array)[i] = datum[i];
-	}
-	any.inout() <<= double_array;
+    DevVarDoubleArray *double_array = new DevVarDoubleArray();
+    double_array->length(datum.size());
+    for (unsigned int i = 0; i < datum.size(); i++)
+    {
+        (*double_array)[i] = datum[i];
+    }
+    any.inout() <<= double_array;
 }
 
 
@@ -1767,15 +1773,15 @@ void DeviceData::operator << (vector<double>& datum)
 //
 //-----------------------------------------------------------------------------
 
-void DeviceData::operator << (vector<string>& datum)
+void DeviceData::operator<<(vector<string> &datum)
 {
-	DevVarStringArray *string_array = new DevVarStringArray();
-	string_array->length(datum.size());
-	for (unsigned int i=0; i<datum.size(); i++)
-	{
-		(*string_array)[i] = string_dup(datum[i].c_str());
-	}
-	any.inout() <<= string_array;
+    DevVarStringArray *string_array = new DevVarStringArray();
+    string_array->length(datum.size());
+    for (unsigned int i = 0; i < datum.size(); i++)
+    {
+        (*string_array)[i] = string_dup(datum[i].c_str());
+    }
+    any.inout() <<= string_array;
 }
 
 //-----------------------------------------------------------------------------
@@ -1784,15 +1790,15 @@ void DeviceData::operator << (vector<string>& datum)
 //
 //-----------------------------------------------------------------------------
 
-void DeviceData::operator << (vector<DevLong64>& datum)
+void DeviceData::operator<<(vector<DevLong64> &datum)
 {
-	DevVarLong64Array *ll_array = new DevVarLong64Array();
-	ll_array->length(datum.size());
-	for (unsigned int i=0; i<datum.size(); i++)
-	{
-		(*ll_array)[i] = datum[i];
-	}
-	any.inout() <<= ll_array;
+    DevVarLong64Array *ll_array = new DevVarLong64Array();
+    ll_array->length(datum.size());
+    for (unsigned int i = 0; i < datum.size(); i++)
+    {
+        (*ll_array)[i] = datum[i];
+    }
+    any.inout() <<= ll_array;
 }
 
 //-----------------------------------------------------------------------------
@@ -1801,15 +1807,15 @@ void DeviceData::operator << (vector<DevLong64>& datum)
 //
 //-----------------------------------------------------------------------------
 
-void DeviceData::operator << (vector<DevULong64>& datum)
+void DeviceData::operator<<(vector<DevULong64> &datum)
 {
-	DevVarULong64Array *ull_array = new DevVarULong64Array();
-	ull_array->length(datum.size());
-	for (unsigned int i=0; i<datum.size(); i++)
-	{
-		(*ull_array)[i] = datum[i];
-	}
-	any.inout() <<= ull_array;
+    DevVarULong64Array *ull_array = new DevVarULong64Array();
+    ull_array->length(datum.size());
+    for (unsigned int i = 0; i < datum.size(); i++)
+    {
+        (*ull_array)[i] = datum[i];
+    }
+    any.inout() <<= ull_array;
 }
 
 //-----------------------------------------------------------------------------
@@ -1819,22 +1825,22 @@ void DeviceData::operator << (vector<DevULong64>& datum)
 //
 //-----------------------------------------------------------------------------
 
-void DeviceData::insert (vector<DevLong> &long_datum, vector<string>& string_datum)
+void DeviceData::insert(vector<DevLong> &long_datum, vector<string> &string_datum)
 {
-	unsigned int i;
+    unsigned int i;
 
-	DevVarLongStringArray *long_string_array = new DevVarLongStringArray();
-	long_string_array->lvalue.length(long_datum.size());
-	for (i=0; i<long_datum.size(); i++)
-	{
-		(long_string_array->lvalue)[i] = long_datum[i];
-	}
-	long_string_array->svalue.length(string_datum.size());
-	for (i=0; i<string_datum.size(); i++)
-	{
-		(long_string_array->svalue)[i] = string_dup(string_datum[i].c_str());
-	}
-	any.inout() <<= long_string_array;
+    DevVarLongStringArray *long_string_array = new DevVarLongStringArray();
+    long_string_array->lvalue.length(long_datum.size());
+    for (i = 0; i < long_datum.size(); i++)
+    {
+        (long_string_array->lvalue)[i] = long_datum[i];
+    }
+    long_string_array->svalue.length(string_datum.size());
+    for (i = 0; i < string_datum.size(); i++)
+    {
+        (long_string_array->svalue)[i] = string_dup(string_datum[i].c_str());
+    }
+    any.inout() <<= long_string_array;
 }
 
 //-----------------------------------------------------------------------------
@@ -1844,52 +1850,52 @@ void DeviceData::insert (vector<DevLong> &long_datum, vector<string>& string_dat
 //
 //-----------------------------------------------------------------------------
 
-bool DeviceData::extract(vector<DevLong> &long_datum, vector<string>& string_datum)
+bool DeviceData::extract(vector<DevLong> &long_datum, vector<string> &string_datum)
 {
-	bool ret;
-	ext->ext_state.reset();
+    bool ret;
+    ext->ext_state.reset();
 
-	const DevVarLongStringArray *long_string_array = NULL;
-	ret = (any.inout() >>= long_string_array);
-	if (ret == false)
-	{
+    const DevVarLongStringArray *long_string_array = NULL;
+    ret = (any.inout() >>= long_string_array);
+    if (ret == false)
+    {
         if (any_is_null())
             return ret;
 
         ext->ext_state.set(wrongtype_flag);
-		if (exceptions_flags.test(wrongtype_flag))
-		{
-			ApiDataExcept::throw_exception((const char*)API_IncompatibleCmdArgumentType,
-				       		(const char*)"Cannot extract, data in DeviceData object is not a structure with sequences of string(s) and long(s) (32 bits)",
-				        	(const char*)"DeviceData::operator>>");
-		}
-	}
-	else
-	{
-	    if (long_string_array == NULL)
-	    {
+        if (exceptions_flags.test(wrongtype_flag))
+        {
+            ApiDataExcept::throw_exception((const char *) API_IncompatibleCmdArgumentType,
+                                           (const char *) "Cannot extract, data in DeviceData object is not a structure with sequences of string(s) and long(s) (32 bits)",
+                                           (const char *) "DeviceData::operator>>");
+        }
+    }
+    else
+    {
+        if (long_string_array == NULL)
+        {
             ext->ext_state.set(wrongtype_flag);
-            ApiDataExcept::throw_exception((const char *)API_IncoherentDevData,
-                                       (const char *)"Incoherent data received from server",
-                                       (const char *)"DeviceData::operator>>");
-	    }
+            ApiDataExcept::throw_exception((const char *) API_IncoherentDevData,
+                                           (const char *) "Incoherent data received from server",
+                                           (const char *) "DeviceData::operator>>");
+        }
         else
         {
             unsigned int i;
 
             long_datum.resize(long_string_array->lvalue.length());
-            for (i=0; i<long_datum.size(); i++)
+            for (i = 0; i < long_datum.size(); i++)
             {
                 long_datum[i] = (long_string_array->lvalue)[i];
             }
             string_datum.resize(long_string_array->svalue.length());
-            for (i=0; i<string_datum.size(); i++)
+            for (i = 0; i < string_datum.size(); i++)
             {
                 string_datum[i] = (long_string_array->svalue)[i];
             }
         }
-	}
-	return ret;
+    }
+    return ret;
 }
 
 //-----------------------------------------------------------------------------
@@ -1898,25 +1904,25 @@ bool DeviceData::extract(vector<DevLong> &long_datum, vector<string>& string_dat
 //
 //-----------------------------------------------------------------------------
 
-bool DeviceData::operator >> (const DevVarLongStringArray* &datum)
+bool DeviceData::operator>>(const DevVarLongStringArray *&datum)
 {
     ext->ext_state.reset();
 
-	bool ret = (any.inout() >>= datum);
-	if (ret == false)
-	{
+    bool ret = (any.inout() >>= datum);
+    if (ret == false)
+    {
         if (any_is_null())
             return ret;
 
         ext->ext_state.set(wrongtype_flag);
-		if (exceptions_flags.test(wrongtype_flag))
-		{
-			ApiDataExcept::throw_exception((const char*)API_IncompatibleCmdArgumentType,
-				       		(const char*)"Cannot extract, data in DeviceData object is not a structure with sequences of string(s) and long(s) (32 bits) ",
-				        	(const char*)"DeviceData::operator>>");
-		}
-	}
-	return ret;
+        if (exceptions_flags.test(wrongtype_flag))
+        {
+            ApiDataExcept::throw_exception((const char *) API_IncompatibleCmdArgumentType,
+                                           (const char *) "Cannot extract, data in DeviceData object is not a structure with sequences of string(s) and long(s) (32 bits) ",
+                                           (const char *) "DeviceData::operator>>");
+        }
+    }
+    return ret;
 }
 
 
@@ -1927,22 +1933,22 @@ bool DeviceData::operator >> (const DevVarLongStringArray* &datum)
 //
 //-----------------------------------------------------------------------------
 
-void DeviceData::insert (vector<double> &double_datum, vector<string>& string_datum)
+void DeviceData::insert(vector<double> &double_datum, vector<string> &string_datum)
 {
-	unsigned int i;
+    unsigned int i;
 
-	DevVarDoubleStringArray *double_string_array = new DevVarDoubleStringArray();
-	double_string_array->dvalue.length(double_datum.size());
-	for (i=0; i<double_datum.size(); i++)
-	{
-		(double_string_array->dvalue)[i] = double_datum[i];
-	}
-	double_string_array->svalue.length(string_datum.size());
-	for (i=0; i<string_datum.size(); i++)
-	{
-		(double_string_array->svalue)[i] = string_dup(string_datum[i].c_str());
-	}
-	any.inout() <<= double_string_array;
+    DevVarDoubleStringArray *double_string_array = new DevVarDoubleStringArray();
+    double_string_array->dvalue.length(double_datum.size());
+    for (i = 0; i < double_datum.size(); i++)
+    {
+        (double_string_array->dvalue)[i] = double_datum[i];
+    }
+    double_string_array->svalue.length(string_datum.size());
+    for (i = 0; i < string_datum.size(); i++)
+    {
+        (double_string_array->svalue)[i] = string_dup(string_datum[i].c_str());
+    }
+    any.inout() <<= double_string_array;
 }
 
 //-----------------------------------------------------------------------------
@@ -1952,52 +1958,52 @@ void DeviceData::insert (vector<double> &double_datum, vector<string>& string_da
 //
 //-----------------------------------------------------------------------------
 
-bool DeviceData::extract (vector<double> &double_datum, vector<string>& string_datum)
+bool DeviceData::extract(vector<double> &double_datum, vector<string> &string_datum)
 {
-	bool ret;
-	ext->ext_state.reset();
+    bool ret;
+    ext->ext_state.reset();
 
-	const DevVarDoubleStringArray *double_string_array = NULL;
-	ret = (any.inout() >>= double_string_array);
-	if (ret == false)
-	{
+    const DevVarDoubleStringArray *double_string_array = NULL;
+    ret = (any.inout() >>= double_string_array);
+    if (ret == false)
+    {
         if (any_is_null())
             return ret;
 
         ext->ext_state.set(wrongtype_flag);
-		if (exceptions_flags.test(wrongtype_flag))
-		{
-			ApiDataExcept::throw_exception((const char*)API_IncompatibleCmdArgumentType,
-				       		(const char*)"Cannot extract, data in DeviceData object is not a boolean",
-				        	(const char*)"DeviceData::operator>>");
-		}
-	}
-	else
-	{
-	    if (double_string_array == NULL)
-	    {
+        if (exceptions_flags.test(wrongtype_flag))
+        {
+            ApiDataExcept::throw_exception((const char *) API_IncompatibleCmdArgumentType,
+                                           (const char *) "Cannot extract, data in DeviceData object is not a boolean",
+                                           (const char *) "DeviceData::operator>>");
+        }
+    }
+    else
+    {
+        if (double_string_array == NULL)
+        {
             ext->ext_state.set(wrongtype_flag);
-            ApiDataExcept::throw_exception((const char *)API_IncoherentDevData,
-                                       (const char *)"Incoherent data received from server",
-                                       (const char *)"DeviceData::operator>>");
-	    }
+            ApiDataExcept::throw_exception((const char *) API_IncoherentDevData,
+                                           (const char *) "Incoherent data received from server",
+                                           (const char *) "DeviceData::operator>>");
+        }
         else
         {
             unsigned int i;
 
             double_datum.resize(double_string_array->dvalue.length());
-            for (i=0; i<double_datum.size(); i++)
+            for (i = 0; i < double_datum.size(); i++)
             {
                 double_datum[i] = (double_string_array->dvalue)[i];
             }
             string_datum.resize(double_string_array->svalue.length());
-            for (i=0; i<string_datum.size(); i++)
+            for (i = 0; i < string_datum.size(); i++)
             {
                 string_datum[i] = (double_string_array->svalue)[i];
             }
         }
-	}
-	return ret;
+    }
+    return ret;
 }
 
 //-----------------------------------------------------------------------------
@@ -2006,25 +2012,25 @@ bool DeviceData::extract (vector<double> &double_datum, vector<string>& string_d
 //
 //-----------------------------------------------------------------------------
 
-bool DeviceData::operator >> (const DevVarDoubleStringArray* &datum)
+bool DeviceData::operator>>(const DevVarDoubleStringArray *&datum)
 {
     ext->ext_state.reset();
 
-	bool ret = (any.inout() >>= datum);
-	if (ret == false)
-	{
+    bool ret = (any.inout() >>= datum);
+    if (ret == false)
+    {
         if (any_is_null())
             return ret;
 
         ext->ext_state.set(wrongtype_flag);
-		if (exceptions_flags.test(wrongtype_flag))
-		{
-			ApiDataExcept::throw_exception((const char*)API_IncompatibleCmdArgumentType,
-				       		(const char*)"Cannot extract, data in DeviceData object is not a structure with sequences of string(s) and double(s) ",
-				        	(const char*)"DeviceData::operator>>");
-		}
-	}
-	return ret;
+        if (exceptions_flags.test(wrongtype_flag))
+        {
+            ApiDataExcept::throw_exception((const char *) API_IncompatibleCmdArgumentType,
+                                           (const char *) "Cannot extract, data in DeviceData object is not a structure with sequences of string(s) and double(s) ",
+                                           (const char *) "DeviceData::operator>>");
+        }
+    }
+    return ret;
 }
 
 //-----------------------------------------------------------------------------
@@ -2034,13 +2040,13 @@ bool DeviceData::operator >> (const DevVarDoubleStringArray* &datum)
 //
 //-----------------------------------------------------------------------------
 
-void DeviceData::insert (const string &str_datum, vector<unsigned char>& char_datum)
+void DeviceData::insert(const string &str_datum, vector<unsigned char> &char_datum)
 {
-	DevEncoded *the_enc = new DevEncoded();
-	the_enc->encoded_format = CORBA::string_dup(str_datum.c_str());
+    DevEncoded *the_enc = new DevEncoded();
+    the_enc->encoded_format = CORBA::string_dup(str_datum.c_str());
 
-	the_enc->encoded_data.replace(char_datum.size(),char_datum.size(),&(char_datum[0]),false);
-	any.inout() <<= the_enc;
+    the_enc->encoded_data.replace(char_datum.size(), char_datum.size(), &(char_datum[0]), false);
+    any.inout() <<= the_enc;
 }
 
 //-----------------------------------------------------------------------------
@@ -2050,13 +2056,13 @@ void DeviceData::insert (const string &str_datum, vector<unsigned char>& char_da
 //
 //-----------------------------------------------------------------------------
 
-void DeviceData::insert (const char *str_datum, DevVarCharArray *char_datum)
+void DeviceData::insert(const char *str_datum, DevVarCharArray *char_datum)
 {
-	DevEncoded *the_enc = new DevEncoded();
-	the_enc->encoded_format = CORBA::string_dup(str_datum);
+    DevEncoded *the_enc = new DevEncoded();
+    the_enc->encoded_format = CORBA::string_dup(str_datum);
 
-	the_enc->encoded_data.replace(char_datum->length(),char_datum->length(),char_datum->get_buffer(),false);
-	any.inout() <<= the_enc;
+    the_enc->encoded_data.replace(char_datum->length(), char_datum->length(), char_datum->get_buffer(), false);
+    any.inout() <<= the_enc;
 }
 
 //-----------------------------------------------------------------------------
@@ -2066,13 +2072,13 @@ void DeviceData::insert (const char *str_datum, DevVarCharArray *char_datum)
 //
 //-----------------------------------------------------------------------------
 
-void DeviceData::insert (const char *str_datum,unsigned char *data,unsigned int length)
+void DeviceData::insert(const char *str_datum, unsigned char *data, unsigned int length)
 {
-	DevEncoded *the_enc = new DevEncoded();
-	the_enc->encoded_format = CORBA::string_dup(str_datum);
+    DevEncoded *the_enc = new DevEncoded();
+    the_enc->encoded_format = CORBA::string_dup(str_datum);
 
-	the_enc->encoded_data.replace(length,length,data,false);
-	any.inout() <<= the_enc;
+    the_enc->encoded_data.replace(length, length, data, false);
+    any.inout() <<= the_enc;
 }
 
 //-----------------------------------------------------------------------------
@@ -2083,42 +2089,42 @@ void DeviceData::insert (const char *str_datum,unsigned char *data,unsigned int 
 //
 //-----------------------------------------------------------------------------
 
-bool DeviceData::extract(const char *&str,const unsigned char *&data_ptr,unsigned int &data_size)
+bool DeviceData::extract(const char *&str, const unsigned char *&data_ptr, unsigned int &data_size)
 {
     ext->ext_state.reset();
 
     const DevEncoded *tmp_enc = NULL;
-	bool ret = (any.inout() >>= tmp_enc);
-	if (ret == false)
-	{
+    bool ret = (any.inout() >>= tmp_enc);
+    if (ret == false)
+    {
         if (any_is_null())
             return ret;
 
         ext->ext_state.set(wrongtype_flag);
-		if (exceptions_flags.test(wrongtype_flag))
-		{
-			ApiDataExcept::throw_exception((const char*)API_IncompatibleCmdArgumentType,
-				       		(const char*)"Cannot extract, data in DeviceData object is not a DevEncoded",
-				        	(const char*)"DeviceData::extract");
-		}
-	}
-	else
-	{
-	    if (tmp_enc == NULL)
-	    {
+        if (exceptions_flags.test(wrongtype_flag))
+        {
+            ApiDataExcept::throw_exception((const char *) API_IncompatibleCmdArgumentType,
+                                           (const char *) "Cannot extract, data in DeviceData object is not a DevEncoded",
+                                           (const char *) "DeviceData::extract");
+        }
+    }
+    else
+    {
+        if (tmp_enc == NULL)
+        {
             ext->ext_state.set(wrongtype_flag);
-            ApiDataExcept::throw_exception((const char *)API_IncoherentDevData,
-                                       (const char *)"Incoherent data received from server",
-                                       (const char *)"DeviceData::extract");
-	    }
+            ApiDataExcept::throw_exception((const char *) API_IncoherentDevData,
+                                           (const char *) "Incoherent data received from server",
+                                           (const char *) "DeviceData::extract");
+        }
         else
         {
             str = tmp_enc->encoded_format;
             data_size = tmp_enc->encoded_data.length();
             data_ptr = tmp_enc->encoded_data.get_buffer();
         }
-	}
-	return ret;
+    }
+    return ret;
 }
 
 //-----------------------------------------------------------------------------
@@ -2129,44 +2135,44 @@ bool DeviceData::extract(const char *&str,const unsigned char *&data_ptr,unsigne
 //
 //-----------------------------------------------------------------------------
 
-bool DeviceData::extract(string &str,vector<unsigned char> &datum)
+bool DeviceData::extract(string &str, vector<unsigned char> &datum)
 {
     ext->ext_state.reset();
 
     const DevEncoded *tmp_enc = NULL;
-	bool ret = (any.inout() >>= tmp_enc);
-	if (ret == false)
-	{
+    bool ret = (any.inout() >>= tmp_enc);
+    if (ret == false)
+    {
         if (any_is_null())
             return ret;
 
         ext->ext_state.set(wrongtype_flag);
-		if (exceptions_flags.test(wrongtype_flag))
-		{
-			ApiDataExcept::throw_exception((const char*)API_IncompatibleCmdArgumentType,
-				       		(const char*)"Cannot extract, data in DeviceData object is not a DevEncoded",
-				        	(const char*)"DeviceData::extract");
-		}
-	}
-	else
-	{
-	    if (tmp_enc == NULL)
-	    {
+        if (exceptions_flags.test(wrongtype_flag))
+        {
+            ApiDataExcept::throw_exception((const char *) API_IncompatibleCmdArgumentType,
+                                           (const char *) "Cannot extract, data in DeviceData object is not a DevEncoded",
+                                           (const char *) "DeviceData::extract");
+        }
+    }
+    else
+    {
+        if (tmp_enc == NULL)
+        {
             ext->ext_state.set(wrongtype_flag);
-            ApiDataExcept::throw_exception((const char *)API_IncoherentDevData,
-                                       (const char *)"Incoherent data received from server",
-                                       (const char *)"DeviceData::extract");
-	    }
+            ApiDataExcept::throw_exception((const char *) API_IncoherentDevData,
+                                           (const char *) "Incoherent data received from server",
+                                           (const char *) "DeviceData::extract");
+        }
         else
         {
-			str = tmp_enc->encoded_format;
+            str = tmp_enc->encoded_format;
 
-			unsigned long length = tmp_enc->encoded_data.length();
-			datum.resize(length);
-			datum.assign(tmp_enc->encoded_data.get_buffer(),tmp_enc->encoded_data.get_buffer() + length);
+            unsigned long length = tmp_enc->encoded_data.length();
+            datum.resize(length);
+            datum.assign(tmp_enc->encoded_data.get_buffer(), tmp_enc->encoded_data.get_buffer() + length);
         }
-	}
-	return ret;
+    }
+    return ret;
 }
 
 //+-------------------------------------------------------------------------
@@ -2178,227 +2184,226 @@ bool DeviceData::extract(string &str,vector<unsigned char> &datum)
 //
 //--------------------------------------------------------------------------
 
-ostream &operator<<(ostream &o_str,DeviceData &dd)
+ostream &operator<<(ostream &o_str, DeviceData &dd)
 {
-	if (dd.any_is_null() == true)
-		o_str << "No data in DeviceData object";
-	else
-	{
-		CORBA::TypeCode_ptr tc;
-		CORBA::TypeCode_var tc_al;
-		CORBA::TypeCode_var tc_seq;
-		CORBA::TypeCode_var tc_field;
+    if (dd.any_is_null() == true)
+        o_str << "No data in DeviceData object";
+    else
+    {
+        CORBA::TypeCode_ptr tc;
+        CORBA::TypeCode_var tc_al;
+        CORBA::TypeCode_var tc_seq;
+        CORBA::TypeCode_var tc_field;
 
-		tc = dd.any->type();
-		switch(tc->kind())
-		{
-		case CORBA::tk_boolean:
-			bool bo_tmp;
-			dd.any >>= CORBA::Any::to_boolean(bo_tmp);
-			if (bo_tmp == true)
-				o_str << "true" ;
-			else
-				o_str << "false" ;
-			break;
+        tc = dd.any->type();
+        switch (tc->kind())
+        {
+            case CORBA::tk_boolean:
+                bool bo_tmp;
+                dd.any >>= CORBA::Any::to_boolean(bo_tmp);
+                if (bo_tmp == true)
+                    o_str << "true";
+                else
+                    o_str << "false";
+                break;
 
-		case CORBA::tk_short:
-			short tmp;
-			dd.any >>= tmp;
-			o_str << tmp;
-			break;
+            case CORBA::tk_short:
+                short tmp;
+                dd.any >>= tmp;
+                o_str << tmp;
+                break;
 
-		case CORBA::tk_long:
-			Tango::DevLong l_tmp;
-			dd.any >>= l_tmp;
-			o_str << l_tmp;
-			break;
+            case CORBA::tk_long:
+                Tango::DevLong l_tmp;
+                dd.any >>= l_tmp;
+                o_str << l_tmp;
+                break;
 
-		case CORBA::tk_longlong:
+            case CORBA::tk_longlong:
 #ifdef TANGO_LONG32
-			long long ll_tmp;
+                long long ll_tmp;
 #else
-			long ll_tmp;
+                long ll_tmp;
 #endif
-			dd.any >>= ll_tmp;
-			o_str << ll_tmp;
-			break;
+                dd.any >>= ll_tmp;
+                o_str << ll_tmp;
+                break;
 
-		case CORBA::tk_float:
-			float f_tmp;
-			dd.any >>= f_tmp;
-			o_str << f_tmp;
-			break;
+            case CORBA::tk_float:
+                float f_tmp;
+                dd.any >>= f_tmp;
+                o_str << f_tmp;
+                break;
 
-		case CORBA::tk_double:
-			double db_tmp;
-			dd.any >>= db_tmp;
-			o_str << db_tmp;
-			break;
+            case CORBA::tk_double:
+                double db_tmp;
+                dd.any >>= db_tmp;
+                o_str << db_tmp;
+                break;
 
-		case CORBA::tk_ushort:
-			unsigned short us_tmp;
-			dd.any >>= us_tmp;
-			o_str << us_tmp;
-			break;
+            case CORBA::tk_ushort:
+                unsigned short us_tmp;
+                dd.any >>= us_tmp;
+                o_str << us_tmp;
+                break;
 
-		case CORBA::tk_ulong:
-			Tango::DevULong ul_tmp;
-			dd.any >>= ul_tmp;
-			o_str << ul_tmp;
-			break;
+            case CORBA::tk_ulong:
+                Tango::DevULong ul_tmp;
+                dd.any >>= ul_tmp;
+                o_str << ul_tmp;
+                break;
 
-		case CORBA::tk_ulonglong:
-			unsigned long ull_tmp;
-			dd.any >>= ull_tmp;
-			o_str << ull_tmp;
-			break;
+            case CORBA::tk_ulonglong:
+                unsigned long ull_tmp;
+                dd.any >>= ull_tmp;
+                o_str << ull_tmp;
+                break;
 
-		case CORBA::tk_string:
-			const char *str_tmp;
-			dd.any >>= str_tmp;
-			o_str << str_tmp;
-			break;
+            case CORBA::tk_string:
+                const char *str_tmp;
+                dd.any >>= str_tmp;
+                o_str << str_tmp;
+                break;
 
-		case CORBA::tk_alias:
-			tc_al = tc->content_type();
-			tc_seq = tc_al->content_type();
-			switch (tc_seq->kind())
-			{
-			case CORBA::tk_octet:
-				Tango::DevVarCharArray *ch_arr;
-				dd.any.inout() >>= ch_arr;
-				o_str << *ch_arr;
-				break;
+            case CORBA::tk_alias:
+                tc_al = tc->content_type();
+                tc_seq = tc_al->content_type();
+                switch (tc_seq->kind())
+                {
+                    case CORBA::tk_octet:
+                        Tango::DevVarCharArray *ch_arr;
+                        dd.any.inout() >>= ch_arr;
+                        o_str << *ch_arr;
+                        break;
 
-			case CORBA::tk_boolean:
-				Tango::DevVarBooleanArray *bl_arr;
-				dd.any.inout() >>= bl_arr;
-				o_str << *bl_arr;
-				break;
+                    case CORBA::tk_boolean:
+                        Tango::DevVarBooleanArray *bl_arr;
+                        dd.any.inout() >>= bl_arr;
+                        o_str << *bl_arr;
+                        break;
 
-			case CORBA::tk_short:
-				Tango::DevVarShortArray *sh_arr;
-				dd.any.inout() >>= sh_arr;
-				o_str << *sh_arr;
-				break;
+                    case CORBA::tk_short:
+                        Tango::DevVarShortArray *sh_arr;
+                        dd.any.inout() >>= sh_arr;
+                        o_str << *sh_arr;
+                        break;
 
-			case CORBA::tk_long:
-				Tango::DevVarLongArray *lg_arr;
-				dd.any.inout() >>= lg_arr;
-				o_str << *lg_arr;
-				break;
+                    case CORBA::tk_long:
+                        Tango::DevVarLongArray *lg_arr;
+                        dd.any.inout() >>= lg_arr;
+                        o_str << *lg_arr;
+                        break;
 
-			case CORBA::tk_longlong:
-				Tango::DevVarLong64Array *llg_arr;
-				dd.any.inout() >>= llg_arr;
-				o_str << *llg_arr;
-				break;
+                    case CORBA::tk_longlong:
+                        Tango::DevVarLong64Array *llg_arr;
+                        dd.any.inout() >>= llg_arr;
+                        o_str << *llg_arr;
+                        break;
 
-			case CORBA::tk_float:
-				Tango::DevVarFloatArray *fl_arr;
-				dd.any.inout() >>= fl_arr;
-				o_str << *fl_arr;
-				break;
+                    case CORBA::tk_float:
+                        Tango::DevVarFloatArray *fl_arr;
+                        dd.any.inout() >>= fl_arr;
+                        o_str << *fl_arr;
+                        break;
 
-			case CORBA::tk_double:
-				Tango::DevVarDoubleArray *db_arr;
-				dd.any.inout() >>= db_arr;
-				o_str << *db_arr;
-				break;
+                    case CORBA::tk_double:
+                        Tango::DevVarDoubleArray *db_arr;
+                        dd.any.inout() >>= db_arr;
+                        o_str << *db_arr;
+                        break;
 
-			case CORBA::tk_ushort:
-				Tango::DevVarUShortArray *us_arr;
-				dd.any.inout() >>= us_arr;
-				o_str << *us_arr;
-				break;
+                    case CORBA::tk_ushort:
+                        Tango::DevVarUShortArray *us_arr;
+                        dd.any.inout() >>= us_arr;
+                        o_str << *us_arr;
+                        break;
 
-			case CORBA::tk_ulong:
-				Tango::DevVarULongArray *ul_arr;
-				dd.any.inout() >>= ul_arr;
-				o_str << *ul_arr;
-				break;
+                    case CORBA::tk_ulong:
+                        Tango::DevVarULongArray *ul_arr;
+                        dd.any.inout() >>= ul_arr;
+                        o_str << *ul_arr;
+                        break;
 
-			case CORBA::tk_ulonglong:
-				Tango::DevVarULong64Array *ull_arr;
-				dd.any.inout() >>= ull_arr;
-				o_str << *ull_arr;
-				break;
+                    case CORBA::tk_ulonglong:
+                        Tango::DevVarULong64Array *ull_arr;
+                        dd.any.inout() >>= ull_arr;
+                        o_str << *ull_arr;
+                        break;
 
-			case CORBA::tk_string:
-				Tango::DevVarStringArray *str_arr;
-				dd.any.inout() >>= str_arr;
-				o_str << *str_arr;
-				break;
+                    case CORBA::tk_string:
+                        Tango::DevVarStringArray *str_arr;
+                        dd.any.inout() >>= str_arr;
+                        o_str << *str_arr;
+                        break;
 
-			default:
-				break;
-			}
-			break;
+                    default:
+                        break;
+                }
+                break;
 
-		case CORBA::tk_struct:
-            tc_field = tc->member_type(0);
-            tc_al = tc_field->content_type();
-            switch (tc_al->kind())
-			{
-                case CORBA::tk_sequence:
-                    tc_seq = tc_al->content_type();
-                    switch (tc_seq->kind())
-                    {
-                        case CORBA::tk_long:
-                            Tango::DevVarLongStringArray *lgstr_arr;
-                            dd.any.inout() >>= lgstr_arr;
-                            o_str << lgstr_arr->lvalue << endl;
-                            o_str << lgstr_arr->svalue;
-                            break;
-
-                        case CORBA::tk_double:
-                            Tango::DevVarDoubleStringArray *dbstr_arr;
-                            dd.any.inout() >>= dbstr_arr;
-                            o_str << dbstr_arr->dvalue << endl;
-                            o_str << dbstr_arr->svalue;
-                            break;
-
-                        default:
-                            break;
-                    }
-                    break;
-
-                case CORBA::tk_string:
-                    Tango::DevEncoded *enc;
-                    dd.any.inout() >>= enc;
-                    o_str << "Encoding string: " << enc->encoded_format << endl;
-                    {
-                        long nb_data_elt = enc->encoded_data.length();
-                        for (long i = 0;i < nb_data_elt;i++)
+            case CORBA::tk_struct:
+                tc_field = tc->member_type(0);
+                tc_al = tc_field->content_type();
+                switch (tc_al->kind())
+                {
+                    case CORBA::tk_sequence:
+                        tc_seq = tc_al->content_type();
+                        switch (tc_seq->kind())
                         {
-                            o_str << "Data element number [" << i << "] = " << (int)enc->encoded_data[i];
-                            if (i < (nb_data_elt - 1))
-                                o_str << '\n';
+                            case CORBA::tk_long:
+                                Tango::DevVarLongStringArray *lgstr_arr;
+                                dd.any.inout() >>= lgstr_arr;
+                                o_str << lgstr_arr->lvalue << endl;
+                                o_str << lgstr_arr->svalue;
+                                break;
+
+                            case CORBA::tk_double:
+                                Tango::DevVarDoubleStringArray *dbstr_arr;
+                                dd.any.inout() >>= dbstr_arr;
+                                o_str << dbstr_arr->dvalue << endl;
+                                o_str << dbstr_arr->svalue;
+                                break;
+
+                            default:
+                                break;
                         }
-                    }
-                    break;
+                        break;
 
-                default:
-                    break;
-			}
-			break;
+                    case CORBA::tk_string:
+                        Tango::DevEncoded *enc;
+                        dd.any.inout() >>= enc;
+                        o_str << "Encoding string: " << enc->encoded_format << endl;
+                        {
+                            long nb_data_elt = enc->encoded_data.length();
+                            for (long i = 0; i < nb_data_elt; i++)
+                            {
+                                o_str << "Data element number [" << i << "] = " << (int) enc->encoded_data[i];
+                                if (i < (nb_data_elt - 1))
+                                    o_str << '\n';
+                            }
+                        }
+                        break;
 
-		case CORBA::tk_enum:
-			Tango::DevState tmp_state;
-			dd.any.inout() >>= tmp_state;
-			o_str << Tango::DevStateName[tmp_state];
-			break;
+                    default:
+                        break;
+                }
+                break;
 
-		default:
-			break;
+            case CORBA::tk_enum:
+                Tango::DevState tmp_state;
+                dd.any.inout() >>= tmp_state;
+                o_str << Tango::DevStateName[tmp_state];
+                break;
 
-		}
+            default:
+                break;
 
-		CORBA::release(tc);
-	}
+        }
 
-	return o_str;
+        CORBA::release(tc);
+    }
+
+    return o_str;
 }
-
 
 } // End of Tango namepsace

--- a/cppapi/client/devapi_data.cpp
+++ b/cppapi/client/devapi_data.cpp
@@ -55,7 +55,9 @@ DeviceData::DeviceData()
 
     ApiUtil *au = ApiUtil::instance();
     if (CORBA::is_nil(au->get_orb()) == true)
+    {
         au->create_orb();
+    }
 
     any = new CORBA::Any();
     exceptions_flags.set(isempty_flag);
@@ -107,7 +109,9 @@ DeviceData::DeviceData(DeviceData &&source)
     any = source.any._retn();
 
     if (source.ext.get() != NULL)
+    {
         ext = move(source.ext);
+    }
 }
 #endif
 
@@ -135,7 +139,9 @@ DeviceData &DeviceData::operator=(const DeviceData &rval)
             *(ext.get()) = *(rval.ext.get());
         }
         else
+        {
             ext.reset();
+        }
 #else
         delete ext;
 
@@ -164,9 +170,13 @@ DeviceData &DeviceData::operator=(DeviceData &&rval)
     any = rval.any._retn();
 
     if (rval.ext.get() != NULL)
+    {
         ext = move(rval.ext);
+    }
     else
+    {
         ext.reset();
+    }
 
     return *this;
 }
@@ -237,7 +247,9 @@ int DeviceData::get_type()
     int data_type = 0;
 
     if (any_is_null() == true)
+    {
         return -1;
+    }
     else
     {
         CORBA::TypeCode_ptr tc;
@@ -403,7 +415,9 @@ bool DeviceData::operator>>(bool &datum)
     if (ret == false)
     {
         if (any_is_null())
+        {
             return ret;
+        }
 
         ext->ext_state.set(wrongtype_flag);
         if (exceptions_flags.test(wrongtype_flag))
@@ -430,7 +444,9 @@ bool DeviceData::operator>>(short &datum)
     if (ret == false)
     {
         if (any_is_null())
+        {
             return ret;
+        }
 
         ext->ext_state.set(wrongtype_flag);
         if (exceptions_flags.test(wrongtype_flag))
@@ -458,7 +474,9 @@ bool DeviceData::operator>>(unsigned short &datum)
     if (ret == false)
     {
         if (any_is_null())
+        {
             return ret;
+        }
 
         ext->ext_state.set(wrongtype_flag);
         if (exceptions_flags.test(wrongtype_flag))
@@ -485,7 +503,9 @@ bool DeviceData::operator>>(DevLong &datum)
     if (ret == false)
     {
         if (any_is_null())
+        {
             return ret;
+        }
 
         ext->ext_state.set(wrongtype_flag);
         if (exceptions_flags.test(wrongtype_flag))
@@ -512,7 +532,9 @@ bool DeviceData::operator>>(DevULong &datum)
     if (ret == false)
     {
         if (any_is_null())
+        {
             return ret;
+        }
 
         ext->ext_state.set(wrongtype_flag);
         if (exceptions_flags.test(wrongtype_flag))
@@ -539,7 +561,9 @@ bool DeviceData::operator>>(DevLong64 &datum)
     if (ret == false)
     {
         if (any_is_null())
+        {
             return ret;
+        }
 
         ext->ext_state.set(wrongtype_flag);
         if (exceptions_flags.test(wrongtype_flag))
@@ -566,7 +590,9 @@ bool DeviceData::operator>>(DevULong64 &datum)
     if (ret == false)
     {
         if (any_is_null())
+        {
             return ret;
+        }
 
         ext->ext_state.set(wrongtype_flag);
         if (exceptions_flags.test(wrongtype_flag))
@@ -593,7 +619,9 @@ bool DeviceData::operator>>(float &datum)
     if (ret == false)
     {
         if (any_is_null())
+        {
             return ret;
+        }
 
         ext->ext_state.set(wrongtype_flag);
         if (exceptions_flags.test(wrongtype_flag))
@@ -621,7 +649,9 @@ bool DeviceData::operator>>(double &datum)
     if (ret == false)
     {
         if (any_is_null())
+        {
             return ret;
+        }
 
         ext->ext_state.set(wrongtype_flag);
         if (exceptions_flags.test(wrongtype_flag))
@@ -649,7 +679,9 @@ bool DeviceData::operator>>(string &datum)
     if (ret == false)
     {
         if (any_is_null())
+        {
             return ret;
+        }
 
         ext->ext_state.set(wrongtype_flag);
         if (exceptions_flags.test(wrongtype_flag))
@@ -680,7 +712,9 @@ bool DeviceData::operator>>(const char *&datum)
     if (ret == false)
     {
         if (any_is_null())
+        {
             return ret;
+        }
 
         ext->ext_state.set(wrongtype_flag);
         if (exceptions_flags.test(wrongtype_flag))
@@ -707,7 +741,9 @@ bool DeviceData::operator>>(DevState &datum)
     if (ret == false)
     {
         if (any_is_null())
+        {
             return ret;
+        }
 
         ext->ext_state.set(wrongtype_flag);
         if (exceptions_flags.test(wrongtype_flag))
@@ -750,7 +786,9 @@ bool DeviceData::operator>>(vector<bool> &datum)
     else
     {
         if (any_is_null())
+        {
             return false;
+        }
 
         if (bool_array == NULL)
         {
@@ -787,7 +825,9 @@ bool DeviceData::operator>>(const DevVarBooleanArray *&datum)
     if (ret == false)
     {
         if (any_is_null())
+        {
             return ret;
+        }
 
         ext->ext_state.set(wrongtype_flag);
         if (exceptions_flags.test(wrongtype_flag))
@@ -815,7 +855,9 @@ bool DeviceData::operator>>(vector<unsigned char> &datum)
     if (ret == false)
     {
         if (any_is_null())
+        {
             return ret;
+        }
 
         ext->ext_state.set(wrongtype_flag);
         if (exceptions_flags.test(wrongtype_flag))
@@ -862,7 +904,9 @@ bool DeviceData::operator>>(const DevVarCharArray *&datum)
     if (ret == false)
     {
         if (any_is_null())
+        {
             return ret;
+        }
 
         ext->ext_state.set(wrongtype_flag);
         if (exceptions_flags.test(wrongtype_flag))
@@ -890,7 +934,9 @@ bool DeviceData::operator>>(vector<short> &datum)
     if (ret == false)
     {
         if (any_is_null())
+        {
             return ret;
+        }
 
         ext->ext_state.set(wrongtype_flag);
         if (exceptions_flags.test(wrongtype_flag))
@@ -938,7 +984,9 @@ bool DeviceData::operator>>(const DevVarShortArray *&datum)
     if (ret == false)
     {
         if (any_is_null())
+        {
             return ret;
+        }
 
         ext->ext_state.set(wrongtype_flag);
         if (exceptions_flags.test(wrongtype_flag))
@@ -966,7 +1014,9 @@ bool DeviceData::operator>>(vector<unsigned short> &datum)
     if (ret == false)
     {
         if (any_is_null())
+        {
             return ret;
+        }
 
         ext->ext_state.set(wrongtype_flag);
         if (exceptions_flags.test(wrongtype_flag))
@@ -1013,7 +1063,9 @@ bool DeviceData::operator>>(const DevVarUShortArray *&datum)
     if (ret == false)
     {
         if (any_is_null())
+        {
             return ret;
+        }
 
         ext->ext_state.set(wrongtype_flag);
         if (exceptions_flags.test(wrongtype_flag))
@@ -1041,7 +1093,9 @@ bool DeviceData::operator>>(vector<DevLong> &datum)
     if (ret == false)
     {
         if (any_is_null())
+        {
             return ret;
+        }
 
         ext->ext_state.set(wrongtype_flag);
         if (exceptions_flags.test(wrongtype_flag))
@@ -1088,7 +1142,9 @@ bool DeviceData::operator>>(const DevVarLongArray *&datum)
     if (ret == false)
     {
         if (any_is_null())
+        {
             return ret;
+        }
 
         ext->ext_state.set(wrongtype_flag);
         if (exceptions_flags.test(wrongtype_flag))
@@ -1117,7 +1173,9 @@ bool DeviceData::operator>>(vector<DevULong> &datum)
     if (ret == false)
     {
         if (any_is_null())
+        {
             return ret;
+        }
 
         ext->ext_state.set(wrongtype_flag);
         if (exceptions_flags.test(wrongtype_flag))
@@ -1164,7 +1222,9 @@ bool DeviceData::operator>>(const DevVarULongArray *&datum)
     if (ret == false)
     {
         if (any_is_null())
+        {
             return ret;
+        }
 
         ext->ext_state.set(wrongtype_flag);
         if (exceptions_flags.test(wrongtype_flag))
@@ -1193,7 +1253,9 @@ bool DeviceData::operator>>(const DevVarLong64Array *&datum)
     if (ret == false)
     {
         if (any_is_null())
+        {
             return ret;
+        }
 
         ext->ext_state.set(wrongtype_flag);
         if (exceptions_flags.test(wrongtype_flag))
@@ -1221,7 +1283,9 @@ bool DeviceData::operator>>(const DevVarULong64Array *&datum)
     if (ret == false)
     {
         if (any_is_null())
+        {
             return ret;
+        }
 
         ext->ext_state.set(wrongtype_flag);
         if (exceptions_flags.test(wrongtype_flag))
@@ -1249,7 +1313,9 @@ bool DeviceData::operator>>(vector<DevLong64> &datum)
     if (ret == false)
     {
         if (any_is_null())
+        {
             return ret;
+        }
 
         ext->ext_state.set(wrongtype_flag);
         if (exceptions_flags.test(wrongtype_flag))
@@ -1295,7 +1361,9 @@ bool DeviceData::operator>>(vector<DevULong64> &datum)
     if (ret == false)
     {
         if (any_is_null())
+        {
             return ret;
+        }
 
         ext->ext_state.set(wrongtype_flag);
         if (exceptions_flags.test(wrongtype_flag))
@@ -1341,7 +1409,9 @@ bool DeviceData::operator>>(vector<float> &datum)
     if (ret == false)
     {
         if (any_is_null())
+        {
             return ret;
+        }
 
         ext->ext_state.set(wrongtype_flag);
         if (exceptions_flags.test(wrongtype_flag))
@@ -1388,7 +1458,9 @@ bool DeviceData::operator>>(const DevVarFloatArray *&datum)
     if (ret == false)
     {
         if (any_is_null())
+        {
             return ret;
+        }
 
         ext->ext_state.set(wrongtype_flag);
         if (exceptions_flags.test(wrongtype_flag))
@@ -1417,7 +1489,9 @@ bool DeviceData::operator>>(vector<double> &datum)
     if (ret == false)
     {
         if (any_is_null())
+        {
             return ret;
+        }
 
         ext->ext_state.set(wrongtype_flag);
         if (exceptions_flags.test(wrongtype_flag))
@@ -1464,7 +1538,9 @@ bool DeviceData::operator>>(const DevVarDoubleArray *&datum)
     if (ret == false)
     {
         if (any_is_null())
+        {
             return ret;
+        }
 
         ext->ext_state.set(wrongtype_flag);
         if (exceptions_flags.test(wrongtype_flag))
@@ -1493,7 +1569,9 @@ bool DeviceData::operator>>(vector<string> &datum)
     if (ret == false)
     {
         if (any_is_null())
+        {
             return ret;
+        }
 
         ext->ext_state.set(wrongtype_flag);
         if (exceptions_flags.test(wrongtype_flag))
@@ -1539,7 +1617,9 @@ bool DeviceData::operator>>(const DevVarStringArray *&datum)
     if (ret == false)
     {
         if (any_is_null())
+        {
             return ret;
+        }
 
         ext->ext_state.set(wrongtype_flag);
         if (exceptions_flags.test(wrongtype_flag))
@@ -1567,7 +1647,9 @@ bool DeviceData::operator>>(const DevEncoded *&datum)
     if (ret == false)
     {
         if (any_is_null())
+        {
             return ret;
+        }
 
         ext->ext_state.set(wrongtype_flag);
         if (exceptions_flags.test(wrongtype_flag))
@@ -1596,7 +1678,9 @@ bool DeviceData::operator>>(DevEncoded &datum)
     if (ret == false)
     {
         if (any_is_null())
+        {
             return ret;
+        }
 
         ext->ext_state.set(wrongtype_flag);
         if (exceptions_flags.test(wrongtype_flag))
@@ -1860,7 +1944,9 @@ bool DeviceData::extract(vector<DevLong> &long_datum, vector<string> &string_dat
     if (ret == false)
     {
         if (any_is_null())
+        {
             return ret;
+        }
 
         ext->ext_state.set(wrongtype_flag);
         if (exceptions_flags.test(wrongtype_flag))
@@ -1912,7 +1998,9 @@ bool DeviceData::operator>>(const DevVarLongStringArray *&datum)
     if (ret == false)
     {
         if (any_is_null())
+        {
             return ret;
+        }
 
         ext->ext_state.set(wrongtype_flag);
         if (exceptions_flags.test(wrongtype_flag))
@@ -1968,7 +2056,9 @@ bool DeviceData::extract(vector<double> &double_datum, vector<string> &string_da
     if (ret == false)
     {
         if (any_is_null())
+        {
             return ret;
+        }
 
         ext->ext_state.set(wrongtype_flag);
         if (exceptions_flags.test(wrongtype_flag))
@@ -2020,7 +2110,9 @@ bool DeviceData::operator>>(const DevVarDoubleStringArray *&datum)
     if (ret == false)
     {
         if (any_is_null())
+        {
             return ret;
+        }
 
         ext->ext_state.set(wrongtype_flag);
         if (exceptions_flags.test(wrongtype_flag))
@@ -2098,7 +2190,9 @@ bool DeviceData::extract(const char *&str, const unsigned char *&data_ptr, unsig
     if (ret == false)
     {
         if (any_is_null())
+        {
             return ret;
+        }
 
         ext->ext_state.set(wrongtype_flag);
         if (exceptions_flags.test(wrongtype_flag))
@@ -2144,7 +2238,9 @@ bool DeviceData::extract(string &str, vector<unsigned char> &datum)
     if (ret == false)
     {
         if (any_is_null())
+        {
             return ret;
+        }
 
         ext->ext_state.set(wrongtype_flag);
         if (exceptions_flags.test(wrongtype_flag))
@@ -2187,7 +2283,9 @@ bool DeviceData::extract(string &str, vector<unsigned char> &datum)
 ostream &operator<<(ostream &o_str, DeviceData &dd)
 {
     if (dd.any_is_null() == true)
+    {
         o_str << "No data in DeviceData object";
+    }
     else
     {
         CORBA::TypeCode_ptr tc;
@@ -2202,9 +2300,13 @@ ostream &operator<<(ostream &o_str, DeviceData &dd)
                 bool bo_tmp;
                 dd.any >>= CORBA::Any::to_boolean(bo_tmp);
                 if (bo_tmp == true)
+                {
                     o_str << "true";
+                }
                 else
+                {
                     o_str << "false";
+                }
                 break;
 
             case CORBA::tk_short:
@@ -2379,7 +2481,9 @@ ostream &operator<<(ostream &o_str, DeviceData &dd)
                             {
                                 o_str << "Data element number [" << i << "] = " << (int) enc->encoded_data[i];
                                 if (i < (nb_data_elt - 1))
+                                {
                                     o_str << '\n';
+                                }
                             }
                         }
                         break;

--- a/cppapi/client/devapi_datahist.cpp
+++ b/cppapi/client/devapi_datahist.cpp
@@ -93,7 +93,9 @@ DeviceDataHistory::DeviceDataHistory(const DeviceDataHistory &source)
     }
 #else
     if (source.ext_hist == NULL)
+    {
         ext_hist = NULL;
+    }
     else
     {
         ext_hist = new DeviceDataHistoryExt();

--- a/cppapi/client/devapi_datahist.cpp
+++ b/cppapi/client/devapi_datahist.cpp
@@ -48,37 +48,40 @@ namespace Tango
 //
 //-----------------------------------------------------------------------------
 
-DeviceDataHistory::DeviceDataHistory():DeviceData(),ext_hist(Tango_nullptr)
+DeviceDataHistory::DeviceDataHistory()
+    : DeviceData(), ext_hist(Tango_nullptr)
 {
-	fail = false;
-	err = new DevErrorList();
-	seq_ptr = NULL;
-	ref_ctr_ptr = NULL;
+    fail = false;
+    err = new DevErrorList();
+    seq_ptr = NULL;
+    ref_ctr_ptr = NULL;
 }
 
-DeviceDataHistory::DeviceDataHistory(int n, int *ref,DevCmdHistoryList *ptr):ext_hist(Tango_nullptr)
+DeviceDataHistory::DeviceDataHistory(int n, int *ref, DevCmdHistoryList *ptr)
+    : ext_hist(Tango_nullptr)
 {
-	ref_ctr_ptr = ref;
-	seq_ptr = ptr;
+    ref_ctr_ptr = ref;
+    seq_ptr = ptr;
 
-	(*ref_ctr_ptr)++;
+    (*ref_ctr_ptr)++;
 
-	any = &((*ptr)[n].value);
-	fail = (*ptr)[n].cmd_failed;
-	time = (*ptr)[n].time;
-	err = &((*ptr)[n].errors);
+    any = &((*ptr)[n].value);
+    fail = (*ptr)[n].cmd_failed;
+    time = (*ptr)[n].time;
+    err = &((*ptr)[n].errors);
 }
 
-DeviceDataHistory::DeviceDataHistory(const DeviceDataHistory & source):DeviceData(source),ext_hist(Tango_nullptr)
+DeviceDataHistory::DeviceDataHistory(const DeviceDataHistory &source)
+    : DeviceData(source), ext_hist(Tango_nullptr)
 {
-	fail = source.fail;
-	time = source.time;
-	err = const_cast<DeviceDataHistory &>(source).err._retn();
+    fail = source.fail;
+    time = source.time;
+    err = const_cast<DeviceDataHistory &>(source).err._retn();
 
-	seq_ptr = source.seq_ptr;
-	ref_ctr_ptr = source.ref_ctr_ptr;
-	if (ref_ctr_ptr != NULL)
-		(*ref_ctr_ptr)++;
+    seq_ptr = source.seq_ptr;
+    ref_ctr_ptr = source.ref_ctr_ptr;
+    if (ref_ctr_ptr != NULL)
+        (*ref_ctr_ptr)++;
 
 #ifdef HAS_UNIQUE_PTR
     if (source.ext_hist.get() != NULL)
@@ -87,25 +90,26 @@ DeviceDataHistory::DeviceDataHistory(const DeviceDataHistory & source):DeviceDat
         *(ext_hist.get()) = *(source.ext_hist.get());
     }
 #else
-	if (source.ext_hist == NULL)
-		ext_hist = NULL;
-	else
-	{
-		ext_hist = new DeviceDataHistoryExt();
-		*ext_hist = *(source.ext_hist);
-	}
+    if (source.ext_hist == NULL)
+        ext_hist = NULL;
+    else
+    {
+        ext_hist = new DeviceDataHistoryExt();
+        *ext_hist = *(source.ext_hist);
+    }
 #endif
 }
 
 #ifdef HAS_RVALUE
-DeviceDataHistory::DeviceDataHistory(DeviceDataHistory && source):DeviceData(move(source)),ext_hist(Tango_nullptr)
+DeviceDataHistory::DeviceDataHistory(DeviceDataHistory &&source)
+    : DeviceData(move(source)), ext_hist(Tango_nullptr)
 {
-	fail = source.fail;
-	time = source.time;
-	err = source.err._retn();
+    fail = source.fail;
+    time = source.time;
+    err = source.err._retn();
 
-	seq_ptr = source.seq_ptr;
-	ref_ctr_ptr = source.ref_ctr_ptr;
+    seq_ptr = source.seq_ptr;
+    ref_ctr_ptr = source.ref_ctr_ptr;
 
     if (source.ext_hist.get() != NULL)
         ext_hist = move(source.ext_hist);
@@ -122,18 +126,18 @@ DeviceDataHistory::DeviceDataHistory(DeviceDataHistory && source):DeviceData(mov
 
 DeviceDataHistory::~DeviceDataHistory()
 {
-	if (seq_ptr != NULL)
-	{
-		any._retn();
-		err._retn();
+    if (seq_ptr != NULL)
+    {
+        any._retn();
+        err._retn();
 
-		(*ref_ctr_ptr)--;
-		if (*ref_ctr_ptr == 0)
-		{
-			delete seq_ptr;
-			delete ref_ctr_ptr;
-		}
-	}
+        (*ref_ctr_ptr)--;
+        if (*ref_ctr_ptr == 0)
+        {
+            delete seq_ptr;
+            delete ref_ctr_ptr;
+        }
+    }
 
 #ifndef HAS_UNIQUE_PTR
     delete ext_hist;
@@ -147,7 +151,7 @@ DeviceDataHistory::~DeviceDataHistory()
 //
 //-----------------------------------------------------------------------------
 
-DeviceDataHistory & DeviceDataHistory::operator=(const DeviceDataHistory &rval)
+DeviceDataHistory &DeviceDataHistory::operator=(const DeviceDataHistory &rval)
 {
 
     if (this != &rval)
@@ -205,7 +209,7 @@ DeviceDataHistory & DeviceDataHistory::operator=(const DeviceDataHistory &rval)
 #endif
     }
 
-	return *this;
+    return *this;
 }
 
 //-----------------------------------------------------------------------------
@@ -215,7 +219,7 @@ DeviceDataHistory & DeviceDataHistory::operator=(const DeviceDataHistory &rval)
 //-----------------------------------------------------------------------------
 
 #ifdef HAS_RVALUE
-DeviceDataHistory & DeviceDataHistory::operator=(DeviceDataHistory &&rval)
+DeviceDataHistory &DeviceDataHistory::operator=(DeviceDataHistory &&rval)
 {
 
 //
@@ -228,9 +232,9 @@ DeviceDataHistory & DeviceDataHistory::operator=(DeviceDataHistory &&rval)
 // Then, assignement of DeviceDataHistory members
 //
 
-	fail = rval.fail;
-	time = rval.time;
-	err = rval.err._retn();
+    fail = rval.fail;
+    time = rval.time;
+    err = rval.err._retn();
 
 //
 // Decrement old ctr
@@ -249,8 +253,8 @@ DeviceDataHistory & DeviceDataHistory::operator=(DeviceDataHistory &&rval)
 // Copy ctr (but don't increment it) and ptr
 //
 
-	seq_ptr = rval.seq_ptr;
-	ref_ctr_ptr = rval.ref_ctr_ptr;
+    seq_ptr = rval.seq_ptr;
+    ref_ctr_ptr = rval.ref_ctr_ptr;
 
 //
 // Extension class
@@ -261,7 +265,7 @@ DeviceDataHistory & DeviceDataHistory::operator=(DeviceDataHistory &&rval)
     else
         ext_hist.reset();
 
-	return *this;
+    return *this;
 }
 #endif
 
@@ -274,67 +278,67 @@ DeviceDataHistory & DeviceDataHistory::operator=(DeviceDataHistory &&rval)
 //
 //--------------------------------------------------------------------------
 
-ostream &operator<<(ostream &o_str,DeviceDataHistory &dh)
+ostream &operator<<(ostream &o_str, DeviceDataHistory &dh)
 {
 
 //
 // First, print date
 //
 
-	time_t tmp_val = dh.time.tv_sec;
+    time_t tmp_val = dh.time.tv_sec;
     char tmp_date[128];
 #ifdef _TG_WINDOWS_
     ctime_s(tmp_date,128,&tmp_val);
 #else
-    ctime_r(&tmp_val,tmp_date);
+    ctime_r(&tmp_val, tmp_date);
 #endif
-	tmp_date[strlen(tmp_date) - 1] = '\0';
-	o_str << tmp_date;
-	o_str << " (" << dh.time.tv_sec << "," << setw(6) << setfill('0') << dh.time.tv_usec << " sec) : ";
+    tmp_date[strlen(tmp_date) - 1] = '\0';
+    o_str << tmp_date;
+    o_str << " (" << dh.time.tv_sec << "," << setw(6) << setfill('0') << dh.time.tv_usec << " sec) : ";
 
 //
 // Print data or error stack
 //
 
-	if (dh.fail == true)
-	{
-		unsigned int nb_err = dh.err.in().length();
-		for (unsigned long i = 0;i < nb_err;i++)
-		{
-			o_str << "Tango error stack" << endl;
-			o_str << "Severity = ";
-			switch ((dh.err.in())[i].severity)
-			{
-			case Tango::WARN :
-				o_str << "WARNING ";
-				break;
+    if (dh.fail == true)
+    {
+        unsigned int nb_err = dh.err.in().length();
+        for (unsigned long i = 0; i < nb_err; i++)
+        {
+            o_str << "Tango error stack" << endl;
+            o_str << "Severity = ";
+            switch ((dh.err.in())[i].severity)
+            {
+                case Tango::WARN :
+                    o_str << "WARNING ";
+                    break;
 
-			case Tango::ERR :
-				o_str << "ERROR ";
-				break;
+                case Tango::ERR :
+                    o_str << "ERROR ";
+                    break;
 
-			case Tango::PANIC :
-				o_str << "PANIC ";
-				break;
+                case Tango::PANIC :
+                    o_str << "PANIC ";
+                    break;
 
-			default :
-				o_str << "Unknown severity code";
-				break;
-			}
-			o_str << endl;
-			o_str << "Error reason = " << (dh.err.in())[i].reason.in() << endl;
-			o_str << "Desc : " << (dh.err.in())[i].desc.in() << endl;
-			o_str << "Origin : " << (dh.err.in())[i].origin.in();
-			if (i != nb_err - 1)
-				o_str << endl;
-		}
-	}
-	else
-	{
-		o_str << static_cast<DeviceData &>(dh);
-	}
+                default :
+                    o_str << "Unknown severity code";
+                    break;
+            }
+            o_str << endl;
+            o_str << "Error reason = " << (dh.err.in())[i].reason.in() << endl;
+            o_str << "Desc : " << (dh.err.in())[i].desc.in() << endl;
+            o_str << "Origin : " << (dh.err.in())[i].origin.in();
+            if (i != nb_err - 1)
+                o_str << endl;
+        }
+    }
+    else
+    {
+        o_str << static_cast<DeviceData &>(dh);
+    }
 
-	return o_str;
+    return o_str;
 }
 
 //-----------------------------------------------------------------------------
@@ -343,316 +347,317 @@ ostream &operator<<(ostream &o_str,DeviceDataHistory &dh)
 //
 //-----------------------------------------------------------------------------
 
-DeviceAttributeHistory::DeviceAttributeHistory():DeviceAttribute(),ext_hist(Tango_nullptr)
+DeviceAttributeHistory::DeviceAttributeHistory()
+    : DeviceAttribute(), ext_hist(Tango_nullptr)
 {
-	fail = false;
-	err_list = new DevErrorList();
+    fail = false;
+    err_list = new DevErrorList();
 }
 
-DeviceAttributeHistory::DeviceAttributeHistory(int n,DevAttrHistoryList_var &seq):ext_hist(Tango_nullptr)
+DeviceAttributeHistory::DeviceAttributeHistory(int n, DevAttrHistoryList_var &seq)
+    : ext_hist(Tango_nullptr)
 {
-	fail = seq[n].attr_failed;
+    fail = seq[n].attr_failed;
 
-	err_list = new DevErrorList(seq[n].errors);
-	time = seq[n].value.time;
-	quality = seq[n].value.quality;
-	dim_x = seq[n].value.dim_x;
-	dim_y = seq[n].value.dim_y;
-	name = seq[n].value.name;
+    err_list = new DevErrorList(seq[n].errors);
+    time = seq[n].value.time;
+    quality = seq[n].value.quality;
+    dim_x = seq[n].value.dim_x;
+    dim_y = seq[n].value.dim_y;
+    name = seq[n].value.name;
 
-	const DevVarLongArray *tmp_seq_lo;
-	CORBA::Long *tmp_lo;
-	const DevVarLong64Array *tmp_seq_lolo;
-	CORBA::LongLong *tmp_lolo;
-	const DevVarShortArray *tmp_seq_sh;
-	CORBA::Short *tmp_sh;
-	const DevVarDoubleArray *tmp_seq_db;
-	CORBA::Double *tmp_db;
-	const DevVarStringArray *tmp_seq_str;
-	char **tmp_str;
-	const DevVarFloatArray *tmp_seq_fl;
-	CORBA::Float *tmp_fl;
-	const DevVarBooleanArray *tmp_seq_boo;
-	CORBA::Boolean *tmp_boo;
-	const DevVarUShortArray *tmp_seq_ush;
-	CORBA::UShort *tmp_ush;
-	const DevVarCharArray *tmp_seq_uch;
-	CORBA::Octet *tmp_uch;
-	const DevVarULongArray *tmp_seq_ulo;
-	CORBA::ULong *tmp_ulo;
-	const DevVarULong64Array *tmp_seq_ulolo;
-	CORBA::ULongLong *tmp_ulolo;
-	const DevVarStateArray *tmp_seq_state;
-	Tango::DevState *tmp_state;
+    const DevVarLongArray *tmp_seq_lo;
+    CORBA::Long *tmp_lo;
+    const DevVarLong64Array *tmp_seq_lolo;
+    CORBA::LongLong *tmp_lolo;
+    const DevVarShortArray *tmp_seq_sh;
+    CORBA::Short *tmp_sh;
+    const DevVarDoubleArray *tmp_seq_db;
+    CORBA::Double *tmp_db;
+    const DevVarStringArray *tmp_seq_str;
+    char **tmp_str;
+    const DevVarFloatArray *tmp_seq_fl;
+    CORBA::Float *tmp_fl;
+    const DevVarBooleanArray *tmp_seq_boo;
+    CORBA::Boolean *tmp_boo;
+    const DevVarUShortArray *tmp_seq_ush;
+    CORBA::UShort *tmp_ush;
+    const DevVarCharArray *tmp_seq_uch;
+    CORBA::Octet *tmp_uch;
+    const DevVarULongArray *tmp_seq_ulo;
+    CORBA::ULong *tmp_ulo;
+    const DevVarULong64Array *tmp_seq_ulolo;
+    CORBA::ULongLong *tmp_ulolo;
+    const DevVarStateArray *tmp_seq_state;
+    Tango::DevState *tmp_state;
 
-	CORBA::ULong max,len;
+    CORBA::ULong max, len;
 
-	if ((fail == false) && (quality != Tango::ATTR_INVALID))
-	{
-		CORBA::TypeCode_var ty = seq[n].value.value.type();
-		CORBA::TypeCode_var ty_alias = ty->content_type();
-		CORBA::TypeCode_var ty_seq = ty_alias->content_type();
-		switch (ty_seq->kind())
-		{
-		case tk_long:
-			seq[n].value.value >>= tmp_seq_lo;
-			max = tmp_seq_lo->maximum();
-			len = tmp_seq_lo->length();
-			tmp_lo = (const_cast<DevVarLongArray *>(tmp_seq_lo))->get_buffer((CORBA::Boolean)true);
-			LongSeq = new DevVarLongArray(max,len,tmp_lo,true);
-			break;
+    if ((fail == false) && (quality != Tango::ATTR_INVALID))
+    {
+        CORBA::TypeCode_var ty = seq[n].value.value.type();
+        CORBA::TypeCode_var ty_alias = ty->content_type();
+        CORBA::TypeCode_var ty_seq = ty_alias->content_type();
+        switch (ty_seq->kind())
+        {
+            case tk_long:
+                seq[n].value.value >>= tmp_seq_lo;
+                max = tmp_seq_lo->maximum();
+                len = tmp_seq_lo->length();
+                tmp_lo = (const_cast<DevVarLongArray *>(tmp_seq_lo))->get_buffer((CORBA::Boolean) true);
+                LongSeq = new DevVarLongArray(max, len, tmp_lo, true);
+                break;
 
-		case tk_longlong:
-			seq[n].value.value >>= tmp_seq_lolo;
-			max = tmp_seq_lolo->maximum();
-			len = tmp_seq_lolo->length();
-			tmp_lolo = (const_cast<DevVarLong64Array *>(tmp_seq_lolo))->get_buffer((CORBA::Boolean)true);
-			Long64Seq = new DevVarLong64Array(max,len,tmp_lolo,true);
-			break;
+            case tk_longlong:
+                seq[n].value.value >>= tmp_seq_lolo;
+                max = tmp_seq_lolo->maximum();
+                len = tmp_seq_lolo->length();
+                tmp_lolo = (const_cast<DevVarLong64Array *>(tmp_seq_lolo))->get_buffer((CORBA::Boolean) true);
+                Long64Seq = new DevVarLong64Array(max, len, tmp_lolo, true);
+                break;
 
-		case tk_short:
-			seq[n].value.value >>= tmp_seq_sh;
-			max = tmp_seq_sh->maximum();
-			len = tmp_seq_sh->length();
-			tmp_sh = (const_cast<DevVarShortArray *>(tmp_seq_sh))->get_buffer((CORBA::Boolean)true);
-			ShortSeq = new DevVarShortArray(max,len,tmp_sh,true);
-			break;
+            case tk_short:
+                seq[n].value.value >>= tmp_seq_sh;
+                max = tmp_seq_sh->maximum();
+                len = tmp_seq_sh->length();
+                tmp_sh = (const_cast<DevVarShortArray *>(tmp_seq_sh))->get_buffer((CORBA::Boolean) true);
+                ShortSeq = new DevVarShortArray(max, len, tmp_sh, true);
+                break;
 
-		case tk_double:
-			seq[n].value.value >>= tmp_seq_db;
-			max = tmp_seq_db->maximum();
-			len = tmp_seq_db->length();
-			tmp_db = (const_cast<DevVarDoubleArray *>(tmp_seq_db))->get_buffer((CORBA::Boolean)true);
-			DoubleSeq = new DevVarDoubleArray(max,len,tmp_db,true);
-			break;
+            case tk_double:
+                seq[n].value.value >>= tmp_seq_db;
+                max = tmp_seq_db->maximum();
+                len = tmp_seq_db->length();
+                tmp_db = (const_cast<DevVarDoubleArray *>(tmp_seq_db))->get_buffer((CORBA::Boolean) true);
+                DoubleSeq = new DevVarDoubleArray(max, len, tmp_db, true);
+                break;
 
-		case tk_string:
-			seq[n].value.value >>= tmp_seq_str;
-			max = tmp_seq_str->maximum();
-			len = tmp_seq_str->length();
-			tmp_str = (const_cast<DevVarStringArray *>(tmp_seq_str))->get_buffer((CORBA::Boolean)true);
-			StringSeq = new DevVarStringArray(max,len,tmp_str,true);
-			break;
+            case tk_string:
+                seq[n].value.value >>= tmp_seq_str;
+                max = tmp_seq_str->maximum();
+                len = tmp_seq_str->length();
+                tmp_str = (const_cast<DevVarStringArray *>(tmp_seq_str))->get_buffer((CORBA::Boolean) true);
+                StringSeq = new DevVarStringArray(max, len, tmp_str, true);
+                break;
 
-		case tk_float:
-			seq[n].value.value >>= tmp_seq_fl;
-			max = tmp_seq_fl->maximum();
-			len = tmp_seq_fl->length();
-			tmp_fl = (const_cast<DevVarFloatArray *>(tmp_seq_fl))->get_buffer((CORBA::Boolean)true);
-			FloatSeq = new DevVarFloatArray(max,len,tmp_fl,true);
-			break;
+            case tk_float:
+                seq[n].value.value >>= tmp_seq_fl;
+                max = tmp_seq_fl->maximum();
+                len = tmp_seq_fl->length();
+                tmp_fl = (const_cast<DevVarFloatArray *>(tmp_seq_fl))->get_buffer((CORBA::Boolean) true);
+                FloatSeq = new DevVarFloatArray(max, len, tmp_fl, true);
+                break;
 
-		case tk_boolean:
-			seq[n].value.value >>= tmp_seq_boo;
-			max = tmp_seq_boo->maximum();
-			len = tmp_seq_boo->length();
-			tmp_boo = (const_cast<DevVarBooleanArray *>(tmp_seq_boo))->get_buffer((CORBA::Boolean)true);
-			BooleanSeq = new DevVarBooleanArray(max,len,tmp_boo,true);
-			break;
+            case tk_boolean:
+                seq[n].value.value >>= tmp_seq_boo;
+                max = tmp_seq_boo->maximum();
+                len = tmp_seq_boo->length();
+                tmp_boo = (const_cast<DevVarBooleanArray *>(tmp_seq_boo))->get_buffer((CORBA::Boolean) true);
+                BooleanSeq = new DevVarBooleanArray(max, len, tmp_boo, true);
+                break;
 
-		case tk_ushort:
-			seq[n].value.value >>= tmp_seq_ush;
-			max = tmp_seq_ush->maximum();
-			len = tmp_seq_ush->length();
-			tmp_ush = (const_cast<DevVarUShortArray *>(tmp_seq_ush))->get_buffer((CORBA::Boolean)true);
-			UShortSeq = new DevVarUShortArray(max,len,tmp_ush,true);
-			break;
+            case tk_ushort:
+                seq[n].value.value >>= tmp_seq_ush;
+                max = tmp_seq_ush->maximum();
+                len = tmp_seq_ush->length();
+                tmp_ush = (const_cast<DevVarUShortArray *>(tmp_seq_ush))->get_buffer((CORBA::Boolean) true);
+                UShortSeq = new DevVarUShortArray(max, len, tmp_ush, true);
+                break;
 
-		case tk_octet:
-			seq[n].value.value >>= tmp_seq_uch;
-			max = tmp_seq_uch->maximum();
-			len = tmp_seq_uch->length();
-			tmp_uch = (const_cast<DevVarCharArray *>(tmp_seq_uch))->get_buffer((CORBA::Boolean)true);
-			UCharSeq = new DevVarCharArray(max,len,tmp_uch,true);
-			break;
+            case tk_octet:
+                seq[n].value.value >>= tmp_seq_uch;
+                max = tmp_seq_uch->maximum();
+                len = tmp_seq_uch->length();
+                tmp_uch = (const_cast<DevVarCharArray *>(tmp_seq_uch))->get_buffer((CORBA::Boolean) true);
+                UCharSeq = new DevVarCharArray(max, len, tmp_uch, true);
+                break;
 
-		case tk_ulong:
-			seq[n].value.value >>= tmp_seq_ulo;
-			max = tmp_seq_ulo->maximum();
-			len = tmp_seq_ulo->length();
-			tmp_ulo = (const_cast<DevVarULongArray *>(tmp_seq_ulo))->get_buffer((CORBA::Boolean)true);
-			ULongSeq = new DevVarULongArray(max,len,tmp_ulo,true);
-			break;
+            case tk_ulong:
+                seq[n].value.value >>= tmp_seq_ulo;
+                max = tmp_seq_ulo->maximum();
+                len = tmp_seq_ulo->length();
+                tmp_ulo = (const_cast<DevVarULongArray *>(tmp_seq_ulo))->get_buffer((CORBA::Boolean) true);
+                ULongSeq = new DevVarULongArray(max, len, tmp_ulo, true);
+                break;
 
-		case tk_ulonglong:
-			seq[n].value.value >>= tmp_seq_ulolo;
-			max = tmp_seq_ulolo->maximum();
-			len = tmp_seq_ulolo->length();
-			tmp_ulolo = (const_cast<DevVarULong64Array *>(tmp_seq_ulolo))->get_buffer((CORBA::Boolean)true);
-			ULong64Seq = new DevVarULong64Array(max,len,tmp_ulolo,true);
-			break;
+            case tk_ulonglong:
+                seq[n].value.value >>= tmp_seq_ulolo;
+                max = tmp_seq_ulolo->maximum();
+                len = tmp_seq_ulolo->length();
+                tmp_ulolo = (const_cast<DevVarULong64Array *>(tmp_seq_ulolo))->get_buffer((CORBA::Boolean) true);
+                ULong64Seq = new DevVarULong64Array(max, len, tmp_ulolo, true);
+                break;
 
-		case tk_enum:
-			seq[n].value.value >>= tmp_seq_state;
-			max = tmp_seq_state->maximum();
-			len = tmp_seq_state->length();
-			tmp_state = (const_cast<DevVarStateArray *>(tmp_seq_state))->get_buffer((CORBA::Boolean)true);
-			StateSeq = new DevVarStateArray(max,len,tmp_state,true);
-			break;
+            case tk_enum:
+                seq[n].value.value >>= tmp_seq_state;
+                max = tmp_seq_state->maximum();
+                len = tmp_seq_state->length();
+                tmp_state = (const_cast<DevVarStateArray *>(tmp_seq_state))->get_buffer((CORBA::Boolean) true);
+                StateSeq = new DevVarStateArray(max, len, tmp_state, true);
+                break;
 
-		default:
-			break;
-		}
-	}
-
-}
-
-
-DeviceAttributeHistory::DeviceAttributeHistory(int n,DevAttrHistoryList_3_var &seq):ext_hist(Tango_nullptr)
-{
-	fail = seq[n].attr_failed;
-
-	err_list = new DevErrorList(seq[n].value.err_list);
-	time = seq[n].value.time;
-	quality = seq[n].value.quality;
-	dim_x = seq[n].value.r_dim.dim_x;
-	dim_y = seq[n].value.r_dim.dim_y;
-	w_dim_x = seq[n].value.w_dim.dim_x;
-	w_dim_y = seq[n].value.w_dim.dim_y;
-	name = seq[n].value.name;
-
-	const DevVarLongArray *tmp_seq_lo;
-	CORBA::Long *tmp_lo;
-	const DevVarLong64Array *tmp_seq_lolo;
-	CORBA::LongLong *tmp_lolo;
-	const DevVarShortArray *tmp_seq_sh;
-	CORBA::Short *tmp_sh;
-	const DevVarDoubleArray *tmp_seq_db;
-	CORBA::Double *tmp_db;
-	const DevVarStringArray *tmp_seq_str;
-	char **tmp_str;
-	const DevVarFloatArray *tmp_seq_fl;
-	CORBA::Float *tmp_fl;
-	const DevVarBooleanArray *tmp_seq_boo;
-	CORBA::Boolean *tmp_boo;
-	const DevVarUShortArray *tmp_seq_ush;
-	CORBA::UShort *tmp_ush;
-	const DevVarCharArray *tmp_seq_uch;
-	CORBA::Octet *tmp_uch;
-	const DevVarULongArray *tmp_seq_ulo;
-	CORBA::ULong *tmp_ulo;
-	const DevVarULong64Array *tmp_seq_ulolo;
-	CORBA::ULongLong *tmp_ulolo;
-	const DevVarStateArray *tmp_seq_state;
-	Tango::DevState *tmp_state;
-
-	CORBA::ULong max,len;
-
-	if ((fail == false) && (quality != Tango::ATTR_INVALID))
-	{
-		CORBA::TypeCode_var ty = seq[n].value.value.type();
-		CORBA::TypeCode_var ty_alias = ty->content_type();
-		CORBA::TypeCode_var ty_seq = ty_alias->content_type();
-		switch (ty_seq->kind())
-		{
-		case tk_long:
-			seq[n].value.value >>= tmp_seq_lo;
-			max = tmp_seq_lo->maximum();
-			len = tmp_seq_lo->length();
-			tmp_lo = (const_cast<DevVarLongArray *>(tmp_seq_lo))->get_buffer((CORBA::Boolean)true);
-			LongSeq = new DevVarLongArray(max,len,tmp_lo,true);
-			break;
-
-		case tk_longlong:
-			seq[n].value.value >>= tmp_seq_lolo;
-			max = tmp_seq_lolo->maximum();
-			len = tmp_seq_lolo->length();
-			tmp_lolo = (const_cast<DevVarLong64Array *>(tmp_seq_lolo))->get_buffer((CORBA::Boolean)true);
-			Long64Seq = new DevVarLong64Array(max,len,tmp_lolo,true);
-			break;
-
-		case tk_short:
-			seq[n].value.value >>= tmp_seq_sh;
-			max = tmp_seq_sh->maximum();
-			len = tmp_seq_sh->length();
-			tmp_sh = (const_cast<DevVarShortArray *>(tmp_seq_sh))->get_buffer((CORBA::Boolean)true);
-			ShortSeq = new DevVarShortArray(max,len,tmp_sh,true);
-			break;
-
-		case tk_double:
-			seq[n].value.value >>= tmp_seq_db;
-			max = tmp_seq_db->maximum();
-			len = tmp_seq_db->length();
-			tmp_db = (const_cast<DevVarDoubleArray *>(tmp_seq_db))->get_buffer((CORBA::Boolean)true);
-			DoubleSeq = new DevVarDoubleArray(max,len,tmp_db,true);
-			break;
-
-		case tk_string:
-			seq[n].value.value >>= tmp_seq_str;
-			max = tmp_seq_str->maximum();
-			len = tmp_seq_str->length();
-			tmp_str = (const_cast<DevVarStringArray *>(tmp_seq_str))->get_buffer((CORBA::Boolean)true);
-			StringSeq = new DevVarStringArray(max,len,tmp_str,true);
-			break;
-
-		case tk_float:
-			seq[n].value.value >>= tmp_seq_fl;
-			max = tmp_seq_fl->maximum();
-			len = tmp_seq_fl->length();
-			tmp_fl = (const_cast<DevVarFloatArray *>(tmp_seq_fl))->get_buffer((CORBA::Boolean)true);
-			FloatSeq = new DevVarFloatArray(max,len,tmp_fl,true);
-			break;
-
-		case tk_boolean:
-			seq[n].value.value >>= tmp_seq_boo;
-			max = tmp_seq_boo->maximum();
-			len = tmp_seq_boo->length();
-			tmp_boo = (const_cast<DevVarBooleanArray *>(tmp_seq_boo))->get_buffer((CORBA::Boolean)true);
-			BooleanSeq = new DevVarBooleanArray(max,len,tmp_boo,true);
-			break;
-
-		case tk_ushort:
-			seq[n].value.value >>= tmp_seq_ush;
-			max = tmp_seq_ush->maximum();
-			len = tmp_seq_ush->length();
-			tmp_ush = (const_cast<DevVarUShortArray *>(tmp_seq_ush))->get_buffer((CORBA::Boolean)true);
-			UShortSeq = new DevVarUShortArray(max,len,tmp_ush,true);
-			break;
-
-		case tk_octet:
-			seq[n].value.value >>= tmp_seq_uch;
-			max = tmp_seq_uch->maximum();
-			len = tmp_seq_uch->length();
-			tmp_uch = (const_cast<DevVarCharArray *>(tmp_seq_uch))->get_buffer((CORBA::Boolean)true);
-			UCharSeq = new DevVarCharArray(max,len,tmp_uch,true);
-			break;
-
-		case tk_ulong:
-			seq[n].value.value >>= tmp_seq_ulo;
-			max = tmp_seq_ulo->maximum();
-			len = tmp_seq_ulo->length();
-			tmp_ulo = (const_cast<DevVarULongArray *>(tmp_seq_ulo))->get_buffer((CORBA::Boolean)true);
-			ULongSeq = new DevVarULongArray(max,len,tmp_ulo,true);
-			break;
-
-		case tk_ulonglong:
-			seq[n].value.value >>= tmp_seq_ulolo;
-			max = tmp_seq_ulolo->maximum();
-			len = tmp_seq_ulolo->length();
-			tmp_ulolo = (const_cast<DevVarULong64Array *>(tmp_seq_ulolo))->get_buffer((CORBA::Boolean)true);
-			ULong64Seq = new DevVarULong64Array(max,len,tmp_ulolo,true);
-			break;
-
-		case tk_enum:
-			seq[n].value.value >>= tmp_seq_state;
-			max = tmp_seq_state->maximum();
-			len = tmp_seq_state->length();
-			tmp_state = (const_cast<DevVarStateArray *>(tmp_seq_state))->get_buffer((CORBA::Boolean)true);
-			StateSeq = new DevVarStateArray(max,len,tmp_state,true);
-			break;
-
-		default:
-			break;
-		}
-	}
+            default:
+                break;
+        }
+    }
 
 }
 
-
-
-DeviceAttributeHistory::DeviceAttributeHistory(const DeviceAttributeHistory & source):DeviceAttribute(source),ext_hist(Tango_nullptr)
+DeviceAttributeHistory::DeviceAttributeHistory(int n, DevAttrHistoryList_3_var &seq)
+    : ext_hist(Tango_nullptr)
 {
-	fail = source.fail;
+    fail = seq[n].attr_failed;
+
+    err_list = new DevErrorList(seq[n].value.err_list);
+    time = seq[n].value.time;
+    quality = seq[n].value.quality;
+    dim_x = seq[n].value.r_dim.dim_x;
+    dim_y = seq[n].value.r_dim.dim_y;
+    w_dim_x = seq[n].value.w_dim.dim_x;
+    w_dim_y = seq[n].value.w_dim.dim_y;
+    name = seq[n].value.name;
+
+    const DevVarLongArray *tmp_seq_lo;
+    CORBA::Long *tmp_lo;
+    const DevVarLong64Array *tmp_seq_lolo;
+    CORBA::LongLong *tmp_lolo;
+    const DevVarShortArray *tmp_seq_sh;
+    CORBA::Short *tmp_sh;
+    const DevVarDoubleArray *tmp_seq_db;
+    CORBA::Double *tmp_db;
+    const DevVarStringArray *tmp_seq_str;
+    char **tmp_str;
+    const DevVarFloatArray *tmp_seq_fl;
+    CORBA::Float *tmp_fl;
+    const DevVarBooleanArray *tmp_seq_boo;
+    CORBA::Boolean *tmp_boo;
+    const DevVarUShortArray *tmp_seq_ush;
+    CORBA::UShort *tmp_ush;
+    const DevVarCharArray *tmp_seq_uch;
+    CORBA::Octet *tmp_uch;
+    const DevVarULongArray *tmp_seq_ulo;
+    CORBA::ULong *tmp_ulo;
+    const DevVarULong64Array *tmp_seq_ulolo;
+    CORBA::ULongLong *tmp_ulolo;
+    const DevVarStateArray *tmp_seq_state;
+    Tango::DevState *tmp_state;
+
+    CORBA::ULong max, len;
+
+    if ((fail == false) && (quality != Tango::ATTR_INVALID))
+    {
+        CORBA::TypeCode_var ty = seq[n].value.value.type();
+        CORBA::TypeCode_var ty_alias = ty->content_type();
+        CORBA::TypeCode_var ty_seq = ty_alias->content_type();
+        switch (ty_seq->kind())
+        {
+            case tk_long:
+                seq[n].value.value >>= tmp_seq_lo;
+                max = tmp_seq_lo->maximum();
+                len = tmp_seq_lo->length();
+                tmp_lo = (const_cast<DevVarLongArray *>(tmp_seq_lo))->get_buffer((CORBA::Boolean) true);
+                LongSeq = new DevVarLongArray(max, len, tmp_lo, true);
+                break;
+
+            case tk_longlong:
+                seq[n].value.value >>= tmp_seq_lolo;
+                max = tmp_seq_lolo->maximum();
+                len = tmp_seq_lolo->length();
+                tmp_lolo = (const_cast<DevVarLong64Array *>(tmp_seq_lolo))->get_buffer((CORBA::Boolean) true);
+                Long64Seq = new DevVarLong64Array(max, len, tmp_lolo, true);
+                break;
+
+            case tk_short:
+                seq[n].value.value >>= tmp_seq_sh;
+                max = tmp_seq_sh->maximum();
+                len = tmp_seq_sh->length();
+                tmp_sh = (const_cast<DevVarShortArray *>(tmp_seq_sh))->get_buffer((CORBA::Boolean) true);
+                ShortSeq = new DevVarShortArray(max, len, tmp_sh, true);
+                break;
+
+            case tk_double:
+                seq[n].value.value >>= tmp_seq_db;
+                max = tmp_seq_db->maximum();
+                len = tmp_seq_db->length();
+                tmp_db = (const_cast<DevVarDoubleArray *>(tmp_seq_db))->get_buffer((CORBA::Boolean) true);
+                DoubleSeq = new DevVarDoubleArray(max, len, tmp_db, true);
+                break;
+
+            case tk_string:
+                seq[n].value.value >>= tmp_seq_str;
+                max = tmp_seq_str->maximum();
+                len = tmp_seq_str->length();
+                tmp_str = (const_cast<DevVarStringArray *>(tmp_seq_str))->get_buffer((CORBA::Boolean) true);
+                StringSeq = new DevVarStringArray(max, len, tmp_str, true);
+                break;
+
+            case tk_float:
+                seq[n].value.value >>= tmp_seq_fl;
+                max = tmp_seq_fl->maximum();
+                len = tmp_seq_fl->length();
+                tmp_fl = (const_cast<DevVarFloatArray *>(tmp_seq_fl))->get_buffer((CORBA::Boolean) true);
+                FloatSeq = new DevVarFloatArray(max, len, tmp_fl, true);
+                break;
+
+            case tk_boolean:
+                seq[n].value.value >>= tmp_seq_boo;
+                max = tmp_seq_boo->maximum();
+                len = tmp_seq_boo->length();
+                tmp_boo = (const_cast<DevVarBooleanArray *>(tmp_seq_boo))->get_buffer((CORBA::Boolean) true);
+                BooleanSeq = new DevVarBooleanArray(max, len, tmp_boo, true);
+                break;
+
+            case tk_ushort:
+                seq[n].value.value >>= tmp_seq_ush;
+                max = tmp_seq_ush->maximum();
+                len = tmp_seq_ush->length();
+                tmp_ush = (const_cast<DevVarUShortArray *>(tmp_seq_ush))->get_buffer((CORBA::Boolean) true);
+                UShortSeq = new DevVarUShortArray(max, len, tmp_ush, true);
+                break;
+
+            case tk_octet:
+                seq[n].value.value >>= tmp_seq_uch;
+                max = tmp_seq_uch->maximum();
+                len = tmp_seq_uch->length();
+                tmp_uch = (const_cast<DevVarCharArray *>(tmp_seq_uch))->get_buffer((CORBA::Boolean) true);
+                UCharSeq = new DevVarCharArray(max, len, tmp_uch, true);
+                break;
+
+            case tk_ulong:
+                seq[n].value.value >>= tmp_seq_ulo;
+                max = tmp_seq_ulo->maximum();
+                len = tmp_seq_ulo->length();
+                tmp_ulo = (const_cast<DevVarULongArray *>(tmp_seq_ulo))->get_buffer((CORBA::Boolean) true);
+                ULongSeq = new DevVarULongArray(max, len, tmp_ulo, true);
+                break;
+
+            case tk_ulonglong:
+                seq[n].value.value >>= tmp_seq_ulolo;
+                max = tmp_seq_ulolo->maximum();
+                len = tmp_seq_ulolo->length();
+                tmp_ulolo = (const_cast<DevVarULong64Array *>(tmp_seq_ulolo))->get_buffer((CORBA::Boolean) true);
+                ULong64Seq = new DevVarULong64Array(max, len, tmp_ulolo, true);
+                break;
+
+            case tk_enum:
+                seq[n].value.value >>= tmp_seq_state;
+                max = tmp_seq_state->maximum();
+                len = tmp_seq_state->length();
+                tmp_state = (const_cast<DevVarStateArray *>(tmp_seq_state))->get_buffer((CORBA::Boolean) true);
+                StateSeq = new DevVarStateArray(max, len, tmp_state, true);
+                break;
+
+            default:
+                break;
+        }
+    }
+
+}
+
+DeviceAttributeHistory::DeviceAttributeHistory(const DeviceAttributeHistory &source)
+    : DeviceAttribute(source), ext_hist(Tango_nullptr)
+{
+    fail = source.fail;
 
 #ifdef HAS_UNIQUE_PTR
     if (source.ext_hist.get() != NULL)
@@ -661,20 +666,21 @@ DeviceAttributeHistory::DeviceAttributeHistory(const DeviceAttributeHistory & so
         *(ext_hist.get()) = *(source.ext_hist.get());
     }
 #else
-	if (source.ext_hist == NULL)
-		ext_hist = NULL;
-	else
-	{
-		ext_hist = new DeviceAttributeHistoryExt();
-		*ext_hist = *(source.ext_hist);
-	}
+    if (source.ext_hist == NULL)
+        ext_hist = NULL;
+    else
+    {
+        ext_hist = new DeviceAttributeHistoryExt();
+        *ext_hist = *(source.ext_hist);
+    }
 #endif
 }
 
 #ifdef HAS_RVALUE
-DeviceAttributeHistory::DeviceAttributeHistory(DeviceAttributeHistory &&source):DeviceAttribute(move(source)),ext_hist(Tango_nullptr)
+DeviceAttributeHistory::DeviceAttributeHistory(DeviceAttributeHistory &&source)
+    : DeviceAttribute(move(source)), ext_hist(Tango_nullptr)
 {
-	fail = source.fail;
+    fail = source.fail;
 
     if (source.ext_hist.get() != NULL)
         ext_hist = move(source.ext_hist);
@@ -702,7 +708,7 @@ DeviceAttributeHistory::~DeviceAttributeHistory()
 //
 //-----------------------------------------------------------------------------
 
-DeviceAttributeHistory & DeviceAttributeHistory::operator=(const DeviceAttributeHistory &rval)
+DeviceAttributeHistory &DeviceAttributeHistory::operator=(const DeviceAttributeHistory &rval)
 {
 
     if (this != &rval)
@@ -739,11 +745,11 @@ DeviceAttributeHistory & DeviceAttributeHistory::operator=(const DeviceAttribute
 #endif
     }
 
-	return *this;
+    return *this;
 }
 
 #ifdef HAS_RVALUE
-DeviceAttributeHistory & DeviceAttributeHistory::operator=(DeviceAttributeHistory &&rval)
+DeviceAttributeHistory &DeviceAttributeHistory::operator=(DeviceAttributeHistory &&rval)
 {
 
 //
@@ -756,14 +762,14 @@ DeviceAttributeHistory & DeviceAttributeHistory::operator=(DeviceAttributeHistor
 // Then, assignement of DeviceAttributeHistory members
 //
 
-	fail = rval.fail;
+    fail = rval.fail;
 
     if (rval.ext_hist.get() != NULL)
         ext_hist = move(rval.ext_hist);
     else
         ext_hist.reset();
 
-	return *this;
+    return *this;
 }
 #endif
 
@@ -776,148 +782,148 @@ DeviceAttributeHistory & DeviceAttributeHistory::operator=(DeviceAttributeHistor
 //
 //--------------------------------------------------------------------------
 
-ostream &operator<<(ostream &o_str,DeviceAttributeHistory &dah)
+ostream &operator<<(ostream &o_str, DeviceAttributeHistory &dah)
 {
 //
 // Print date
 //
 
-	if (dah.time.tv_sec != 0)
-	{
-		char tmp_date[128];
-		time_t tmp_val = dah.time.tv_sec;
+    if (dah.time.tv_sec != 0)
+    {
+        char tmp_date[128];
+        time_t tmp_val = dah.time.tv_sec;
 #ifdef _TG_WINDOWS_
-		ctime_s(tmp_date,128,&tmp_val);
+        ctime_s(tmp_date,128,&tmp_val);
 #else
-        ctime_r(&tmp_val,tmp_date);
+        ctime_r(&tmp_val, tmp_date);
 #endif
-		tmp_date[strlen(tmp_date) - 1] = '\0';
-		o_str << tmp_date;
-		o_str << " (" << dah.time.tv_sec << "," << setw(6) << setfill('0') << dah.time.tv_usec << " sec) : ";
-	}
+        tmp_date[strlen(tmp_date) - 1] = '\0';
+        o_str << tmp_date;
+        o_str << " (" << dah.time.tv_sec << "," << setw(6) << setfill('0') << dah.time.tv_usec << " sec) : ";
+    }
 
 //
 // print attribute name
 //
 
-	o_str << dah.name;
+    o_str << dah.name;
 
 //
 // print dim_x and dim_y
 //
 
-	o_str << " (dim_x = " << dah.dim_x << ", dim_y = " << dah.dim_y << ", ";
+    o_str << " (dim_x = " << dah.dim_x << ", dim_y = " << dah.dim_y << ", ";
 
 //
 // print write dim_x and dim_y
 //
 
-	o_str << "w_dim_x = " << dah.w_dim_x << ", w_dim_y = " << dah.w_dim_y << ", ";
+    o_str << "w_dim_x = " << dah.w_dim_x << ", w_dim_y = " << dah.w_dim_y << ", ";
 
 //
 // Print quality
 //
 
-	o_str << "Data quality factor = ";
-	switch (dah.quality)
-	{
-	case Tango::ATTR_VALID:
-		o_str << "VALID)" << endl;
-		break;
+    o_str << "Data quality factor = ";
+    switch (dah.quality)
+    {
+        case Tango::ATTR_VALID:
+            o_str << "VALID)" << endl;
+            break;
 
-	case Tango::ATTR_INVALID:
-		o_str << "INVALID)";
-		break;
+        case Tango::ATTR_INVALID:
+            o_str << "INVALID)";
+            break;
 
-	case Tango::ATTR_ALARM:
-		o_str << "ALARM)" << endl;
-		break;
+        case Tango::ATTR_ALARM:
+            o_str << "ALARM)" << endl;
+            break;
 
-	case Tango::ATTR_CHANGING:
-		o_str << "CHANGING)" << endl;
-		break;
+        case Tango::ATTR_CHANGING:
+            o_str << "CHANGING)" << endl;
+            break;
 
-	case Tango::ATTR_WARNING:
-		o_str << "WARNING) " << endl;
-		break;
-	}
+        case Tango::ATTR_WARNING:
+            o_str << "WARNING) " << endl;
+            break;
+    }
 
 //
 // Print data (if valid) or error stack
 //
 
-	if (dah.fail == true)
-	{
-		unsigned int nb_err = dah.err_list.in().length();
-		for (unsigned long i = 0;i < nb_err;i++)
-		{
-			o_str << "Tango error stack" << endl;
-			o_str << "Severity = ";
-			switch (dah.err_list[i].severity)
-			{
-			case Tango::WARN :
-				o_str << "WARNING ";
-				break;
+    if (dah.fail == true)
+    {
+        unsigned int nb_err = dah.err_list.in().length();
+        for (unsigned long i = 0; i < nb_err; i++)
+        {
+            o_str << "Tango error stack" << endl;
+            o_str << "Severity = ";
+            switch (dah.err_list[i].severity)
+            {
+                case Tango::WARN :
+                    o_str << "WARNING ";
+                    break;
 
-			case Tango::ERR :
-				o_str << "ERROR ";
-				break;
+                case Tango::ERR :
+                    o_str << "ERROR ";
+                    break;
 
-			case Tango::PANIC :
-				o_str << "PANIC ";
-				break;
+                case Tango::PANIC :
+                    o_str << "PANIC ";
+                    break;
 
-			default :
-				o_str << "Unknown severity code";
-				break;
-			}
-			o_str << endl;
-			o_str << "Error reason = " << dah.err_list[i].reason.in() << endl;
-			o_str << "Desc : " << dah.err_list[i].desc.in() << endl;
-			o_str << "Origin : " << dah.err_list[i].origin.in();
-			if (i != nb_err - 1)
-				o_str << endl;
-		}
-	}
-	else
-	{
-		if (dah.quality != Tango::ATTR_INVALID)
-		{
-			if (dah.is_empty() == true)
-				o_str << "No data in DeviceData object";
-			else
-			{
-				if (dah.LongSeq.operator->() != NULL)
-					o_str << *(dah.LongSeq.operator->());
-				else if (dah.ShortSeq.operator->() != NULL)
-					o_str << *(dah.ShortSeq.operator->());
-				else if (dah.DoubleSeq.operator->() != NULL)
-					o_str << *(dah.DoubleSeq.operator->());
-				else if (dah.FloatSeq.operator->() != NULL)
-					o_str << *(dah.FloatSeq.operator->());
-				else if (dah.BooleanSeq.operator->() != NULL)
-					o_str << *(dah.BooleanSeq.operator->());
-				else if (dah.UShortSeq.operator->() != NULL)
-					o_str << *(dah.UShortSeq.operator->());
-				else if (dah.UCharSeq.operator->() != NULL)
-					o_str << *(dah.UCharSeq.operator->());
-				else if (dah.Long64Seq.operator->() != NULL)
-					o_str << *(dah.Long64Seq.operator->());
-				else if (dah.ULongSeq.operator->() != NULL)
-					o_str << *(dah.ULongSeq.operator->());
-				else if (dah.ULong64Seq.operator->() != NULL)
-					o_str << *(dah.ULong64Seq.operator->());
-				else if (dah.StateSeq.operator->() != NULL)
-					o_str << *(dah.StateSeq.operator->());
-				else if (dah.EncodedSeq.operator->() != NULL)
-					o_str << *(dah.EncodedSeq.operator->());
-				else
-					o_str << *(dah.StringSeq.operator->());
-			}
-		}
-	}
+                default :
+                    o_str << "Unknown severity code";
+                    break;
+            }
+            o_str << endl;
+            o_str << "Error reason = " << dah.err_list[i].reason.in() << endl;
+            o_str << "Desc : " << dah.err_list[i].desc.in() << endl;
+            o_str << "Origin : " << dah.err_list[i].origin.in();
+            if (i != nb_err - 1)
+                o_str << endl;
+        }
+    }
+    else
+    {
+        if (dah.quality != Tango::ATTR_INVALID)
+        {
+            if (dah.is_empty() == true)
+                o_str << "No data in DeviceData object";
+            else
+            {
+                if (dah.LongSeq.operator->() != NULL)
+                    o_str << *(dah.LongSeq.operator->());
+                else if (dah.ShortSeq.operator->() != NULL)
+                    o_str << *(dah.ShortSeq.operator->());
+                else if (dah.DoubleSeq.operator->() != NULL)
+                    o_str << *(dah.DoubleSeq.operator->());
+                else if (dah.FloatSeq.operator->() != NULL)
+                    o_str << *(dah.FloatSeq.operator->());
+                else if (dah.BooleanSeq.operator->() != NULL)
+                    o_str << *(dah.BooleanSeq.operator->());
+                else if (dah.UShortSeq.operator->() != NULL)
+                    o_str << *(dah.UShortSeq.operator->());
+                else if (dah.UCharSeq.operator->() != NULL)
+                    o_str << *(dah.UCharSeq.operator->());
+                else if (dah.Long64Seq.operator->() != NULL)
+                    o_str << *(dah.Long64Seq.operator->());
+                else if (dah.ULongSeq.operator->() != NULL)
+                    o_str << *(dah.ULongSeq.operator->());
+                else if (dah.ULong64Seq.operator->() != NULL)
+                    o_str << *(dah.ULong64Seq.operator->());
+                else if (dah.StateSeq.operator->() != NULL)
+                    o_str << *(dah.StateSeq.operator->());
+                else if (dah.EncodedSeq.operator->() != NULL)
+                    o_str << *(dah.EncodedSeq.operator->());
+                else
+                    o_str << *(dah.StringSeq.operator->());
+            }
+        }
+    }
 
-	return o_str;
+    return o_str;
 }
 
 } // End of Tango namepsace

--- a/cppapi/client/devapi_datahist.cpp
+++ b/cppapi/client/devapi_datahist.cpp
@@ -81,7 +81,9 @@ DeviceDataHistory::DeviceDataHistory(const DeviceDataHistory &source)
     seq_ptr = source.seq_ptr;
     ref_ctr_ptr = source.ref_ctr_ptr;
     if (ref_ctr_ptr != NULL)
+    {
         (*ref_ctr_ptr)++;
+    }
 
 #ifdef HAS_UNIQUE_PTR
     if (source.ext_hist.get() != NULL)
@@ -112,9 +114,13 @@ DeviceDataHistory::DeviceDataHistory(DeviceDataHistory &&source)
     ref_ctr_ptr = source.ref_ctr_ptr;
 
     if (source.ext_hist.get() != NULL)
+    {
         ext_hist = move(source.ext_hist);
+    }
     else
+    {
         ext_hist.reset();
+    }
 }
 #endif
 
@@ -196,7 +202,9 @@ DeviceDataHistory &DeviceDataHistory::operator=(const DeviceDataHistory &rval)
             *(ext_hist.get()) = *(rval.ext_hist.get());
         }
         else
+        {
             ext_hist.reset();
+        }
 #else
         delete ext_hist;
         if (rval.ext_hist != NULL)
@@ -261,9 +269,13 @@ DeviceDataHistory &DeviceDataHistory::operator=(DeviceDataHistory &&rval)
 //
 
     if (rval.ext_hist.get() != NULL)
+    {
         ext_hist = move(rval.ext_hist);
+    }
     else
+    {
         ext_hist.reset();
+    }
 
     return *this;
 }
@@ -330,7 +342,9 @@ ostream &operator<<(ostream &o_str, DeviceDataHistory &dh)
             o_str << "Desc : " << (dh.err.in())[i].desc.in() << endl;
             o_str << "Origin : " << (dh.err.in())[i].origin.in();
             if (i != nb_err - 1)
+            {
                 o_str << endl;
+            }
         }
     }
     else
@@ -683,7 +697,9 @@ DeviceAttributeHistory::DeviceAttributeHistory(DeviceAttributeHistory &&source)
     fail = source.fail;
 
     if (source.ext_hist.get() != NULL)
+    {
         ext_hist = move(source.ext_hist);
+    }
 
 }
 #endif
@@ -732,7 +748,9 @@ DeviceAttributeHistory &DeviceAttributeHistory::operator=(const DeviceAttributeH
             *(ext_hist.get()) = *(rval.ext_hist.get());
         }
         else
+        {
             ext_hist.reset();
+        }
 #else
         delete ext_hist;
         if (rval.ext_hist != NULL)
@@ -765,9 +783,13 @@ DeviceAttributeHistory &DeviceAttributeHistory::operator=(DeviceAttributeHistory
     fail = rval.fail;
 
     if (rval.ext_hist.get() != NULL)
+    {
         ext_hist = move(rval.ext_hist);
+    }
     else
+    {
         ext_hist.reset();
+    }
 
     return *this;
 }
@@ -882,7 +904,9 @@ ostream &operator<<(ostream &o_str, DeviceAttributeHistory &dah)
             o_str << "Desc : " << dah.err_list[i].desc.in() << endl;
             o_str << "Origin : " << dah.err_list[i].origin.in();
             if (i != nb_err - 1)
+            {
                 o_str << endl;
+            }
         }
     }
     else
@@ -890,35 +914,63 @@ ostream &operator<<(ostream &o_str, DeviceAttributeHistory &dah)
         if (dah.quality != Tango::ATTR_INVALID)
         {
             if (dah.is_empty() == true)
+            {
                 o_str << "No data in DeviceData object";
+            }
             else
             {
                 if (dah.LongSeq.operator->() != NULL)
+                {
                     o_str << *(dah.LongSeq.operator->());
+                }
                 else if (dah.ShortSeq.operator->() != NULL)
+                {
                     o_str << *(dah.ShortSeq.operator->());
+                }
                 else if (dah.DoubleSeq.operator->() != NULL)
+                {
                     o_str << *(dah.DoubleSeq.operator->());
+                }
                 else if (dah.FloatSeq.operator->() != NULL)
+                {
                     o_str << *(dah.FloatSeq.operator->());
+                }
                 else if (dah.BooleanSeq.operator->() != NULL)
+                {
                     o_str << *(dah.BooleanSeq.operator->());
+                }
                 else if (dah.UShortSeq.operator->() != NULL)
+                {
                     o_str << *(dah.UShortSeq.operator->());
+                }
                 else if (dah.UCharSeq.operator->() != NULL)
+                {
                     o_str << *(dah.UCharSeq.operator->());
+                }
                 else if (dah.Long64Seq.operator->() != NULL)
+                {
                     o_str << *(dah.Long64Seq.operator->());
+                }
                 else if (dah.ULongSeq.operator->() != NULL)
+                {
                     o_str << *(dah.ULongSeq.operator->());
+                }
                 else if (dah.ULong64Seq.operator->() != NULL)
+                {
                     o_str << *(dah.ULong64Seq.operator->());
+                }
                 else if (dah.StateSeq.operator->() != NULL)
+                {
                     o_str << *(dah.StateSeq.operator->());
+                }
                 else if (dah.EncodedSeq.operator->() != NULL)
+                {
                     o_str << *(dah.EncodedSeq.operator->());
+                }
                 else
+                {
                     o_str << *(dah.StringSeq.operator->());
+                }
             }
         }
     }

--- a/cppapi/client/devapi_datahist.cpp
+++ b/cppapi/client/devapi_datahist.cpp
@@ -215,7 +215,9 @@ DeviceDataHistory &DeviceDataHistory::operator=(const DeviceDataHistory &rval)
             *ext_hist = *(rval.ext_hist);
         }
         else
+        {
             ext_hist = NULL;
+        }
 #endif
     }
 
@@ -683,7 +685,9 @@ DeviceAttributeHistory::DeviceAttributeHistory(const DeviceAttributeHistory &sou
     }
 #else
     if (source.ext_hist == NULL)
+    {
         ext_hist = NULL;
+    }
     else
     {
         ext_hist = new DeviceAttributeHistoryExt();
@@ -761,7 +765,9 @@ DeviceAttributeHistory &DeviceAttributeHistory::operator=(const DeviceAttributeH
             *ext_hist = *(rval.ext_hist);
         }
         else
+        {
             ext_hist = NULL;
+        }
 #endif
     }
 

--- a/cppapi/server/attribute.tpp
+++ b/cppapi/server/attribute.tpp
@@ -52,78 +52,78 @@ namespace Tango
 //
 //------------------------------------------------------------------------------------------------------------------
 
-template <typename T>
+template<typename T>
 void Attribute::check_hard_coded_properties(const T &user_conf)
 {
 //
 // Check attribute name
 //
 
-	string user_att_name(user_conf.name.in());
-	transform(user_att_name.begin(),user_att_name.end(),user_att_name.begin(),::tolower);
-	if (user_att_name != get_name_lower())
-	{
-		throw_hard_coded_prop("name");
-	}
+    string user_att_name(user_conf.name.in());
+    transform(user_att_name.begin(), user_att_name.end(), user_att_name.begin(), ::tolower);
+    if (user_att_name != get_name_lower())
+    {
+        throw_hard_coded_prop("name");
+    }
 
 //
 // Check data type
 //
 
-	if (user_conf.data_type != data_type)
-	{
-		throw_hard_coded_prop("data_type");
-	}
+    if (user_conf.data_type != data_type)
+    {
+        throw_hard_coded_prop("data_type");
+    }
 
 //
 // Check data format
 //
 
-	if (user_conf.data_format != data_format)
-	{
-		throw_hard_coded_prop("data_format");
-	}
+    if (user_conf.data_format != data_format)
+    {
+        throw_hard_coded_prop("data_format");
+    }
 
 //
 // Check writable
 //
 
-	if (user_conf.writable != writable)
-	{
-		throw_hard_coded_prop("writable");
-	}
+    if (user_conf.writable != writable)
+    {
+        throw_hard_coded_prop("writable");
+    }
 
 //
 // Check max_dim_x
 //
 
-	if (user_conf.max_dim_x != max_x)
-	{
-		throw_hard_coded_prop("max_dim_x");
-	}
+    if (user_conf.max_dim_x != max_x)
+    {
+        throw_hard_coded_prop("max_dim_x");
+    }
 
 //
 // Check max_dim_y
 //
 
-	if (user_conf.max_dim_y != max_y)
-	{
-		throw_hard_coded_prop("max_dim_y");
-	}
+    if (user_conf.max_dim_y != max_y)
+    {
+        throw_hard_coded_prop("max_dim_y");
+    }
 
 //
 // Check writable_attr_name
 //
 
-	string local_w_name(writable_attr_name);
-	transform(local_w_name.begin(),local_w_name.end(),local_w_name.begin(),::tolower);
-	string user_w_name(user_conf.writable_attr_name.in());
-	transform(user_w_name.begin(),user_w_name.end(),user_w_name.begin(),::tolower);
+    string local_w_name(writable_attr_name);
+    transform(local_w_name.begin(), local_w_name.end(), local_w_name.begin(), ::tolower);
+    string user_w_name(user_conf.writable_attr_name.in());
+    transform(user_w_name.begin(), user_w_name.end(), user_w_name.begin(), ::tolower);
 
-	if (user_w_name != local_w_name)
-	{
-		throw_hard_coded_prop("writable_attr_name");
-	}
+    if (user_w_name != local_w_name)
+    {
+        throw_hard_coded_prop("writable_attr_name");
+    }
 }
 
 //+-----------------------------------------------------------------------------------------------------------------
@@ -140,15 +140,15 @@ void Attribute::check_hard_coded_properties(const T &user_conf)
 //
 //------------------------------------------------------------------------------------------------------------------
 
-template <typename T>
+template<typename T>
 void Attribute::set_hard_coded_properties(const T &user_conf)
 {
-	data_type = user_conf.data_type;
-	data_format = user_conf.data_format;
-	writable = user_conf.writable;
-	max_x = user_conf.max_dim_x;
-	max_y = user_conf.max_dim_y;
-	writable_attr_name = user_conf.writable_attr_name;
+    data_type = user_conf.data_type;
+    data_format = user_conf.data_format;
+    writable = user_conf.writable;
+    max_x = user_conf.max_dim_x;
+    max_y = user_conf.max_dim_y;
+    writable_attr_name = user_conf.writable_attr_name;
 }
 
 //+-------------------------------------------------------------------------------------------------------------------
@@ -166,7 +166,7 @@ void Attribute::set_hard_coded_properties(const T &user_conf)
 //
 //-------------------------------------------------------------------------------------------------------------------
 
-template <typename T>
+template<typename T>
 void Attribute::set_min_alarm(const T &new_min_alarm)
 {
 
@@ -174,45 +174,46 @@ void Attribute::set_min_alarm(const T &new_min_alarm)
 // Check type validity
 //
 
-	if((data_type == Tango::DEV_STRING) ||
-		(data_type == Tango::DEV_BOOLEAN) ||
-		(data_type == Tango::DEV_STATE) ||
-		(data_type == Tango::DEV_ENUM))
-		throw_err_data_type("min_alarm",d_name,"Attribute::set_min_alarm()");
+    if ((data_type == Tango::DEV_STRING) ||
+        (data_type == Tango::DEV_BOOLEAN) ||
+        (data_type == Tango::DEV_STATE) ||
+        (data_type == Tango::DEV_ENUM))
+        throw_err_data_type("min_alarm", d_name, "Attribute::set_min_alarm()");
 
-	else if (!(data_type == DEV_ENCODED && ranges_type2const<T>::enu == DEV_UCHAR) &&
-		(data_type != ranges_type2const<T>::enu))
-	{
-		string err_msg = "Attribute (" + name + ") data type does not match the type provided : " + ranges_type2const<T>::str;
-		Except::throw_exception((const char *)API_IncompatibleAttrDataType,
-					  (const char *)err_msg.c_str(),
-					  (const char *)"Attribute::set_min_alarm()");
-	}
+    else if (!(data_type == DEV_ENCODED && ranges_type2const<T>::enu == DEV_UCHAR) &&
+        (data_type != ranges_type2const<T>::enu))
+    {
+        string err_msg =
+            "Attribute (" + name + ") data type does not match the type provided : " + ranges_type2const<T>::str;
+        Except::throw_exception((const char *) API_IncompatibleAttrDataType,
+                                (const char *) err_msg.c_str(),
+                                (const char *) "Attribute::set_min_alarm()");
+    }
 
 //
 //	Check coherence with max_alarm
 //
 
-	if(alarm_conf.test(max_level))
-	{
-		T max_alarm_tmp;
-		memcpy((void *) &max_alarm_tmp, (const void *) &max_alarm, sizeof(T));
-		if(new_min_alarm >= max_alarm_tmp)
-			throw_incoherent_val_err("min_alarm","max_alarm",d_name,"Attribute::set_min_alarm()");
-	}
+    if (alarm_conf.test(max_level))
+    {
+        T max_alarm_tmp;
+        memcpy((void *) &max_alarm_tmp, (const void *) &max_alarm, sizeof(T));
+        if (new_min_alarm >= max_alarm_tmp)
+            throw_incoherent_val_err("min_alarm", "max_alarm", d_name, "Attribute::set_min_alarm()");
+    }
 
 //
 // Store new min alarm as a string
 //
 
-	TangoSys_MemStream str;
-	str.precision(TANGO_FLOAT_PRECISION);
-	if(ranges_type2const<T>::enu == Tango::DEV_UCHAR)
-		str << (short)new_min_alarm; // to represent the numeric value
-	else
-		str << new_min_alarm;
-	string min_alarm_tmp_str;
-	min_alarm_tmp_str = str.str();
+    TangoSys_MemStream str;
+    str.precision(TANGO_FLOAT_PRECISION);
+    if (ranges_type2const<T>::enu == Tango::DEV_UCHAR)
+        str << (short) new_min_alarm; // to represent the numeric value
+    else
+        str << new_min_alarm;
+    string min_alarm_tmp_str;
+    min_alarm_tmp_str = str.str();
 
 //
 // Get the monitor protecting device att config
@@ -223,92 +224,92 @@ void Attribute::set_min_alarm(const T &new_min_alarm)
     Tango::TangoMonitor *mon_ptr = NULL;
     if (tg->is_svr_starting() == false && tg->is_device_restarting(d_name) == false)
         mon_ptr = &(get_att_device()->get_att_conf_monitor());
-	AutoTangoMonitor sync1(mon_ptr);
+    AutoTangoMonitor sync1(mon_ptr);
 
 //
 // Store the new alarm locally
 //
 
-	Attr_CheckVal old_min_alarm;
-	memcpy((void *)&old_min_alarm, (void *)&min_alarm, sizeof(T));
-	memcpy((void *)&min_alarm, (void *)&new_min_alarm, sizeof(T));
+    Attr_CheckVal old_min_alarm;
+    memcpy((void *) &old_min_alarm, (void *) &min_alarm, sizeof(T));
+    memcpy((void *) &min_alarm, (void *) &new_min_alarm, sizeof(T));
 
 //
 // Then, update database
 //
 
-	Tango::DeviceClass *dev_class = get_att_device_class(d_name);
-	Tango::MultiClassAttribute *mca = dev_class->get_class_attr();
-	Tango::Attr &att = mca->get_attr(name);
-	vector<AttrProperty> &def_user_prop = att.get_user_default_properties();
-	size_t nb_user = def_user_prop.size();
+    Tango::DeviceClass *dev_class = get_att_device_class(d_name);
+    Tango::MultiClassAttribute *mca = dev_class->get_class_attr();
+    Tango::Attr &att = mca->get_attr(name);
+    vector<AttrProperty> &def_user_prop = att.get_user_default_properties();
+    size_t nb_user = def_user_prop.size();
 
-	string usr_def_val;
-	bool user_defaults = false;
-	if (nb_user != 0)
-	{
-		size_t i;
-		for (i = 0;i < nb_user;i++)
-		{
-			if (def_user_prop[i].get_name() == "min_alarm")
-				break;
-		}
-		if (i != nb_user) // user defaults defined
-		{
-			user_defaults = true;
-			usr_def_val = def_user_prop[i].get_value();
-		}
-	}
+    string usr_def_val;
+    bool user_defaults = false;
+    if (nb_user != 0)
+    {
+        size_t i;
+        for (i = 0; i < nb_user; i++)
+        {
+            if (def_user_prop[i].get_name() == "min_alarm")
+                break;
+        }
+        if (i != nb_user) // user defaults defined
+        {
+            user_defaults = true;
+            usr_def_val = def_user_prop[i].get_value();
+        }
+    }
 
 
-	if (Tango::Util::_UseDb == true)
-	{
-		if(user_defaults && min_alarm_tmp_str == usr_def_val)
-		{
-			DbDatum attr_dd(name), prop_dd("min_alarm");
-			DbData db_data;
-			db_data.push_back(attr_dd);
-			db_data.push_back(prop_dd);
+    if (Tango::Util::_UseDb == true)
+    {
+        if (user_defaults && min_alarm_tmp_str == usr_def_val)
+        {
+            DbDatum attr_dd(name), prop_dd("min_alarm");
+            DbData db_data;
+            db_data.push_back(attr_dd);
+            db_data.push_back(prop_dd);
 
-			bool retry = true;
-			while (retry == true)
-			{
-				try
-				{
-					tg->get_database()->delete_device_attribute_property(d_name,db_data);
-					retry = false;
-				}
-				catch (CORBA::COMM_FAILURE &)
-				{
-					tg->get_database()->reconnect(true);
-				}
-			}
-		}
-		else
-		{
-			try
-			{
-				upd_att_prop_db(min_alarm,"min_alarm");
-			}
-			catch (Tango::DevFailed &)
-			{
-				memcpy((void *)&min_alarm, (void *)&old_min_alarm, sizeof(T));
-				throw;
-			}
-		}
-	}
+            bool retry = true;
+            while (retry == true)
+            {
+                try
+                {
+                    tg->get_database()->delete_device_attribute_property(d_name, db_data);
+                    retry = false;
+                }
+                catch (CORBA::COMM_FAILURE &)
+                {
+                    tg->get_database()->reconnect(true);
+                }
+            }
+        }
+        else
+        {
+            try
+            {
+                upd_att_prop_db(min_alarm, "min_alarm");
+            }
+            catch (Tango::DevFailed &)
+            {
+                memcpy((void *) &min_alarm, (void *) &old_min_alarm, sizeof(T));
+                throw;
+            }
+        }
+    }
 
 //
 // Set the min_alarm flag
 //
 
-	alarm_conf.set(min_level);
+    alarm_conf.set(min_level);
 
 //
 // Store new alarm as a string
 //
 
-	min_alarm_str = min_alarm_tmp_str;
+    min_alarm_str = min_alarm_tmp_str;
 
 //
 // Push a att conf event
@@ -321,7 +322,7 @@ void Attribute::set_min_alarm(const T &new_min_alarm)
 // Delete device startup exception related to min_alarm if there is any
 //
 
-    delete_startup_exception("min_alarm",d_name);
+    delete_startup_exception("min_alarm", d_name);
 }
 
 //+------------------------------------------------------------------------------------------------------------------
@@ -340,36 +341,38 @@ void Attribute::set_min_alarm(const T &new_min_alarm)
 //
 //-------------------------------------------------------------------------------------------------------------------
 
-template <typename T>
+template<typename T>
 void Attribute::get_min_alarm(T &min_al)
 {
-	if (!(data_type == DEV_ENCODED && ranges_type2const<T>::enu == DEV_UCHAR) &&
-		(data_type != ranges_type2const<T>::enu))
-	{
-		string err_msg = "Attribute (" + name + ") data type does not match the type provided : " + ranges_type2const<T>::str;
-		Except::throw_exception((const char *)API_IncompatibleAttrDataType,
-					  (const char *)err_msg.c_str(),
-					  (const char *)"Attribute::get_min_alarm()");
-	}
-	else if((data_type == Tango::DEV_STRING) ||
-		(data_type == Tango::DEV_BOOLEAN) ||
-		(data_type == Tango::DEV_STATE) ||
-		(data_type == Tango::DEV_ENUM))
-	{
-		string err_msg = "Minimum alarm has no meaning for the attribute's (" + name + ") data type : " + ranges_type2const<T>::str;
-		Except::throw_exception((const char *)API_AttrOptProp,
-				      err_msg.c_str(),
-				      (const char *)"Attribute::get_min_alarm()");
-	}
+    if (!(data_type == DEV_ENCODED && ranges_type2const<T>::enu == DEV_UCHAR) &&
+        (data_type != ranges_type2const<T>::enu))
+    {
+        string err_msg =
+            "Attribute (" + name + ") data type does not match the type provided : " + ranges_type2const<T>::str;
+        Except::throw_exception((const char *) API_IncompatibleAttrDataType,
+                                (const char *) err_msg.c_str(),
+                                (const char *) "Attribute::get_min_alarm()");
+    }
+    else if ((data_type == Tango::DEV_STRING) ||
+        (data_type == Tango::DEV_BOOLEAN) ||
+        (data_type == Tango::DEV_STATE) ||
+        (data_type == Tango::DEV_ENUM))
+    {
+        string err_msg =
+            "Minimum alarm has no meaning for the attribute's (" + name + ") data type : " + ranges_type2const<T>::str;
+        Except::throw_exception((const char *) API_AttrOptProp,
+                                err_msg.c_str(),
+                                (const char *) "Attribute::get_min_alarm()");
+    }
 
-	if (!alarm_conf[min_level])
-	{
-		Except::throw_exception((const char *)API_AttrNotAllowed,
-					(const char *)"Minimum alarm not defined for this attribute",
-					(const char *)"Attribute::get_min_alarm()");
-	}
+    if (!alarm_conf[min_level])
+    {
+        Except::throw_exception((const char *) API_AttrNotAllowed,
+                                (const char *) "Minimum alarm not defined for this attribute",
+                                (const char *) "Attribute::get_min_alarm()");
+    }
 
-	memcpy((void *)&min_al,(void *)&min_alarm,sizeof(T));
+    memcpy((void *) &min_al, (void *) &min_alarm, sizeof(T));
 }
 
 //+-----------------------------------------------------------------------------------------------------------------
@@ -387,7 +390,7 @@ void Attribute::get_min_alarm(T &min_al)
 //
 //------------------------------------------------------------------------------------------------------------------
 
-template <typename T>
+template<typename T>
 void Attribute::set_max_alarm(const T &new_max_alarm)
 {
 
@@ -395,141 +398,142 @@ void Attribute::set_max_alarm(const T &new_max_alarm)
 // Check type validity
 //
 
-	if((data_type == Tango::DEV_STRING) ||
-		(data_type == Tango::DEV_BOOLEAN) ||
-		(data_type == Tango::DEV_STATE) ||
-		(data_type == Tango::DEV_ENUM))
-		throw_err_data_type("max_alarm",d_name,"Attribute::set_max_alarm()");
+    if ((data_type == Tango::DEV_STRING) ||
+        (data_type == Tango::DEV_BOOLEAN) ||
+        (data_type == Tango::DEV_STATE) ||
+        (data_type == Tango::DEV_ENUM))
+        throw_err_data_type("max_alarm", d_name, "Attribute::set_max_alarm()");
 
-	else if (!(data_type == DEV_ENCODED && ranges_type2const<T>::enu == DEV_UCHAR) &&
-		(data_type != ranges_type2const<T>::enu))
-	{
-		string err_msg = "Attribute (" + name + ") data type does not match the type provided : " + ranges_type2const<T>::str;
-		Except::throw_exception((const char *)API_IncompatibleAttrDataType,
-					  (const char *)err_msg.c_str(),
-					  (const char *)"Attribute::set_max_alarm()");
-	}
+    else if (!(data_type == DEV_ENCODED && ranges_type2const<T>::enu == DEV_UCHAR) &&
+        (data_type != ranges_type2const<T>::enu))
+    {
+        string err_msg =
+            "Attribute (" + name + ") data type does not match the type provided : " + ranges_type2const<T>::str;
+        Except::throw_exception((const char *) API_IncompatibleAttrDataType,
+                                (const char *) err_msg.c_str(),
+                                (const char *) "Attribute::set_max_alarm()");
+    }
 
 //
 //	Check coherence with min_alarm
 //
 
-	if(alarm_conf.test(min_level))
-	{
-		T min_alarm_tmp;
-		memcpy((void *) &min_alarm_tmp, (const void *) &min_alarm, sizeof(T));
-		if(new_max_alarm <= min_alarm_tmp)
-			throw_incoherent_val_err("min_alarm","max_alarm",d_name,"Attribute::set_max_alarm()");
-	}
+    if (alarm_conf.test(min_level))
+    {
+        T min_alarm_tmp;
+        memcpy((void *) &min_alarm_tmp, (const void *) &min_alarm, sizeof(T));
+        if (new_max_alarm <= min_alarm_tmp)
+            throw_incoherent_val_err("min_alarm", "max_alarm", d_name, "Attribute::set_max_alarm()");
+    }
 
 //
 // Store new max alarm as a string
 //
 
-	TangoSys_MemStream str;
-	str.precision(TANGO_FLOAT_PRECISION);
-	if(ranges_type2const<T>::enu == Tango::DEV_UCHAR)
-		str << (short)new_max_alarm; // to represent the numeric value
-	else
-		str << new_max_alarm;
-	string max_alarm_tmp_str;
-	max_alarm_tmp_str = str.str();
+    TangoSys_MemStream str;
+    str.precision(TANGO_FLOAT_PRECISION);
+    if (ranges_type2const<T>::enu == Tango::DEV_UCHAR)
+        str << (short) new_max_alarm; // to represent the numeric value
+    else
+        str << new_max_alarm;
+    string max_alarm_tmp_str;
+    max_alarm_tmp_str = str.str();
 
 //
 // Get the monitor protecting device att config
 // If the server is in its starting phase, give a NULL ptr to the AutoLock object
 //
 
-	Tango::Util *tg = Tango::Util::instance();
-	Tango::TangoMonitor *mon_ptr = NULL;
-	if (tg->is_svr_starting() == false && tg->is_device_restarting(d_name) == false)
-		mon_ptr = &(get_att_device()->get_att_conf_monitor());
-	AutoTangoMonitor sync1(mon_ptr);
+    Tango::Util *tg = Tango::Util::instance();
+    Tango::TangoMonitor *mon_ptr = NULL;
+    if (tg->is_svr_starting() == false && tg->is_device_restarting(d_name) == false)
+        mon_ptr = &(get_att_device()->get_att_conf_monitor());
+    AutoTangoMonitor sync1(mon_ptr);
 
 //
 // Store the new alarm locally
 //
 
-	Attr_CheckVal old_max_alarm;
-	memcpy((void *)&old_max_alarm, (void *)&max_alarm, sizeof(T));
-	memcpy((void *)&max_alarm, (void *)&new_max_alarm, sizeof(T));
+    Attr_CheckVal old_max_alarm;
+    memcpy((void *) &old_max_alarm, (void *) &max_alarm, sizeof(T));
+    memcpy((void *) &max_alarm, (void *) &new_max_alarm, sizeof(T));
 
 //
 // Then, update database
 //
 
-	Tango::DeviceClass *dev_class = get_att_device_class(d_name);
-	Tango::MultiClassAttribute *mca = dev_class->get_class_attr();
-	Tango::Attr &att = mca->get_attr(name);
-	vector<AttrProperty> &def_user_prop = att.get_user_default_properties();
-	size_t nb_user = def_user_prop.size();
+    Tango::DeviceClass *dev_class = get_att_device_class(d_name);
+    Tango::MultiClassAttribute *mca = dev_class->get_class_attr();
+    Tango::Attr &att = mca->get_attr(name);
+    vector<AttrProperty> &def_user_prop = att.get_user_default_properties();
+    size_t nb_user = def_user_prop.size();
 
-	string usr_def_val;
-	bool user_defaults = false;
-	if (nb_user != 0)
-	{
-		size_t i;
-		for (i = 0;i < nb_user;i++)
-		{
-			if (def_user_prop[i].get_name() == "max_alarm")
-				break;
-		}
-		if (i != nb_user) // user defaults defined
-		{
-			user_defaults = true;
-			usr_def_val = def_user_prop[i].get_value();
-		}
-	}
+    string usr_def_val;
+    bool user_defaults = false;
+    if (nb_user != 0)
+    {
+        size_t i;
+        for (i = 0; i < nb_user; i++)
+        {
+            if (def_user_prop[i].get_name() == "max_alarm")
+                break;
+        }
+        if (i != nb_user) // user defaults defined
+        {
+            user_defaults = true;
+            usr_def_val = def_user_prop[i].get_value();
+        }
+    }
 
 
-	if (Tango::Util::_UseDb == true)
-	{
-		if(user_defaults && max_alarm_tmp_str == usr_def_val)
-		{
-			DbDatum attr_dd(name), prop_dd("max_alarm");
-			DbData db_data;
-			db_data.push_back(attr_dd);
-			db_data.push_back(prop_dd);
+    if (Tango::Util::_UseDb == true)
+    {
+        if (user_defaults && max_alarm_tmp_str == usr_def_val)
+        {
+            DbDatum attr_dd(name), prop_dd("max_alarm");
+            DbData db_data;
+            db_data.push_back(attr_dd);
+            db_data.push_back(prop_dd);
 
-			bool retry = true;
-			while (retry == true)
-			{
-				try
-				{
-					tg->get_database()->delete_device_attribute_property(d_name,db_data);
-					retry = false;
-				}
-				catch (CORBA::COMM_FAILURE &)
-				{
-					tg->get_database()->reconnect(true);
-				}
-			}
-		}
-		else
-		{
-			try
-			{
-				upd_att_prop_db(max_alarm,"max_alarm");
-			}
-			catch (Tango::DevFailed &)
-			{
-				memcpy((void *)&max_alarm, (void *)&old_max_alarm, sizeof(T));
-				throw;
-			}
-		}
-	}
+            bool retry = true;
+            while (retry == true)
+            {
+                try
+                {
+                    tg->get_database()->delete_device_attribute_property(d_name, db_data);
+                    retry = false;
+                }
+                catch (CORBA::COMM_FAILURE &)
+                {
+                    tg->get_database()->reconnect(true);
+                }
+            }
+        }
+        else
+        {
+            try
+            {
+                upd_att_prop_db(max_alarm, "max_alarm");
+            }
+            catch (Tango::DevFailed &)
+            {
+                memcpy((void *) &max_alarm, (void *) &old_max_alarm, sizeof(T));
+                throw;
+            }
+        }
+    }
 
 //
 // Set the max_alarm flag
 //
 
-	alarm_conf.set(max_level);
+    alarm_conf.set(max_level);
 
 //
 // Store new alarm as a string
 //
 
-	max_alarm_str = max_alarm_tmp_str;
+    max_alarm_str = max_alarm_tmp_str;
 
 //
 // Push a att conf event
@@ -542,7 +546,7 @@ void Attribute::set_max_alarm(const T &new_max_alarm)
 // Delete device startup exception related to max_alarm if there is any
 //
 
-	delete_startup_exception("max_alarm",d_name);
+    delete_startup_exception("max_alarm", d_name);
 }
 
 
@@ -562,30 +566,34 @@ void Attribute::set_max_alarm(const T &new_max_alarm)
 //
 //-------------------------------------------------------------------------------------------------------------------
 
-template <typename T>
+template<typename T>
 void Attribute::get_max_alarm(T &max_al)
 {
-	if (!(data_type == DEV_ENCODED && ranges_type2const<T>::enu == DEV_UCHAR) &&
-		(data_type != ranges_type2const<T>::enu))
-	{
-		string err_msg = "Attribute (" + name + ") data type does not match the type provided : " + ranges_type2const<T>::str;
-		Except::throw_exception(API_IncompatibleAttrDataType,err_msg.c_str(),"Attribute::get_max_alarm()");
-	}
-	else if((data_type == Tango::DEV_STRING) ||
-		(data_type == Tango::DEV_BOOLEAN) ||
-		(data_type == Tango::DEV_STATE) ||
-		(data_type == Tango::DEV_ENUM))
-	{
-		string err_msg = "Maximum alarm has no meaning for the attribute's (" + name + ") data type : " + ranges_type2const<T>::str;
-		Except::throw_exception(API_AttrOptProp,err_msg.c_str(),"Attribute::get_max_alarm()");
-	}
+    if (!(data_type == DEV_ENCODED && ranges_type2const<T>::enu == DEV_UCHAR) &&
+        (data_type != ranges_type2const<T>::enu))
+    {
+        string err_msg =
+            "Attribute (" + name + ") data type does not match the type provided : " + ranges_type2const<T>::str;
+        Except::throw_exception(API_IncompatibleAttrDataType, err_msg.c_str(), "Attribute::get_max_alarm()");
+    }
+    else if ((data_type == Tango::DEV_STRING) ||
+        (data_type == Tango::DEV_BOOLEAN) ||
+        (data_type == Tango::DEV_STATE) ||
+        (data_type == Tango::DEV_ENUM))
+    {
+        string err_msg =
+            "Maximum alarm has no meaning for the attribute's (" + name + ") data type : " + ranges_type2const<T>::str;
+        Except::throw_exception(API_AttrOptProp, err_msg.c_str(), "Attribute::get_max_alarm()");
+    }
 
-	if (!alarm_conf[max_level])
-	{
-		Except::throw_exception(API_AttrNotAllowed,"Maximum alarm not defined for this attribute","Attribute::get_max_alarm()");
-	}
+    if (!alarm_conf[max_level])
+    {
+        Except::throw_exception(API_AttrNotAllowed,
+                                "Maximum alarm not defined for this attribute",
+                                "Attribute::get_max_alarm()");
+    }
 
-	memcpy((void *)&max_al,(void *)&max_alarm,sizeof(T));
+    memcpy((void *) &max_al, (void *) &max_alarm, sizeof(T));
 }
 
 //+------------------------------------------------------------------------------------------------------------------
@@ -603,7 +611,7 @@ void Attribute::get_max_alarm(T &max_al)
 //
 //-------------------------------------------------------------------------------------------------------------------
 
-template <typename T>
+template<typename T>
 void Attribute::set_min_warning(const T &new_min_warning)
 {
 
@@ -611,153 +619,154 @@ void Attribute::set_min_warning(const T &new_min_warning)
 // Check type validity
 //
 
-	if((data_type == Tango::DEV_STRING) ||
-		(data_type == Tango::DEV_BOOLEAN) ||
-		(data_type == Tango::DEV_STATE) ||
-		(data_type == Tango::DEV_ENUM))
-		throw_err_data_type("min_warning",d_name,"Attribute::set_min_warning()");
+    if ((data_type == Tango::DEV_STRING) ||
+        (data_type == Tango::DEV_BOOLEAN) ||
+        (data_type == Tango::DEV_STATE) ||
+        (data_type == Tango::DEV_ENUM))
+        throw_err_data_type("min_warning", d_name, "Attribute::set_min_warning()");
 
-	else if (!(data_type == DEV_ENCODED &&
-			 ranges_type2const<T>::enu == DEV_UCHAR) &&
-			 (data_type != ranges_type2const<T>::enu))
-	{
-		string err_msg = "Attribute (" + name + ") data type does not match the type provided : " + ranges_type2const<T>::str;
-		Except::throw_exception(API_IncompatibleAttrDataType,err_msg.c_str(),"Attribute::set_min_warning()");
-	}
+    else if (!(data_type == DEV_ENCODED &&
+        ranges_type2const<T>::enu == DEV_UCHAR) &&
+        (data_type != ranges_type2const<T>::enu))
+    {
+        string err_msg =
+            "Attribute (" + name + ") data type does not match the type provided : " + ranges_type2const<T>::str;
+        Except::throw_exception(API_IncompatibleAttrDataType, err_msg.c_str(), "Attribute::set_min_warning()");
+    }
 
 //
 //	Check coherence with max_warning
 //
 
-	if(alarm_conf.test(max_warn))
-	{
-		T max_warning_tmp;
-		memcpy((void *) &max_warning_tmp, (const void *) &max_warning, sizeof(T));
-		if(new_min_warning >= max_warning_tmp)
-			throw_incoherent_val_err("min_warning","max_warning",d_name,"Attribute::set_min_warning()");
-	}
+    if (alarm_conf.test(max_warn))
+    {
+        T max_warning_tmp;
+        memcpy((void *) &max_warning_tmp, (const void *) &max_warning, sizeof(T));
+        if (new_min_warning >= max_warning_tmp)
+            throw_incoherent_val_err("min_warning", "max_warning", d_name, "Attribute::set_min_warning()");
+    }
 
 //
 // Store new min warning as a string
 //
 
-	TangoSys_MemStream str;
-	str.precision(TANGO_FLOAT_PRECISION);
-	if(ranges_type2const<T>::enu == Tango::DEV_UCHAR)
-		str << (short)new_min_warning; // to represent the numeric value
-	else
-		str << new_min_warning;
-	string min_warning_tmp_str;
-	min_warning_tmp_str = str.str();
+    TangoSys_MemStream str;
+    str.precision(TANGO_FLOAT_PRECISION);
+    if (ranges_type2const<T>::enu == Tango::DEV_UCHAR)
+        str << (short) new_min_warning; // to represent the numeric value
+    else
+        str << new_min_warning;
+    string min_warning_tmp_str;
+    min_warning_tmp_str = str.str();
 
 //
 // Get the monitor protecting device att config
 // If the server is in its starting phase, give a NULL ptr to the AutoLock object
 //
 
-	Tango::Util *tg = Tango::Util::instance();
-	Tango::TangoMonitor *mon_ptr = NULL;
-	if (tg->is_svr_starting() == false && tg->is_device_restarting(d_name) == false)
-		mon_ptr = &(get_att_device()->get_att_conf_monitor());
-	AutoTangoMonitor sync1(mon_ptr);
+    Tango::Util *tg = Tango::Util::instance();
+    Tango::TangoMonitor *mon_ptr = NULL;
+    if (tg->is_svr_starting() == false && tg->is_device_restarting(d_name) == false)
+        mon_ptr = &(get_att_device()->get_att_conf_monitor());
+    AutoTangoMonitor sync1(mon_ptr);
 
 //
 // Store the new warning locally
 //
 
-	Attr_CheckVal old_min_warning;
-	memcpy((void *)&old_min_warning, (void *)&min_warning, sizeof(T));
-	memcpy((void *)&min_warning, (void *)&new_min_warning, sizeof(T));
+    Attr_CheckVal old_min_warning;
+    memcpy((void *) &old_min_warning, (void *) &min_warning, sizeof(T));
+    memcpy((void *) &min_warning, (void *) &new_min_warning, sizeof(T));
 
 //
 // Then, update database
 //
 
-	Tango::DeviceClass *dev_class = get_att_device_class(d_name);
-	Tango::MultiClassAttribute *mca = dev_class->get_class_attr();
-	Tango::Attr &att = mca->get_attr(name);
-	vector<AttrProperty> &def_user_prop = att.get_user_default_properties();
-	size_t nb_user = def_user_prop.size();
+    Tango::DeviceClass *dev_class = get_att_device_class(d_name);
+    Tango::MultiClassAttribute *mca = dev_class->get_class_attr();
+    Tango::Attr &att = mca->get_attr(name);
+    vector<AttrProperty> &def_user_prop = att.get_user_default_properties();
+    size_t nb_user = def_user_prop.size();
 
-	string usr_def_val;
-	bool user_defaults = false;
-	if (nb_user != 0)
-	{
-		size_t i;
-		for (i = 0;i < nb_user;i++)
-		{
-			if (def_user_prop[i].get_name() == "min_warning")
-				break;
-		}
-		if (i != nb_user) // user defaults defined
-		{
-			user_defaults = true;
-			usr_def_val = def_user_prop[i].get_value();
-		}
-	}
+    string usr_def_val;
+    bool user_defaults = false;
+    if (nb_user != 0)
+    {
+        size_t i;
+        for (i = 0; i < nb_user; i++)
+        {
+            if (def_user_prop[i].get_name() == "min_warning")
+                break;
+        }
+        if (i != nb_user) // user defaults defined
+        {
+            user_defaults = true;
+            usr_def_val = def_user_prop[i].get_value();
+        }
+    }
 
 
-	if (Tango::Util::_UseDb == true)
-	{
-		if(user_defaults && min_warning_tmp_str == usr_def_val)
-		{
-			DbDatum attr_dd(name), prop_dd("min_warning");
-			DbData db_data;
-			db_data.push_back(attr_dd);
-			db_data.push_back(prop_dd);
+    if (Tango::Util::_UseDb == true)
+    {
+        if (user_defaults && min_warning_tmp_str == usr_def_val)
+        {
+            DbDatum attr_dd(name), prop_dd("min_warning");
+            DbData db_data;
+            db_data.push_back(attr_dd);
+            db_data.push_back(prop_dd);
 
-			bool retry = true;
-			while (retry == true)
-			{
-				try
-				{
-					tg->get_database()->delete_device_attribute_property(d_name,db_data);
-					retry = false;
-				}
-				catch (CORBA::COMM_FAILURE &)
-				{
-					tg->get_database()->reconnect(true);
-				}
-			}
-		}
-		else
-		{
-			try
-			{
-				upd_att_prop_db(min_warning,"min_warning");
-			}
-			catch (Tango::DevFailed &)
-			{
-				memcpy((void *)&min_warning, (void *)&old_min_warning, sizeof(T));
-				throw;
-			}
-		}
-	}
+            bool retry = true;
+            while (retry == true)
+            {
+                try
+                {
+                    tg->get_database()->delete_device_attribute_property(d_name, db_data);
+                    retry = false;
+                }
+                catch (CORBA::COMM_FAILURE &)
+                {
+                    tg->get_database()->reconnect(true);
+                }
+            }
+        }
+        else
+        {
+            try
+            {
+                upd_att_prop_db(min_warning, "min_warning");
+            }
+            catch (Tango::DevFailed &)
+            {
+                memcpy((void *) &min_warning, (void *) &old_min_warning, sizeof(T));
+                throw;
+            }
+        }
+    }
 
 //
 // Set the min_warn flag
 //
 
-	alarm_conf.set(min_warn);
+    alarm_conf.set(min_warn);
 
 //
 // Store new warning as a string
 //
 
-	min_warning_str = min_warning_tmp_str;
+    min_warning_str = min_warning_tmp_str;
 
 //
 // Push a att conf event
 //
 
-	if (tg->is_svr_starting() == false && tg->is_device_restarting(d_name) == false)
-		get_att_device()->push_att_conf_event(this);
+    if (tg->is_svr_starting() == false && tg->is_device_restarting(d_name) == false)
+        get_att_device()->push_att_conf_event(this);
 
 //
 // Delete device startup exception related to min_warning if there is any
 //
 
-	delete_startup_exception("min_warning",d_name);
+    delete_startup_exception("min_warning", d_name);
 }
 
 
@@ -777,30 +786,34 @@ void Attribute::set_min_warning(const T &new_min_warning)
 //
 //-------------------------------------------------------------------------------------------------------------------
 
-template <typename T>
+template<typename T>
 void Attribute::get_min_warning(T &min_war)
 {
-	if (!(data_type == DEV_ENCODED && ranges_type2const<T>::enu == DEV_UCHAR) &&
-		(data_type != ranges_type2const<T>::enu))
-	{
-		string err_msg = "Attribute (" + name + ") data type does not match the type provided : " + ranges_type2const<T>::str;
-		Except::throw_exception(API_IncompatibleAttrDataType,err_msg.c_str(),"Attribute::get_min_warning()");
-	}
-	else if((data_type == Tango::DEV_STRING) ||
-		(data_type == Tango::DEV_BOOLEAN) ||
-		(data_type == Tango::DEV_STATE) ||
-		(data_type == Tango::DEV_ENUM))
-	{
-		string err_msg = "Minimum warning has no meaning for the attribute's (" + name + ") data type : " + ranges_type2const<T>::str;
-		Except::throw_exception(API_AttrOptProp,err_msg.c_str(),"Attribute::get_min_warning()");
-	}
+    if (!(data_type == DEV_ENCODED && ranges_type2const<T>::enu == DEV_UCHAR) &&
+        (data_type != ranges_type2const<T>::enu))
+    {
+        string err_msg =
+            "Attribute (" + name + ") data type does not match the type provided : " + ranges_type2const<T>::str;
+        Except::throw_exception(API_IncompatibleAttrDataType, err_msg.c_str(), "Attribute::get_min_warning()");
+    }
+    else if ((data_type == Tango::DEV_STRING) ||
+        (data_type == Tango::DEV_BOOLEAN) ||
+        (data_type == Tango::DEV_STATE) ||
+        (data_type == Tango::DEV_ENUM))
+    {
+        string err_msg = "Minimum warning has no meaning for the attribute's (" + name + ") data type : "
+            + ranges_type2const<T>::str;
+        Except::throw_exception(API_AttrOptProp, err_msg.c_str(), "Attribute::get_min_warning()");
+    }
 
-	if (!alarm_conf[min_warn])
-	{
-		Except::throw_exception(API_AttrNotAllowed,"Minimum warning not defined for this attribute","Attribute::get_min_warning()");
-	}
+    if (!alarm_conf[min_warn])
+    {
+        Except::throw_exception(API_AttrNotAllowed,
+                                "Minimum warning not defined for this attribute",
+                                "Attribute::get_min_warning()");
+    }
 
-	memcpy((void *)&min_war,(void *)&min_warning,sizeof(T));
+    memcpy((void *) &min_war, (void *) &min_warning, sizeof(T));
 }
 
 //+-----------------------------------------------------------------------------------------------------------------
@@ -818,7 +831,7 @@ void Attribute::get_min_warning(T &min_war)
 //
 //-----------------------------------------------------------------------------------------------------------------
 
-template <typename T>
+template<typename T>
 void Attribute::set_max_warning(const T &new_max_warning)
 {
 
@@ -826,152 +839,153 @@ void Attribute::set_max_warning(const T &new_max_warning)
 // Check type validity
 //
 
-	if((data_type == Tango::DEV_STRING) ||
-		(data_type == Tango::DEV_BOOLEAN) ||
-		(data_type == Tango::DEV_STATE) ||
-		(data_type == Tango::DEV_ENUM))
-		throw_err_data_type("max_warning",d_name,"Attribute::set_max_warning()");
+    if ((data_type == Tango::DEV_STRING) ||
+        (data_type == Tango::DEV_BOOLEAN) ||
+        (data_type == Tango::DEV_STATE) ||
+        (data_type == Tango::DEV_ENUM))
+        throw_err_data_type("max_warning", d_name, "Attribute::set_max_warning()");
 
-	else if (!(data_type == DEV_ENCODED && ranges_type2const<T>::enu == DEV_UCHAR) &&
-		(data_type != ranges_type2const<T>::enu))
-	{
-		string err_msg = "Attribute (" + name + ") data type does not match the type provided : " + ranges_type2const<T>::str;
-		Except::throw_exception(API_IncompatibleAttrDataType,err_msg.c_str(),"Attribute::set_max_warning()");
-	}
+    else if (!(data_type == DEV_ENCODED && ranges_type2const<T>::enu == DEV_UCHAR) &&
+        (data_type != ranges_type2const<T>::enu))
+    {
+        string err_msg =
+            "Attribute (" + name + ") data type does not match the type provided : " + ranges_type2const<T>::str;
+        Except::throw_exception(API_IncompatibleAttrDataType, err_msg.c_str(), "Attribute::set_max_warning()");
+    }
 
 //
 //	Check coherence with min_warning
 //
 
-	if(alarm_conf.test(min_warn))
-	{
-		T min_warning_tmp;
-		memcpy((void *) &min_warning_tmp, (const void *) &min_warning, sizeof(T));
-		if(new_max_warning <= min_warning_tmp)
-			throw_incoherent_val_err("min_warning","max_warning",d_name,"Attribute::set_max_warning()");
-	}
+    if (alarm_conf.test(min_warn))
+    {
+        T min_warning_tmp;
+        memcpy((void *) &min_warning_tmp, (const void *) &min_warning, sizeof(T));
+        if (new_max_warning <= min_warning_tmp)
+            throw_incoherent_val_err("min_warning", "max_warning", d_name, "Attribute::set_max_warning()");
+    }
 
 //
 // Store new max warning as a string
 //
 
-	TangoSys_MemStream str;
-	str.precision(TANGO_FLOAT_PRECISION);
-	if(ranges_type2const<T>::enu == Tango::DEV_UCHAR)
-		str << (short)new_max_warning; // to represent the numeric value
-	else
-		str << new_max_warning;
-	string max_warning_tmp_str;
-	max_warning_tmp_str = str.str();
+    TangoSys_MemStream str;
+    str.precision(TANGO_FLOAT_PRECISION);
+    if (ranges_type2const<T>::enu == Tango::DEV_UCHAR)
+        str << (short) new_max_warning; // to represent the numeric value
+    else
+        str << new_max_warning;
+    string max_warning_tmp_str;
+    max_warning_tmp_str = str.str();
 
 //
 // Get the monitor protecting device att config
 // If the server is in its starting phase, give a NULL ptr to the AutoLock object
 //
 
-	Tango::Util *tg = Tango::Util::instance();
-	Tango::TangoMonitor *mon_ptr = NULL;
-	if (tg->is_svr_starting() == false && tg->is_device_restarting(d_name) == false)
-		mon_ptr = &(get_att_device()->get_att_conf_monitor());
-	AutoTangoMonitor sync1(mon_ptr);
+    Tango::Util *tg = Tango::Util::instance();
+    Tango::TangoMonitor *mon_ptr = NULL;
+    if (tg->is_svr_starting() == false && tg->is_device_restarting(d_name) == false)
+        mon_ptr = &(get_att_device()->get_att_conf_monitor());
+    AutoTangoMonitor sync1(mon_ptr);
 
 //
 // Store the new warning locally
 //
 
-	Attr_CheckVal old_max_warning;
-	memcpy((void *)&old_max_warning, (void *)&max_warning, sizeof(T));
-	memcpy((void *)&max_warning, (void *)&new_max_warning, sizeof(T));
+    Attr_CheckVal old_max_warning;
+    memcpy((void *) &old_max_warning, (void *) &max_warning, sizeof(T));
+    memcpy((void *) &max_warning, (void *) &new_max_warning, sizeof(T));
 
 //
 // Then, update database
 //
 
-	Tango::DeviceClass *dev_class = get_att_device_class(d_name);
-	Tango::MultiClassAttribute *mca = dev_class->get_class_attr();
-	Tango::Attr &att = mca->get_attr(name);
-	vector<AttrProperty> &def_user_prop = att.get_user_default_properties();
-	size_t nb_user = def_user_prop.size();
+    Tango::DeviceClass *dev_class = get_att_device_class(d_name);
+    Tango::MultiClassAttribute *mca = dev_class->get_class_attr();
+    Tango::Attr &att = mca->get_attr(name);
+    vector<AttrProperty> &def_user_prop = att.get_user_default_properties();
+    size_t nb_user = def_user_prop.size();
 
-	string usr_def_val;
-	bool user_defaults = false;
-	if (nb_user != 0)
-	{
-		size_t i;
-		for (i = 0;i < nb_user;i++)
-		{
-			if (def_user_prop[i].get_name() == "max_warning")
-				break;
-		}
-		if (i != nb_user) // user defaults defined
-		{
-			user_defaults = true;
-			usr_def_val = def_user_prop[i].get_value();
-		}
-	}
+    string usr_def_val;
+    bool user_defaults = false;
+    if (nb_user != 0)
+    {
+        size_t i;
+        for (i = 0; i < nb_user; i++)
+        {
+            if (def_user_prop[i].get_name() == "max_warning")
+                break;
+        }
+        if (i != nb_user) // user defaults defined
+        {
+            user_defaults = true;
+            usr_def_val = def_user_prop[i].get_value();
+        }
+    }
 
 
-	if (Tango::Util::_UseDb == true)
-	{
-		if(user_defaults && max_warning_tmp_str == usr_def_val)
-		{
-			DbDatum attr_dd(name), prop_dd("max_warning");
-			DbData db_data;
-			db_data.push_back(attr_dd);
-			db_data.push_back(prop_dd);
+    if (Tango::Util::_UseDb == true)
+    {
+        if (user_defaults && max_warning_tmp_str == usr_def_val)
+        {
+            DbDatum attr_dd(name), prop_dd("max_warning");
+            DbData db_data;
+            db_data.push_back(attr_dd);
+            db_data.push_back(prop_dd);
 
-			bool retry = true;
-			while (retry == true)
-			{
-				try
-				{
-					tg->get_database()->delete_device_attribute_property(d_name,db_data);
-					retry = false;
-				}
-				catch (CORBA::COMM_FAILURE &)
-				{
-					tg->get_database()->reconnect(true);
-				}
-			}
-		}
-		else
-		{
-			try
-			{
-				upd_att_prop_db(max_warning,"max_warning");
-			}
-			catch (Tango::DevFailed &)
-			{
-				memcpy((void *)&max_warning, (void *)&old_max_warning, sizeof(T));
-				throw;
-			}
-		}
-	}
+            bool retry = true;
+            while (retry == true)
+            {
+                try
+                {
+                    tg->get_database()->delete_device_attribute_property(d_name, db_data);
+                    retry = false;
+                }
+                catch (CORBA::COMM_FAILURE &)
+                {
+                    tg->get_database()->reconnect(true);
+                }
+            }
+        }
+        else
+        {
+            try
+            {
+                upd_att_prop_db(max_warning, "max_warning");
+            }
+            catch (Tango::DevFailed &)
+            {
+                memcpy((void *) &max_warning, (void *) &old_max_warning, sizeof(T));
+                throw;
+            }
+        }
+    }
 
 //
 // Set the max_warn flag
 //
 
-	alarm_conf.set(max_warn);
+    alarm_conf.set(max_warn);
 
 //
 // Store new warning as a string
 //
 
-	max_warning_str = max_warning_tmp_str;
+    max_warning_str = max_warning_tmp_str;
 
 //
 // Push a att conf event
 //
 
-	if (tg->is_svr_starting() == false && tg->is_device_restarting(d_name) == false)
-		get_att_device()->push_att_conf_event(this);
+    if (tg->is_svr_starting() == false && tg->is_device_restarting(d_name) == false)
+        get_att_device()->push_att_conf_event(this);
 
 //
 // Delete device startup exception related to max_warning if there is any
 //
 
-	delete_startup_exception("max_warning",d_name);
+    delete_startup_exception("max_warning", d_name);
 }
 
 //+------------------------------------------------------------------------------------------------------------------
@@ -990,30 +1004,34 @@ void Attribute::set_max_warning(const T &new_max_warning)
 //
 //-------------------------------------------------------------------------------------------------------------------
 
-template <typename T>
+template<typename T>
 void Attribute::get_max_warning(T &max_war)
 {
-	if (!(data_type == DEV_ENCODED && ranges_type2const<T>::enu == DEV_UCHAR) &&
-		(data_type != ranges_type2const<T>::enu))
-	{
-		string err_msg = "Attribute (" + name + ") data type does not match the type provided : " + ranges_type2const<T>::str;
-		Except::throw_exception(API_IncompatibleAttrDataType,err_msg.c_str(),"Attribute::get_max_warning()");
-	}
-	else if((data_type == Tango::DEV_STRING) ||
-		(data_type == Tango::DEV_BOOLEAN) ||
-		(data_type == Tango::DEV_STATE) ||
-		(data_type == Tango::DEV_ENUM))
-	{
-		string err_msg = "Maximum warning has no meaning for the attribute's (" + name + ") data type : " + ranges_type2const<T>::str;
-		Except::throw_exception(API_AttrOptProp,err_msg.c_str(),"Attribute::get_max_warning()");
-	}
+    if (!(data_type == DEV_ENCODED && ranges_type2const<T>::enu == DEV_UCHAR) &&
+        (data_type != ranges_type2const<T>::enu))
+    {
+        string err_msg =
+            "Attribute (" + name + ") data type does not match the type provided : " + ranges_type2const<T>::str;
+        Except::throw_exception(API_IncompatibleAttrDataType, err_msg.c_str(), "Attribute::get_max_warning()");
+    }
+    else if ((data_type == Tango::DEV_STRING) ||
+        (data_type == Tango::DEV_BOOLEAN) ||
+        (data_type == Tango::DEV_STATE) ||
+        (data_type == Tango::DEV_ENUM))
+    {
+        string err_msg = "Maximum warning has no meaning for the attribute's (" + name + ") data type : "
+            + ranges_type2const<T>::str;
+        Except::throw_exception(API_AttrOptProp, err_msg.c_str(), "Attribute::get_max_warning()");
+    }
 
-	if (!alarm_conf[max_warn])
-	{
-		Except::throw_exception(API_AttrNotAllowed,"Maximum warning not defined for this attribute","Attribute::get_max_warning()");
-	}
+    if (!alarm_conf[max_warn])
+    {
+        Except::throw_exception(API_AttrNotAllowed,
+                                "Maximum warning not defined for this attribute",
+                                "Attribute::get_max_warning()");
+    }
 
-	memcpy((void *)&max_war,(void *)&max_warning,sizeof(T));
+    memcpy((void *) &max_war, (void *) &max_warning, sizeof(T));
 }
 
 //+------------------------------------------------------------------------------------------------------------------
@@ -1030,7 +1048,7 @@ void Attribute::get_max_warning(T &max_war)
 //
 //-------------------------------------------------------------------------------------------------------------------
 
-template <typename T>
+template<typename T>
 void Attribute::get_properties(Tango::MultiAttrProp<T> &props)
 {
 
@@ -1038,13 +1056,14 @@ void Attribute::get_properties(Tango::MultiAttrProp<T> &props)
 // Check data type
 //
 
-	if (!(data_type == DEV_ENCODED && ranges_type2const<T>::enu == DEV_UCHAR) &&
-		!(data_type == DEV_ENUM && ranges_type2const<T>::enu == DEV_SHORT) &&
-		(data_type != ranges_type2const<T>::enu))
-	{
-		string err_msg = "Attribute (" + name + ") data type does not match the type provided : " + ranges_type2const<T>::str;
-		Except::throw_exception(API_IncompatibleAttrDataType,err_msg.c_str(),"Attribute::get_properties()");
-	}
+    if (!(data_type == DEV_ENCODED && ranges_type2const<T>::enu == DEV_UCHAR) &&
+        !(data_type == DEV_ENUM && ranges_type2const<T>::enu == DEV_SHORT) &&
+        (data_type != ranges_type2const<T>::enu))
+    {
+        string err_msg =
+            "Attribute (" + name + ") data type does not match the type provided : " + ranges_type2const<T>::str;
+        Except::throw_exception(API_IncompatibleAttrDataType, err_msg.c_str(), "Attribute::get_properties()");
+    }
 
 //
 // Get the monitor protecting device att config
@@ -1055,32 +1074,32 @@ void Attribute::get_properties(Tango::MultiAttrProp<T> &props)
     Tango::TangoMonitor *mon_ptr = NULL;
     if (tg->is_svr_starting() == false && tg->is_device_restarting(d_name) == false)
         mon_ptr = &(get_att_device()->get_att_conf_monitor());
-	AutoTangoMonitor sync1(mon_ptr);
+    AutoTangoMonitor sync1(mon_ptr);
 
-	AttributeConfig_5 conf;
-	get_properties(conf);
+    AttributeConfig_5 conf;
+    get_properties(conf);
 
-	props.label = conf.label;
-	props.description = conf.description;
-	props.unit = conf.unit;
-	props.standard_unit = conf.standard_unit;
-	props.display_unit = conf.display_unit;
-	props.format = conf.format;
-	props.min_alarm = conf.att_alarm.min_alarm;
-	props.max_alarm = conf.att_alarm.max_alarm;
-	props.min_value = conf.min_value;
-	props.max_value = conf.max_value;
-	props.min_warning = conf.att_alarm.min_warning;
-	props.max_warning = conf.att_alarm.max_warning;
-	props.delta_t = conf.att_alarm.delta_t;
-	props.delta_val = conf.att_alarm.delta_val;
-	props.event_period = conf.event_prop.per_event.period;
-	props.archive_period = conf.event_prop.arch_event.period;
-	props.rel_change = conf.event_prop.ch_event.rel_change;
-	props.abs_change = conf.event_prop.ch_event.abs_change;
-	props.archive_rel_change = conf.event_prop.arch_event.rel_change;
-	props.archive_abs_change = conf.event_prop.arch_event.abs_change;
-	props.enum_labels = enum_labels;
+    props.label = conf.label;
+    props.description = conf.description;
+    props.unit = conf.unit;
+    props.standard_unit = conf.standard_unit;
+    props.display_unit = conf.display_unit;
+    props.format = conf.format;
+    props.min_alarm = conf.att_alarm.min_alarm;
+    props.max_alarm = conf.att_alarm.max_alarm;
+    props.min_value = conf.min_value;
+    props.max_value = conf.max_value;
+    props.min_warning = conf.att_alarm.min_warning;
+    props.max_warning = conf.att_alarm.max_warning;
+    props.delta_t = conf.att_alarm.delta_t;
+    props.delta_val = conf.att_alarm.delta_val;
+    props.event_period = conf.event_prop.per_event.period;
+    props.archive_period = conf.event_prop.arch_event.period;
+    props.rel_change = conf.event_prop.ch_event.rel_change;
+    props.abs_change = conf.event_prop.ch_event.abs_change;
+    props.archive_rel_change = conf.event_prop.arch_event.rel_change;
+    props.archive_abs_change = conf.event_prop.arch_event.abs_change;
+    props.enum_labels = enum_labels;
 }
 
 //+------------------------------------------------------------------------------------------------------------------
@@ -1097,7 +1116,7 @@ void Attribute::get_properties(Tango::MultiAttrProp<T> &props)
 //
 //-------------------------------------------------------------------------------------------------------------------
 
-template <typename T>
+template<typename T>
 void Attribute::set_properties(Tango::MultiAttrProp<T> &props)
 {
 
@@ -1105,48 +1124,49 @@ void Attribute::set_properties(Tango::MultiAttrProp<T> &props)
 // Check data type
 //
 
-	if (!(data_type == DEV_ENCODED && ranges_type2const<T>::enu == DEV_UCHAR) &&
-		!(data_type == DEV_ENUM && ranges_type2const<T>::enu == DEV_SHORT) &&
-		(data_type != ranges_type2const<T>::enu))
-	{
-		string err_msg = "Attribute (" + name + ") data type does not match the type provided : " + ranges_type2const<T>::str;
-		Except::throw_exception(API_IncompatibleAttrDataType,err_msg.c_str(),"Attribute::set_properties()");
-	}
+    if (!(data_type == DEV_ENCODED && ranges_type2const<T>::enu == DEV_UCHAR) &&
+        !(data_type == DEV_ENUM && ranges_type2const<T>::enu == DEV_SHORT) &&
+        (data_type != ranges_type2const<T>::enu))
+    {
+        string err_msg =
+            "Attribute (" + name + ") data type does not match the type provided : " + ranges_type2const<T>::str;
+        Except::throw_exception(API_IncompatibleAttrDataType, err_msg.c_str(), "Attribute::set_properties()");
+    }
 
 //
 // Check if the user set values of properties which do not have any meaning for particular attribute data types
 //
 
-	if((data_type == Tango::DEV_STRING) ||
-		(data_type == Tango::DEV_BOOLEAN) ||
-		(data_type == Tango::DEV_STATE) ||
-		(data_type == Tango::DEV_ENUM))
-	{
-		if(TG_strcasecmp(props.min_alarm,AlrmValueNotSpec) != 0)
-			throw_err_data_type("min_alarm",d_name,"Attribute::set_properties()");
-		if(TG_strcasecmp(props.max_alarm,AlrmValueNotSpec) != 0)
-			throw_err_data_type("max_alarm",d_name,"Attribute::set_properties()");
-		if(TG_strcasecmp(props.min_value,AlrmValueNotSpec) != 0)
-			throw_err_data_type("min_value",d_name,"Attribute::set_properties()");
-		if(TG_strcasecmp(props.max_value,AlrmValueNotSpec) != 0)
-			throw_err_data_type("max_value",d_name,"Attribute::set_properties()");
-		if(TG_strcasecmp(props.min_warning,AlrmValueNotSpec) != 0)
-			throw_err_data_type("min_warning",d_name,"Attribute::set_properties()");
-		if(TG_strcasecmp(props.max_warning,AlrmValueNotSpec) != 0)
-			throw_err_data_type("max_warning",d_name,"Attribute::set_properties()");
-		if(TG_strcasecmp(props.delta_t,AlrmValueNotSpec) != 0)
-			throw_err_data_type("delta_t",d_name,"Attribute::set_properties()");
-		if(TG_strcasecmp(props.delta_val,AlrmValueNotSpec) != 0)
-			throw_err_data_type("delta_val",d_name,"Attribute::set_properties()");
-		if(TG_strcasecmp(props.rel_change,AlrmValueNotSpec) != 0)
-			throw_err_data_type("rel_change",d_name,"Attribute::set_properties()");
-		if(TG_strcasecmp(props.abs_change,AlrmValueNotSpec) != 0)
-			throw_err_data_type("abs_change",d_name,"Attribute::set_properties()");
-		if(TG_strcasecmp(props.archive_rel_change,AlrmValueNotSpec) != 0)
-			throw_err_data_type("archive_rel_change",d_name,"Attribute::set_properties()");
-		if(TG_strcasecmp(props.archive_abs_change,AlrmValueNotSpec) != 0)
-			throw_err_data_type("archive_abs_change",d_name,"Attribute::set_properties()");
-	}
+    if ((data_type == Tango::DEV_STRING) ||
+        (data_type == Tango::DEV_BOOLEAN) ||
+        (data_type == Tango::DEV_STATE) ||
+        (data_type == Tango::DEV_ENUM))
+    {
+        if (TG_strcasecmp(props.min_alarm, AlrmValueNotSpec) != 0)
+            throw_err_data_type("min_alarm", d_name, "Attribute::set_properties()");
+        if (TG_strcasecmp(props.max_alarm, AlrmValueNotSpec) != 0)
+            throw_err_data_type("max_alarm", d_name, "Attribute::set_properties()");
+        if (TG_strcasecmp(props.min_value, AlrmValueNotSpec) != 0)
+            throw_err_data_type("min_value", d_name, "Attribute::set_properties()");
+        if (TG_strcasecmp(props.max_value, AlrmValueNotSpec) != 0)
+            throw_err_data_type("max_value", d_name, "Attribute::set_properties()");
+        if (TG_strcasecmp(props.min_warning, AlrmValueNotSpec) != 0)
+            throw_err_data_type("min_warning", d_name, "Attribute::set_properties()");
+        if (TG_strcasecmp(props.max_warning, AlrmValueNotSpec) != 0)
+            throw_err_data_type("max_warning", d_name, "Attribute::set_properties()");
+        if (TG_strcasecmp(props.delta_t, AlrmValueNotSpec) != 0)
+            throw_err_data_type("delta_t", d_name, "Attribute::set_properties()");
+        if (TG_strcasecmp(props.delta_val, AlrmValueNotSpec) != 0)
+            throw_err_data_type("delta_val", d_name, "Attribute::set_properties()");
+        if (TG_strcasecmp(props.rel_change, AlrmValueNotSpec) != 0)
+            throw_err_data_type("rel_change", d_name, "Attribute::set_properties()");
+        if (TG_strcasecmp(props.abs_change, AlrmValueNotSpec) != 0)
+            throw_err_data_type("abs_change", d_name, "Attribute::set_properties()");
+        if (TG_strcasecmp(props.archive_rel_change, AlrmValueNotSpec) != 0)
+            throw_err_data_type("archive_rel_change", d_name, "Attribute::set_properties()");
+        if (TG_strcasecmp(props.archive_abs_change, AlrmValueNotSpec) != 0)
+            throw_err_data_type("archive_abs_change", d_name, "Attribute::set_properties()");
+    }
 
 //
 // Get the monitor protecting device att config
@@ -1157,39 +1177,39 @@ void Attribute::set_properties(Tango::MultiAttrProp<T> &props)
     Tango::TangoMonitor *mon_ptr = NULL;
     if (tg->is_svr_starting() == false && tg->is_device_restarting(d_name) == false)
         mon_ptr = &(get_att_device()->get_att_conf_monitor());
-	AutoTangoMonitor sync1(mon_ptr);
+    AutoTangoMonitor sync1(mon_ptr);
 
 //
 // Get current attribute configuration (to retrieve un-mutable properties) and update properties with provided values
 //
 
-	AttributeConfig_5 conf;
-	get_properties(conf);
+    AttributeConfig_5 conf;
+    get_properties(conf);
 
-	conf.label = CORBA::string_dup(props.label.c_str());
-	conf.description = CORBA::string_dup(props.description.c_str());
-	conf.unit = CORBA::string_dup(props.unit.c_str());
-	conf.standard_unit = CORBA::string_dup(props.standard_unit.c_str());
-	conf.display_unit = CORBA::string_dup(props.display_unit.c_str());
-	conf.format = CORBA::string_dup(props.format.c_str());
-	conf.att_alarm.min_alarm = CORBA::string_dup(props.min_alarm);
-	conf.att_alarm.max_alarm = CORBA::string_dup(props.max_alarm);
-	conf.min_value = CORBA::string_dup(props.min_value);
-	conf.max_value = CORBA::string_dup(props.max_value);
-	conf.att_alarm.min_warning = CORBA::string_dup(props.min_warning);
-	conf.att_alarm.max_warning = CORBA::string_dup(props.max_warning);
-	conf.att_alarm.delta_t = CORBA::string_dup(props.delta_t);
-	conf.att_alarm.delta_val = CORBA::string_dup(props.delta_val);
-	conf.event_prop.per_event.period = CORBA::string_dup(props.event_period);
-	conf.event_prop.arch_event.period = CORBA::string_dup(props.archive_period);
-	conf.event_prop.ch_event.rel_change = CORBA::string_dup(props.rel_change);
-	conf.event_prop.ch_event.abs_change = CORBA::string_dup(props.abs_change);
-	conf.event_prop.arch_event.rel_change = CORBA::string_dup(props.archive_rel_change);
-	conf.event_prop.arch_event.abs_change = CORBA::string_dup(props.archive_abs_change);
+    conf.label = CORBA::string_dup(props.label.c_str());
+    conf.description = CORBA::string_dup(props.description.c_str());
+    conf.unit = CORBA::string_dup(props.unit.c_str());
+    conf.standard_unit = CORBA::string_dup(props.standard_unit.c_str());
+    conf.display_unit = CORBA::string_dup(props.display_unit.c_str());
+    conf.format = CORBA::string_dup(props.format.c_str());
+    conf.att_alarm.min_alarm = CORBA::string_dup(props.min_alarm);
+    conf.att_alarm.max_alarm = CORBA::string_dup(props.max_alarm);
+    conf.min_value = CORBA::string_dup(props.min_value);
+    conf.max_value = CORBA::string_dup(props.max_value);
+    conf.att_alarm.min_warning = CORBA::string_dup(props.min_warning);
+    conf.att_alarm.max_warning = CORBA::string_dup(props.max_warning);
+    conf.att_alarm.delta_t = CORBA::string_dup(props.delta_t);
+    conf.att_alarm.delta_val = CORBA::string_dup(props.delta_val);
+    conf.event_prop.per_event.period = CORBA::string_dup(props.event_period);
+    conf.event_prop.arch_event.period = CORBA::string_dup(props.archive_period);
+    conf.event_prop.ch_event.rel_change = CORBA::string_dup(props.rel_change);
+    conf.event_prop.ch_event.abs_change = CORBA::string_dup(props.abs_change);
+    conf.event_prop.arch_event.rel_change = CORBA::string_dup(props.archive_rel_change);
+    conf.event_prop.arch_event.abs_change = CORBA::string_dup(props.archive_abs_change);
 
-	conf.enum_labels.length(props.enum_labels.size());
-	for (size_t loop = 0;loop < props.enum_labels.size();loop++)
-		conf.enum_labels[loop] = CORBA::string_dup(props.enum_labels[loop].c_str());
+    conf.enum_labels.length(props.enum_labels.size());
+    for (size_t loop = 0; loop < props.enum_labels.size(); loop++)
+        conf.enum_labels[loop] = CORBA::string_dup(props.enum_labels[loop].c_str());
 
 //
 // Set properties and update database
@@ -1202,7 +1222,7 @@ void Attribute::set_properties(Tango::MultiAttrProp<T> &props)
         fwd_attr->upd_att_config(conf);
     }
     else
-        set_upd_properties(conf,d_name,true);
+        set_upd_properties(conf, d_name, true);
 
 //
 // Push a att conf event
@@ -1228,102 +1248,103 @@ void Attribute::set_properties(Tango::MultiAttrProp<T> &props)
 //
 //-------------------------------------------------------------------------------------------------------------------
 
-template <typename T>
-void Attribute::set_upd_properties(const T &conf,string &dev_name,bool from_ds)
+template<typename T>
+void Attribute::set_upd_properties(const T &conf, string &dev_name, bool from_ds)
 {
 
 //
 // Backup current configuration
 //
 
-	T old_conf;
-	if (is_fwd_att() == false)
-		get_properties(old_conf);
+    T old_conf;
+    if (is_fwd_att() == false)
+        get_properties(old_conf);
 
 //
 // Set flags which disable attribute configuration roll back in case there are some device startup exceptions
 //
 
-	bool is_startup_exception = check_startup_exceptions;
-	if(is_startup_exception == true)
-		startup_exceptions_clear = false;
+    bool is_startup_exception = check_startup_exceptions;
+    if (is_startup_exception == true)
+        startup_exceptions_clear = false;
 
-	try
-	{
+    try
+    {
 
 //
 // Set properties locally. In case of exception bring the backed-up values
 //
 
-		vector<AttPropDb> v_db;
-		set_properties(conf,dev_name,from_ds,v_db);
+        vector<AttPropDb> v_db;
+        set_properties(conf, dev_name, from_ds, v_db);
 
 //
 // Check ranges coherence for min and max properties (min-max alarm / min-max value ...)
 //
 
-		check_range_coherency(dev_name);
+        check_range_coherency(dev_name);
 
 //
 // At this point the attribute configuration is correct. Clear the device startup exceptions flag
 //
 
-		startup_exceptions_clear = true;
+        startup_exceptions_clear = true;
 
 //
 // Update database
 //
 
-		try
-		{
-			upd_database(v_db);
-		}
-		catch(DevFailed &)
-		{
+        try
+        {
+            upd_database(v_db);
+        }
+        catch (DevFailed &)
+        {
 
 //
 // In case of exception, try to store old properties in the database and inform the user about the error
 //
 
-			try
-			{
-				v_db.clear();
-				set_properties(old_conf,dev_name,from_ds,v_db);
-				upd_database(v_db);
-			}
-			catch(DevFailed &)
-			{
+            try
+            {
+                v_db.clear();
+                set_properties(old_conf, dev_name, from_ds, v_db);
+                upd_database(v_db);
+            }
+            catch (DevFailed &)
+            {
 
 //
 // If the old values could not be restored, notify the user about possible database corruption
 //
 
-				TangoSys_OMemStream o;
+                TangoSys_OMemStream o;
 
-				o << "Device " << dev_name << "-> Attribute : " << name;
-				o << "\nDatabase error occurred whilst setting attribute properties. The database may be corrupted." << ends;
-				Except::throw_exception(API_CorruptedDatabase,o.str(),"Attribute::set_upd_properties()");
-			}
+                o << "Device " << dev_name << "-> Attribute : " << name;
+                o << "\nDatabase error occurred whilst setting attribute properties. The database may be corrupted."
+                  << ends;
+                Except::throw_exception(API_CorruptedDatabase, o.str(), "Attribute::set_upd_properties()");
+            }
 
-			throw;
-		}
-	}
-	catch(DevFailed &)
-	{
+            throw;
+        }
+    }
+    catch (DevFailed &)
+    {
 
 //
 // If there are any device startup exceptions, do not roll back the attribute configuration unless the new
 // configuration is correct
 //
 
-		if(is_startup_exception == false && startup_exceptions_clear == true && is_fwd_att() == false)
-		{
-			vector<AttPropDb> v_db;
-			set_properties(old_conf,dev_name,true,v_db);
-		}
+        if (is_startup_exception == false && startup_exceptions_clear == true && is_fwd_att() == false)
+        {
+            vector<AttPropDb> v_db;
+            set_properties(old_conf, dev_name, true, v_db);
+        }
 
-		throw;
-	}
+        throw;
+    }
 }
 
 //+-------------------------------------------------------------------------------------------------------------------
@@ -1342,328 +1363,341 @@ void Attribute::set_upd_properties(const T &conf,string &dev_name,bool from_ds)
 //
 //--------------------------------------------------------------------------------------------------------------------
 
-template <typename T>
-void Attribute::Attribute_2_AttributeValue_base(T *ptr,Tango::DeviceImpl *d)
+template<typename T>
+void Attribute::Attribute_2_AttributeValue_base(T *ptr, Tango::DeviceImpl *d)
 {
-	if ((name_lower == "state") || (name_lower == "status"))
-	{
-		ptr->quality = Tango::ATTR_VALID;
+    if ((name_lower == "state") || (name_lower == "status"))
+    {
+        ptr->quality = Tango::ATTR_VALID;
 
-		if (name_lower == "state")
-		{
-			ptr->value.dev_state_att(d->get_state());
-		}
-		else
-		{
-			Tango::DevVarStringArray str_seq(1);
-			str_seq.length(1);
-			str_seq[0] = CORBA::string_dup(d->get_status().c_str());
+        if (name_lower == "state")
+        {
+            ptr->value.dev_state_att(d->get_state());
+        }
+        else
+        {
+            Tango::DevVarStringArray str_seq(1);
+            str_seq.length(1);
+            str_seq[0] = CORBA::string_dup(d->get_status().c_str());
 
-			ptr->value.string_att_value(str_seq);
-		}
+            ptr->value.string_att_value(str_seq);
+        }
 
 #ifdef _TG_WINDOWS_
-		struct _timeb t;
-		_ftime(&t);
+        struct _timeb t;
+        _ftime(&t);
 
-		ptr->time.tv_sec = (long)t.time;
-		ptr->time.tv_usec = (long)(t.millitm * 1000);
-		ptr->time.tv_nsec = 0;
+        ptr->time.tv_sec = (long)t.time;
+        ptr->time.tv_usec = (long)(t.millitm * 1000);
+        ptr->time.tv_nsec = 0;
 #else
-		struct timeval after;
+        struct timeval after;
 
-		gettimeofday(&after,NULL);
+        gettimeofday(&after, NULL);
 
-		ptr->time.tv_sec = after.tv_sec;
-		ptr->time.tv_usec = after.tv_usec;
-		ptr->time.tv_nsec = 0;
+        ptr->time.tv_sec = after.tv_sec;
+        ptr->time.tv_usec = after.tv_usec;
+        ptr->time.tv_nsec = 0;
 #endif
-		ptr->r_dim.dim_x = 1;
-		ptr->r_dim.dim_y = 0;
-		ptr->w_dim.dim_x = 0;
-		ptr->w_dim.dim_y = 0;
+        ptr->r_dim.dim_x = 1;
+        ptr->r_dim.dim_y = 0;
+        ptr->w_dim.dim_x = 0;
+        ptr->w_dim.dim_y = 0;
 
-		ptr->name = CORBA::string_dup(name.c_str());
-		ptr->data_format = data_format;
-	}
-	else
-	{
-		if (quality != Tango::ATTR_INVALID)
-		{
-			MultiAttribute *m_attr = d->get_device_attr();
+        ptr->name = CORBA::string_dup(name.c_str());
+        ptr->data_format = data_format;
+    }
+    else
+    {
+        if (quality != Tango::ATTR_INVALID)
+        {
+            MultiAttribute *m_attr = d->get_device_attr();
 
-			// Add the attribute setpoint to the value sequence
+            // Add the attribute setpoint to the value sequence
 
-			if ((writable == Tango::READ_WRITE) ||
-			    (writable == Tango::READ_WITH_WRITE))
-			{
-				m_attr->add_write_value(*this);
-			}
+            if ((writable == Tango::READ_WRITE) ||
+                (writable == Tango::READ_WITH_WRITE))
+            {
+                m_attr->add_write_value(*this);
+            }
 
-			// check for alarms to position the data quality value.
-			if ( is_alarmed().any() == true )
-			{
-				check_alarm();
-			}
+            // check for alarms to position the data quality value.
+            if (is_alarmed().any() == true)
+            {
+                check_alarm();
+            }
 
-			ptr->r_dim.dim_x = dim_x;
-			ptr->r_dim.dim_y = dim_y;
-			if ((writable == Tango::READ_WRITE) ||
-			     (writable == Tango::READ_WITH_WRITE))
-			{
-				WAttribute &assoc_att = m_attr->get_w_attr_by_ind(get_assoc_ind());
-				ptr->w_dim.dim_x = assoc_att.get_w_dim_x();
-				ptr->w_dim.dim_y = assoc_att.get_w_dim_y();
-			}
-			else
-			{
-				ptr->w_dim.dim_x = 0;
-				ptr->w_dim.dim_y = 0;
-			}
-		}
-		else
-		{
-			ptr->r_dim.dim_x = 0;
-			ptr->r_dim.dim_y = 0;
-			ptr->w_dim.dim_x = 0;
-			ptr->w_dim.dim_y = 0;
-			ptr->value.union_no_data(true);
-		}
+            ptr->r_dim.dim_x = dim_x;
+            ptr->r_dim.dim_y = dim_y;
+            if ((writable == Tango::READ_WRITE) ||
+                (writable == Tango::READ_WITH_WRITE))
+            {
+                WAttribute &assoc_att = m_attr->get_w_attr_by_ind(get_assoc_ind());
+                ptr->w_dim.dim_x = assoc_att.get_w_dim_x();
+                ptr->w_dim.dim_y = assoc_att.get_w_dim_y();
+            }
+            else
+            {
+                ptr->w_dim.dim_x = 0;
+                ptr->w_dim.dim_y = 0;
+            }
+        }
+        else
+        {
+            ptr->r_dim.dim_x = 0;
+            ptr->r_dim.dim_y = 0;
+            ptr->w_dim.dim_x = 0;
+            ptr->w_dim.dim_y = 0;
+            ptr->value.union_no_data(true);
+        }
 
-		ptr->time = when;
-		ptr->quality = quality;
-		ptr->data_format = data_format;
-		ptr->name = CORBA::string_dup(name.c_str());
-	}
+        ptr->time = when;
+        ptr->quality = quality;
+        ptr->data_format = data_format;
+        ptr->name = CORBA::string_dup(name.c_str());
+    }
 }
 
-template <typename T,typename V>
-void Attribute::AttrValUnion_fake_copy(const T *src,V *dst)
+template<typename T, typename V>
+void Attribute::AttrValUnion_fake_copy(const T *src, V *dst)
 {
-	switch (src->value._d())
-	{
-		case ATT_BOOL:
-		{
-			const DevVarBooleanArray &tmp_seq = src->value.bool_att_value();
-			DevVarBooleanArray tmp_seq_4(tmp_seq.length(),tmp_seq.length(),const_cast<bool *>(tmp_seq.get_buffer()),false);
-			dst->value.bool_att_value(tmp_seq_4);
-		}
-		break;
+    switch (src->value._d())
+    {
+        case ATT_BOOL:
+        {
+            const DevVarBooleanArray &tmp_seq = src->value.bool_att_value();
+            DevVarBooleanArray
+                tmp_seq_4(tmp_seq.length(), tmp_seq.length(), const_cast<bool *>(tmp_seq.get_buffer()), false);
+            dst->value.bool_att_value(tmp_seq_4);
+        }
+            break;
 
-		case ATT_SHORT:
-		{
-			const DevVarShortArray &tmp_seq = src->value.short_att_value();
-			DevVarShortArray tmp_seq_4(tmp_seq.length(),tmp_seq.length(),const_cast<short *>(tmp_seq.get_buffer()),false);
-			dst->value.short_att_value(tmp_seq_4);
-		}
-		break;
+        case ATT_SHORT:
+        {
+            const DevVarShortArray &tmp_seq = src->value.short_att_value();
+            DevVarShortArray
+                tmp_seq_4(tmp_seq.length(), tmp_seq.length(), const_cast<short *>(tmp_seq.get_buffer()), false);
+            dst->value.short_att_value(tmp_seq_4);
+        }
+            break;
 
-		case ATT_LONG:
-		{
-			const DevVarLongArray &tmp_seq = src->value.long_att_value();
-			DevVarLongArray tmp_seq_4(tmp_seq.length(),tmp_seq.length(),const_cast<DevLong *>(tmp_seq.get_buffer()),false);
-			dst->value.long_att_value(tmp_seq_4);
-		}
-		break;
+        case ATT_LONG:
+        {
+            const DevVarLongArray &tmp_seq = src->value.long_att_value();
+            DevVarLongArray
+                tmp_seq_4(tmp_seq.length(), tmp_seq.length(), const_cast<DevLong *>(tmp_seq.get_buffer()), false);
+            dst->value.long_att_value(tmp_seq_4);
+        }
+            break;
 
-		case ATT_LONG64:
-		{
-			const DevVarLong64Array &tmp_seq = src->value.long64_att_value();
-			DevVarLong64Array tmp_seq_4(tmp_seq.length(),tmp_seq.length(),const_cast<DevLong64 *>(tmp_seq.get_buffer()),false);
-			dst->value.long64_att_value(tmp_seq_4);
-		}
-		break;
+        case ATT_LONG64:
+        {
+            const DevVarLong64Array &tmp_seq = src->value.long64_att_value();
+            DevVarLong64Array
+                tmp_seq_4(tmp_seq.length(), tmp_seq.length(), const_cast<DevLong64 *>(tmp_seq.get_buffer()), false);
+            dst->value.long64_att_value(tmp_seq_4);
+        }
+            break;
 
-		case ATT_FLOAT:
-		{
-			const DevVarFloatArray &tmp_seq = src->value.float_att_value();
-			DevVarFloatArray tmp_seq_4(tmp_seq.length(),tmp_seq.length(),const_cast<float *>(tmp_seq.get_buffer()),false);
-			dst->value.float_att_value(tmp_seq_4);
-		}
-		break;
+        case ATT_FLOAT:
+        {
+            const DevVarFloatArray &tmp_seq = src->value.float_att_value();
+            DevVarFloatArray
+                tmp_seq_4(tmp_seq.length(), tmp_seq.length(), const_cast<float *>(tmp_seq.get_buffer()), false);
+            dst->value.float_att_value(tmp_seq_4);
+        }
+            break;
 
-		case ATT_DOUBLE:
-		{
-			const DevVarDoubleArray &tmp_seq = src->value.double_att_value();
-			DevVarDoubleArray tmp_seq_4(tmp_seq.length(),tmp_seq.length(),const_cast<double *>(tmp_seq.get_buffer()),false);
-			dst->value.double_att_value(tmp_seq_4);
-		}
-		break;
+        case ATT_DOUBLE:
+        {
+            const DevVarDoubleArray &tmp_seq = src->value.double_att_value();
+            DevVarDoubleArray
+                tmp_seq_4(tmp_seq.length(), tmp_seq.length(), const_cast<double *>(tmp_seq.get_buffer()), false);
+            dst->value.double_att_value(tmp_seq_4);
+        }
+            break;
 
-		case ATT_UCHAR:
-		{
-			const DevVarCharArray &tmp_seq = src->value.uchar_att_value();
-			DevVarCharArray tmp_seq_4(tmp_seq.length(),tmp_seq.length(),const_cast<unsigned char *>(tmp_seq.get_buffer()),false);
-			dst->value.uchar_att_value(tmp_seq_4);
-		}
-		break;
+        case ATT_UCHAR:
+        {
+            const DevVarCharArray &tmp_seq = src->value.uchar_att_value();
+            DevVarCharArray
+                tmp_seq_4(tmp_seq.length(), tmp_seq.length(), const_cast<unsigned char *>(tmp_seq.get_buffer()), false);
+            dst->value.uchar_att_value(tmp_seq_4);
+        }
+            break;
 
-		case ATT_USHORT:
-		{
-			const DevVarUShortArray &tmp_seq = src->value.ushort_att_value();
-			DevVarUShortArray tmp_seq_4(tmp_seq.length(),tmp_seq.length(),const_cast<DevUShort *>(tmp_seq.get_buffer()),false);
-			dst->value.ushort_att_value(tmp_seq_4);
-		}
-		break;
+        case ATT_USHORT:
+        {
+            const DevVarUShortArray &tmp_seq = src->value.ushort_att_value();
+            DevVarUShortArray
+                tmp_seq_4(tmp_seq.length(), tmp_seq.length(), const_cast<DevUShort *>(tmp_seq.get_buffer()), false);
+            dst->value.ushort_att_value(tmp_seq_4);
+        }
+            break;
 
-		case ATT_ULONG:
-		{
-			const DevVarULongArray &tmp_seq = src->value.ulong_att_value();
-			DevVarULongArray tmp_seq_4(tmp_seq.length(),tmp_seq.length(),const_cast<DevULong *>(tmp_seq.get_buffer()),false);
-			dst->value.ulong_att_value(tmp_seq_4);
-		}
-		break;
+        case ATT_ULONG:
+        {
+            const DevVarULongArray &tmp_seq = src->value.ulong_att_value();
+            DevVarULongArray
+                tmp_seq_4(tmp_seq.length(), tmp_seq.length(), const_cast<DevULong *>(tmp_seq.get_buffer()), false);
+            dst->value.ulong_att_value(tmp_seq_4);
+        }
+            break;
 
-		case ATT_ULONG64:
-		{
-			const DevVarULong64Array &tmp_seq = src->value.ulong64_att_value();
-			DevVarULong64Array tmp_seq_4(tmp_seq.length(),tmp_seq.length(),const_cast<DevULong64 *>(tmp_seq.get_buffer()),false);
-			dst->value.ulong64_att_value(tmp_seq_4);
-		}
-		break;
+        case ATT_ULONG64:
+        {
+            const DevVarULong64Array &tmp_seq = src->value.ulong64_att_value();
+            DevVarULong64Array
+                tmp_seq_4(tmp_seq.length(), tmp_seq.length(), const_cast<DevULong64 *>(tmp_seq.get_buffer()), false);
+            dst->value.ulong64_att_value(tmp_seq_4);
+        }
+            break;
 
-		case ATT_STRING:
-		{
-			const DevVarStringArray &tmp_seq = src->value.string_att_value();
-			DevVarStringArray tmp_seq_4(tmp_seq.length(),tmp_seq.length(),const_cast<DevString *>(tmp_seq.get_buffer()),false);
-			dst->value.string_att_value(tmp_seq_4);
-		}
-		break;
+        case ATT_STRING:
+        {
+            const DevVarStringArray &tmp_seq = src->value.string_att_value();
+            DevVarStringArray
+                tmp_seq_4(tmp_seq.length(), tmp_seq.length(), const_cast<DevString *>(tmp_seq.get_buffer()), false);
+            dst->value.string_att_value(tmp_seq_4);
+        }
+            break;
 
-		case ATT_STATE:
-		{
-			const DevVarStateArray &tmp_seq = src->value.state_att_value();
-			DevVarStateArray tmp_seq_4(tmp_seq.length(),tmp_seq.length(),const_cast<DevState *>(tmp_seq.get_buffer()),false);
-			dst->value.state_att_value(tmp_seq_4);
-		}
-		break;
+        case ATT_STATE:
+        {
+            const DevVarStateArray &tmp_seq = src->value.state_att_value();
+            DevVarStateArray
+                tmp_seq_4(tmp_seq.length(), tmp_seq.length(), const_cast<DevState *>(tmp_seq.get_buffer()), false);
+            dst->value.state_att_value(tmp_seq_4);
+        }
+            break;
 
-		case DEVICE_STATE:
-		{
-			const DevState &sta = src->value.dev_state_att();
-			dst->value.dev_state_att(sta);
-		}
-		break;
+        case DEVICE_STATE:
+        {
+            const DevState &sta = src->value.dev_state_att();
+            dst->value.dev_state_att(sta);
+        }
+            break;
 
-		case ATT_ENCODED:
-		{
-			const DevVarEncodedArray &tmp_seq = src->value.encoded_att_value();
-			DevVarEncodedArray tmp_seq_4(tmp_seq.length(),tmp_seq.length(),const_cast<DevEncoded *>(tmp_seq.get_buffer()),false);
-			dst->value.encoded_att_value(tmp_seq_4);
-		}
-		break;
+        case ATT_ENCODED:
+        {
+            const DevVarEncodedArray &tmp_seq = src->value.encoded_att_value();
+            DevVarEncodedArray
+                tmp_seq_4(tmp_seq.length(), tmp_seq.length(), const_cast<DevEncoded *>(tmp_seq.get_buffer()), false);
+            dst->value.encoded_att_value(tmp_seq_4);
+        }
+            break;
 
-		case ATT_NO_DATA:
-		break;
-	}
+        case ATT_NO_DATA:
+            break;
+    }
 }
 
-template <typename T>
-void Attribute::AttrValUnion_2_Any(const T *src,CORBA::Any &dst)
+template<typename T>
+void Attribute::AttrValUnion_2_Any(const T *src, CORBA::Any &dst)
 {
-	switch (src->value._d())
-	{
-		case ATT_BOOL:
-		{
-			const DevVarBooleanArray &tmp_seq = src->value.bool_att_value();
-			dst <<= tmp_seq;
-		}
-		break;
+    switch (src->value._d())
+    {
+        case ATT_BOOL:
+        {
+            const DevVarBooleanArray &tmp_seq = src->value.bool_att_value();
+            dst <<= tmp_seq;
+        }
+            break;
 
-		case ATT_SHORT:
-		{
-			const DevVarShortArray &tmp_seq = src->value.short_att_value();
-			dst <<= tmp_seq;
-		}
-		break;
+        case ATT_SHORT:
+        {
+            const DevVarShortArray &tmp_seq = src->value.short_att_value();
+            dst <<= tmp_seq;
+        }
+            break;
 
-		case ATT_LONG:
-		{
-			const DevVarLongArray &tmp_seq = src->value.long_att_value();
-			dst <<= tmp_seq;
-		}
-		break;
+        case ATT_LONG:
+        {
+            const DevVarLongArray &tmp_seq = src->value.long_att_value();
+            dst <<= tmp_seq;
+        }
+            break;
 
-		case ATT_LONG64:
-		{
-			const DevVarLong64Array &tmp_seq = src->value.long64_att_value();
-			dst <<= tmp_seq;
-		}
-		break;
+        case ATT_LONG64:
+        {
+            const DevVarLong64Array &tmp_seq = src->value.long64_att_value();
+            dst <<= tmp_seq;
+        }
+            break;
 
-		case ATT_FLOAT:
-		{
-			const DevVarFloatArray &tmp_seq = src->value.float_att_value();
-			dst <<= tmp_seq;
-		}
-		break;
+        case ATT_FLOAT:
+        {
+            const DevVarFloatArray &tmp_seq = src->value.float_att_value();
+            dst <<= tmp_seq;
+        }
+            break;
 
-		case ATT_DOUBLE:
-		{
-			const DevVarDoubleArray &tmp_seq = src->value.double_att_value();
-			dst <<= tmp_seq;
-		}
-		break;
+        case ATT_DOUBLE:
+        {
+            const DevVarDoubleArray &tmp_seq = src->value.double_att_value();
+            dst <<= tmp_seq;
+        }
+            break;
 
-		case ATT_UCHAR:
-		{
-			const DevVarCharArray &tmp_seq = src->value.uchar_att_value();
-			dst <<= tmp_seq;
-		}
-		break;
+        case ATT_UCHAR:
+        {
+            const DevVarCharArray &tmp_seq = src->value.uchar_att_value();
+            dst <<= tmp_seq;
+        }
+            break;
 
-		case ATT_USHORT:
-		{
-			const DevVarUShortArray &tmp_seq = src->value.ushort_att_value();
-			dst <<= tmp_seq;
-		}
-		break;
+        case ATT_USHORT:
+        {
+            const DevVarUShortArray &tmp_seq = src->value.ushort_att_value();
+            dst <<= tmp_seq;
+        }
+            break;
 
-		case ATT_ULONG:
-		{
-			const DevVarULongArray &tmp_seq = src->value.ulong_att_value();
-			dst <<= tmp_seq;
-		}
-		break;
+        case ATT_ULONG:
+        {
+            const DevVarULongArray &tmp_seq = src->value.ulong_att_value();
+            dst <<= tmp_seq;
+        }
+            break;
 
-		case ATT_ULONG64:
-		{
-			const DevVarULong64Array &tmp_seq = src->value.ulong64_att_value();
-			dst <<= tmp_seq;
-		}
-		break;
+        case ATT_ULONG64:
+        {
+            const DevVarULong64Array &tmp_seq = src->value.ulong64_att_value();
+            dst <<= tmp_seq;
+        }
+            break;
 
-		case ATT_STRING:
-		{
-			const DevVarStringArray &tmp_seq = src->value.string_att_value();
-			dst <<= tmp_seq;
-		}
-		break;
+        case ATT_STRING:
+        {
+            const DevVarStringArray &tmp_seq = src->value.string_att_value();
+            dst <<= tmp_seq;
+        }
+            break;
 
-		case ATT_STATE:
-		{
-			const DevVarStateArray &tmp_seq = src->value.state_att_value();
-			dst <<= tmp_seq;
-		}
-		break;
+        case ATT_STATE:
+        {
+            const DevVarStateArray &tmp_seq = src->value.state_att_value();
+            dst <<= tmp_seq;
+        }
+            break;
 
-		case DEVICE_STATE:
-		{
-			const DevState &sta = src->value.dev_state_att();
-			dst <<= sta;
-		}
-		break;
+        case DEVICE_STATE:
+        {
+            const DevState &sta = src->value.dev_state_att();
+            dst <<= sta;
+        }
+            break;
 
-		case ATT_ENCODED:
-		{
-			const DevVarEncodedArray &tmp_seq = src->value.encoded_att_value();
-			dst <<= tmp_seq;
-		}
-		break;
+        case ATT_ENCODED:
+        {
+            const DevVarEncodedArray &tmp_seq = src->value.encoded_att_value();
+            dst <<= tmp_seq;
+        }
+            break;
 
-		case ATT_NO_DATA:
-		break;
-	}
+        case ATT_NO_DATA:
+            break;
+    }
 }
 
 } // End of Tango namespace

--- a/cppapi/server/blackbox.cpp
+++ b/cppapi/server/blackbox.cpp
@@ -1690,8 +1690,10 @@ void BlackBox::build_info_as_str(long index)
 
         int res = getnameinfo((const sockaddr *) &si, sizeof(si), host, 512, 0, 0, 0);
 #ifdef _TG_WINDOWS_
-        for (int i = 0;i < ::strlen(host);i++)
+        for (int i = 0; i < ::strlen(host); i++)
+        {
             host[i] = ::tolower(host[i]);
+        }
 #endif
 
         if (res == 0)

--- a/cppapi/server/blackbox.cpp
+++ b/cppapi/server/blackbox.cpp
@@ -76,8 +76,9 @@ extern omni_thread::key_t key;
 
 CORBA::Boolean get_client_addr(omni::omniInterceptors::serverReceiveRequest_T::info_T &info)
 {
-    omni_thread::self()->set_value(key,new client_addr(((omni::giopStrand &)info.giop_s.strand()).connection->peeraddress()));
-	return true;
+    omni_thread::self()
+        ->set_value(key, new client_addr(((omni::giopStrand &) info.giop_s.strand()).connection->peeraddress()));
+    return true;
 }
 
 //+------------------------------------------------------------------------------------------------------------------
@@ -92,13 +93,13 @@ CORBA::Boolean get_client_addr(omni::omniInterceptors::serverReceiveRequest_T::i
 
 BlackBoxElt::BlackBoxElt()
 {
-	req_type = Req_Unknown;
-	attr_type = Attr_Unknown;
-	op_type = Op_Unknown;
-	when.tv_sec = when.tv_usec = 0;
-	host_ip_str[0] = '\0';
-	client_ident = false;
-	attr_names.reserve(DEFAULT_ATTR_NB);
+    req_type = Req_Unknown;
+    attr_type = Attr_Unknown;
+    op_type = Op_Unknown;
+    when.tv_sec = when.tv_usec = 0;
+    host_ip_str[0] = '\0';
+    client_ident = false;
+    attr_names.reserve(DEFAULT_ATTR_NB);
 }
 
 BlackBoxElt::~BlackBoxElt()
@@ -120,18 +121,20 @@ BlackBoxElt::~BlackBoxElt()
 //
 //-------------------------------------------------------------------------------------------------------------------
 
-BlackBox::BlackBox():box(DefaultBlackBoxDepth)
+BlackBox::BlackBox()
+    : box(DefaultBlackBoxDepth)
 {
-	insert_elt = 0;
-	nb_elt = 0;
-	max_elt = DefaultBlackBoxDepth;
+    insert_elt = 0;
+    nb_elt = 0;
+    max_elt = DefaultBlackBoxDepth;
 }
 
-BlackBox::BlackBox(long max_size):box(max_size)
+BlackBox::BlackBox(long max_size)
+    : box(max_size)
 {
-	insert_elt = 0;
-	nb_elt = 0;
-	max_elt = max_size;
+    insert_elt = 0;
+    nb_elt = 0;
+    max_elt = max_size;
 }
 
 //+-------------------------------------------------------------------------------------------------------------------
@@ -156,49 +159,49 @@ void BlackBox::insert_corba_attr(BlackBoxElt_AttrType attr)
 // Take mutex
 //
 
-	sync.lock();
+    sync.lock();
 
 //
 // Insert elt in the box
 //
 
-	box[insert_elt].req_type = Req_Attribute;
-	box[insert_elt].attr_type = attr;
-	box[insert_elt].op_type = Op_Unknown;
-	box[insert_elt].client_ident = false;
+    box[insert_elt].req_type = Req_Attribute;
+    box[insert_elt].attr_type = attr;
+    box[insert_elt].op_type = Op_Unknown;
+    box[insert_elt].client_ident = false;
 
 #ifdef _TG_WINDOWS_
-//
-// Note that the exact conversion between milli-sec and u-sec will be done only when data is send back to user.
-// This save some times in unnecessary computation
-//
-	struct _timeb t;
-	_ftime(&t);
+    //
+    // Note that the exact conversion between milli-sec and u-sec will be done only when data is send back to user.
+    // This save some times in unnecessary computation
+    //
+        struct _timeb t;
+        _ftime(&t);
 
-	box[insert_elt].when.tv_usec = (long)t.millitm;
-	box[insert_elt].when.tv_sec = (unsigned long)t.time;
+        box[insert_elt].when.tv_usec = (long)t.millitm;
+        box[insert_elt].when.tv_sec = (unsigned long)t.time;
 #else
-	struct timezone tz;
-	gettimeofday(&box[insert_elt].when,&tz);
+    struct timezone tz;
+    gettimeofday(&box[insert_elt].when, &tz);
 #endif
 
 //
 // get client address
 //
 
-	get_client_host();
+    get_client_host();
 
 //
 // manage insert and read indexes
 //
 
-	inc_indexes();
+    inc_indexes();
 
 //
 // Release mutex
 //
 
-	sync.unlock();
+    sync.unlock();
 }
 
 //+------------------------------------------------------------------------------------------------------------------
@@ -218,59 +221,59 @@ void BlackBox::insert_corba_attr(BlackBoxElt_AttrType attr)
 //-------------------------------------------------------------------------------------------------------------------
 
 
-void BlackBox::insert_cmd(const char *cmd,long vers,DevSource sour)
+void BlackBox::insert_cmd(const char *cmd, long vers, DevSource sour)
 {
-	sync.lock();
+    sync.lock();
 
-	insert_cmd_nl(cmd,vers,sour);
+    insert_cmd_nl(cmd, vers, sour);
 
-	sync.unlock();
+    sync.unlock();
 }
 
-void BlackBox::insert_cmd_nl(const char *cmd,long vers,DevSource sour)
+void BlackBox::insert_cmd_nl(const char *cmd, long vers, DevSource sour)
 {
 
 //
 // Insert elt in the box
 //
 
-	box[insert_elt].req_type = Req_Operation;
-	box[insert_elt].attr_type = Attr_Unknown;
-	if (vers == 1)
-		box[insert_elt].op_type = Op_Command_inout;
-	else if (vers <= 3)
-		box[insert_elt].op_type = Op_Command_inout_2;
-	else
-		box[insert_elt].op_type = Op_Command_inout_4;
-	box[insert_elt].cmd_name = cmd;
-	box[insert_elt].source = sour;
-	box[insert_elt].client_ident = false;
+    box[insert_elt].req_type = Req_Operation;
+    box[insert_elt].attr_type = Attr_Unknown;
+    if (vers == 1)
+        box[insert_elt].op_type = Op_Command_inout;
+    else if (vers <= 3)
+        box[insert_elt].op_type = Op_Command_inout_2;
+    else
+        box[insert_elt].op_type = Op_Command_inout_4;
+    box[insert_elt].cmd_name = cmd;
+    box[insert_elt].source = sour;
+    box[insert_elt].client_ident = false;
 #ifdef _TG_WINDOWS_
-//
-// Note that the exact conversion between milli-sec and u-sec will be done only when data is send back to user.
-// This save some times in unnecessary computation
-//
-	struct _timeb t;
-	_ftime(&t);
+    //
+    // Note that the exact conversion between milli-sec and u-sec will be done only when data is send back to user.
+    // This save some times in unnecessary computation
+    //
+        struct _timeb t;
+        _ftime(&t);
 
-	box[insert_elt].when.tv_usec = (long)t.millitm;
-	box[insert_elt].when.tv_sec = (unsigned long)t.time;
+        box[insert_elt].when.tv_usec = (long)t.millitm;
+        box[insert_elt].when.tv_sec = (unsigned long)t.time;
 #else
-	struct timezone tz;
-	gettimeofday(&box[insert_elt].when,&tz);
+    struct timezone tz;
+    gettimeofday(&box[insert_elt].when, &tz);
 #endif
 
 //
 // get client address
 //
 
-	get_client_host();
+    get_client_host();
 
 //
 // manage insert and read indexes
 //
 
-	inc_indexes();
+    inc_indexes();
 }
 
 //+-------------------------------------------------------------------------------------------------------------------
@@ -290,38 +293,38 @@ void BlackBox::insert_cmd_nl(const char *cmd,long vers,DevSource sour)
 //------------------------------------------------------------------------------------------------------------------
 
 
-void BlackBox::insert_cmd_cl_ident(const char *cmd,const ClntIdent &cl_id,long vers,DevSource sour)
+void BlackBox::insert_cmd_cl_ident(const char *cmd, const ClntIdent &cl_id, long vers, DevSource sour)
 {
-	sync.lock();
+    sync.lock();
 
 //
 // Add basic info in the box
 //
 
     long old_insert = insert_elt;
-	insert_cmd_nl(cmd,vers,sour);
+    insert_cmd_nl(cmd, vers, sour);
 
 //
 // Check if the command is executed due to polling. If true, simply return
 //
 
-	if (box[old_insert].host_ip_str[0] == 'p' ||
+    if (box[old_insert].host_ip_str[0] == 'p' ||
         box[old_insert].host_ip_str[0] == 'u' ||
         box[old_insert].host_ip_str[0] == 'i')
-	{
-		sync.unlock();
-		return;
-	}
+    {
+        sync.unlock();
+        return;
+    }
 
 //
 // Add client ident info into the client_addr instance and into the box
 //
 
     omni_thread::value_t *ip = omni_thread::self()->get_value(key);
-	add_cl_ident(cl_id,static_cast<client_addr *>(ip));
-	update_client_host(static_cast<client_addr *>(ip));
+    add_cl_ident(cl_id, static_cast<client_addr *>(ip));
+    update_client_host(static_cast<client_addr *>(ip));
 
-	sync.unlock();
+    sync.unlock();
 }
 
 //+-------------------------------------------------------------------------------------------------------------------
@@ -339,29 +342,29 @@ void BlackBox::insert_cmd_cl_ident(const char *cmd,const ClntIdent &cl_id,long v
 //
 //--------------------------------------------------------------------------------------------------------------------
 
-void BlackBox::add_cl_ident(const ClntIdent &cl_ident,client_addr *cl_addr)
+void BlackBox::add_cl_ident(const ClntIdent &cl_ident, client_addr *cl_addr)
 {
-	cl_addr->client_ident = true;
-	Tango::LockerLanguage cl_lang = cl_ident._d();
-	cl_addr->client_lang = cl_lang;
-	if (cl_lang == Tango::CPP)
-	{
-		cl_addr->client_pid = cl_ident.cpp_clnt();
-		string str(cl_addr->client_ip);
-		if (str.find(":unix:") != string::npos)
-		{
-		    string::size_type pos = str.find(' ');
-		    if (pos != string::npos)
+    cl_addr->client_ident = true;
+    Tango::LockerLanguage cl_lang = cl_ident._d();
+    cl_addr->client_lang = cl_lang;
+    if (cl_lang == Tango::CPP)
+    {
+        cl_addr->client_pid = cl_ident.cpp_clnt();
+        string str(cl_addr->client_ip);
+        if (str.find(":unix:") != string::npos)
+        {
+            string::size_type pos = str.find(' ');
+            if (pos != string::npos)
                 cl_addr->client_ip[pos] = '\0';
-		}
-	}
-	else
-	{
-		Tango::JavaClntIdent jci = cl_ident.java_clnt();
-		cl_addr->java_main_class = jci.MainClass;
-		cl_addr->java_ident[0] = jci.uuid[0];
-		cl_addr->java_ident[1] = jci.uuid[1];
-	}
+        }
+    }
+    else
+    {
+        Tango::JavaClntIdent jci = cl_ident.java_clnt();
+        cl_addr->java_main_class = jci.MainClass;
+        cl_addr->java_ident[0] = jci.uuid[0];
+        cl_addr->java_ident[1] = jci.uuid[1];
+    }
 }
 
 //+-------------------------------------------------------------------------------------------------------------------
@@ -380,16 +383,16 @@ void BlackBox::add_cl_ident(const ClntIdent &cl_ident,client_addr *cl_addr)
 
 void BlackBox::update_client_host(client_addr *ip)
 {
-	long local_insert_elt = insert_elt;
-	if (local_insert_elt == 0)
-		local_insert_elt = max_elt - 1;
-	else
-		local_insert_elt--;
+    long local_insert_elt = insert_elt;
+    if (local_insert_elt == 0)
+        local_insert_elt = max_elt - 1;
+    else
+        local_insert_elt--;
 
-	box[local_insert_elt].client_ident = true;
-	box[local_insert_elt].client_lang = ip->client_lang;
-	box[local_insert_elt].client_pid = ip->client_pid;
-	box[local_insert_elt].java_main_class = ip->java_main_class;
+    box[local_insert_elt].client_ident = true;
+    box[local_insert_elt].client_lang = ip->client_lang;
+    box[local_insert_elt].client_pid = ip->client_pid;
+    box[local_insert_elt].java_main_class = ip->java_main_class;
 }
 
 
@@ -410,41 +413,41 @@ void BlackBox::update_client_host(client_addr *ip)
 
 void BlackBox::insert_op(BlackBoxElt_OpType op)
 {
-	sync.lock();
+    sync.lock();
 
-	insert_op_nl(op);
+    insert_op_nl(op);
 
-	sync.unlock();
+    sync.unlock();
 }
 
-void BlackBox::insert_op(BlackBoxElt_OpType op,const ClntIdent &cl_id)
+void BlackBox::insert_op(BlackBoxElt_OpType op, const ClntIdent &cl_id)
 {
-	sync.lock();
+    sync.lock();
 
     long old_insert = insert_elt;
-	insert_op_nl(op);
+    insert_op_nl(op);
 
 //
 // Check if the command is executed due to polling. If true, simply return
 //
 
-	if (box[old_insert].host_ip_str[0] == 'p' ||
+    if (box[old_insert].host_ip_str[0] == 'p' ||
         box[old_insert].host_ip_str[0] == 'u' ||
         box[old_insert].host_ip_str[0] == 'i')
-	{
-		sync.unlock();
-		return;
-	}
+    {
+        sync.unlock();
+        return;
+    }
 
 //
 // Add client ident info into the client_addr instance and into the box
 //
 
-	omni_thread::value_t *ip = omni_thread::self()->get_value(key);
-	add_cl_ident(cl_id,static_cast<client_addr *>(ip));
-	update_client_host(static_cast<client_addr *>(ip));
+    omni_thread::value_t *ip = omni_thread::self()->get_value(key);
+    add_cl_ident(cl_id, static_cast<client_addr *>(ip));
+    update_client_host(static_cast<client_addr *>(ip));
 
-	sync.unlock();
+    sync.unlock();
 }
 
 void BlackBox::insert_op_nl(BlackBoxElt_OpType op)
@@ -453,36 +456,36 @@ void BlackBox::insert_op_nl(BlackBoxElt_OpType op)
 // Insert elt in the box
 //
 
-	box[insert_elt].req_type = Req_Operation;
-	box[insert_elt].attr_type = Attr_Unknown;
-	box[insert_elt].op_type = op;
-	box[insert_elt].client_ident = false;
+    box[insert_elt].req_type = Req_Operation;
+    box[insert_elt].attr_type = Attr_Unknown;
+    box[insert_elt].op_type = op;
+    box[insert_elt].client_ident = false;
 #ifdef _TG_WINDOWS_
-//
-// Note that the exact conversion between milli-sec and u-sec will be done only when data is send back to user.
-// This save some times in unnecessary computation
-//
-	struct _timeb t;
-	_ftime(&t);
+    //
+    // Note that the exact conversion between milli-sec and u-sec will be done only when data is send back to user.
+    // This save some times in unnecessary computation
+    //
+        struct _timeb t;
+        _ftime(&t);
 
-	box[insert_elt].when.tv_usec = (long)t.millitm;
-	box[insert_elt].when.tv_sec = (unsigned long)t.time;
+        box[insert_elt].when.tv_usec = (long)t.millitm;
+        box[insert_elt].when.tv_sec = (unsigned long)t.time;
 #else
-	struct timezone tz;
-	gettimeofday(&box[insert_elt].when,&tz);
+    struct timezone tz;
+    gettimeofday(&box[insert_elt].when, &tz);
 #endif
 
 //
 // get client address
 //
 
-	get_client_host();
+    get_client_host();
 
 //
 // manage insert and read indexes
 //
 
-	inc_indexes();
+    inc_indexes();
 }
 
 //+--------------------------------------------------------------------------------------------------------------------
@@ -503,136 +506,136 @@ void BlackBox::insert_op_nl(BlackBoxElt_OpType op)
 //---------------------------------------------------------------------------------------------------------------------
 
 
-void BlackBox::insert_attr(const Tango::DevVarStringArray &names,long vers,DevSource sour)
+void BlackBox::insert_attr(const Tango::DevVarStringArray &names, long vers, DevSource sour)
 {
 
 //
 // Take mutex
 //
 
-	sync.lock();
+    sync.lock();
 
 //
 // Insert elt in the box
 //
 
-	box[insert_elt].req_type = Req_Operation;
-	box[insert_elt].attr_type = Attr_Unknown;
-	switch (vers)
-	{
-	case 1 :
-		box[insert_elt].op_type = Op_Read_Attr;
-		break;
+    box[insert_elt].req_type = Req_Operation;
+    box[insert_elt].attr_type = Attr_Unknown;
+    switch (vers)
+    {
+        case 1 :
+            box[insert_elt].op_type = Op_Read_Attr;
+            break;
 
-	case 2 :
-		box[insert_elt].op_type = Op_Read_Attr_2;
-		break;
+        case 2 :
+            box[insert_elt].op_type = Op_Read_Attr_2;
+            break;
 
-	case 3 :
-		box[insert_elt].op_type = Op_Read_Attr_3;
-		break;
+        case 3 :
+            box[insert_elt].op_type = Op_Read_Attr_3;
+            break;
 
-	case 4 :
-		box[insert_elt].op_type = Op_Read_Attr_4;
-		break;
-	}
-	box[insert_elt].source = sour;
-	box[insert_elt].client_ident = false;
+        case 4 :
+            box[insert_elt].op_type = Op_Read_Attr_4;
+            break;
+    }
+    box[insert_elt].source = sour;
+    box[insert_elt].client_ident = false;
 
 
-	box[insert_elt].attr_names.clear();
-	for (unsigned long i = 0;i < names.length();i++)
-	{
-		string tmp_str(names[i]);
-		box[insert_elt].attr_names.push_back(tmp_str);
-	}
+    box[insert_elt].attr_names.clear();
+    for (unsigned long i = 0; i < names.length(); i++)
+    {
+        string tmp_str(names[i]);
+        box[insert_elt].attr_names.push_back(tmp_str);
+    }
 
 #ifdef _TG_WINDOWS_
-//
-// Note that the exact conversion between milli-sec and u-sec will be done only when data is send back to user.
-// This save some times in unnecessary computation
-//
-	struct _timeb t;
-	_ftime(&t);
+    //
+    // Note that the exact conversion between milli-sec and u-sec will be done only when data is send back to user.
+    // This save some times in unnecessary computation
+    //
+        struct _timeb t;
+        _ftime(&t);
 
-	box[insert_elt].when.tv_usec = (long)t.millitm;
-	box[insert_elt].when.tv_sec = (unsigned long)t.time;
+        box[insert_elt].when.tv_usec = (long)t.millitm;
+        box[insert_elt].when.tv_sec = (unsigned long)t.time;
 #else
-	struct timezone tz;
-	gettimeofday(&box[insert_elt].when,&tz);
+    struct timezone tz;
+    gettimeofday(&box[insert_elt].when, &tz);
 #endif
 
 //
 // get client address
 //
 
-	get_client_host();
+    get_client_host();
 
 //
 // manage insert and read indexes
 //
 
-	inc_indexes();
+    inc_indexes();
 
 //
 // Release mutex
 //
 
-	sync.unlock();
+    sync.unlock();
 }
 
-void BlackBox::insert_attr(const Tango::DevVarStringArray &names,const ClntIdent &cl_id,long vers,DevSource sour)
+void BlackBox::insert_attr(const Tango::DevVarStringArray &names, const ClntIdent &cl_id, long vers, DevSource sour)
 {
 
 //
 // Take mutex
 //
 
-	sync.lock();
+    sync.lock();
 
 //
 // Insert elt in the box
 //
 
-	box[insert_elt].req_type = Req_Operation;
-	box[insert_elt].attr_type = Attr_Unknown;
+    box[insert_elt].req_type = Req_Operation;
+    box[insert_elt].attr_type = Attr_Unknown;
 
-	if (vers == 5)
-		box[insert_elt].op_type = Op_Read_Attr_5;
-	else
-		box[insert_elt].op_type = Op_Read_Attr_4;
+    if (vers == 5)
+        box[insert_elt].op_type = Op_Read_Attr_5;
+    else
+        box[insert_elt].op_type = Op_Read_Attr_4;
 
-	box[insert_elt].source = sour;
-	box[insert_elt].client_ident = false;
+    box[insert_elt].source = sour;
+    box[insert_elt].client_ident = false;
 
 
-	box[insert_elt].attr_names.clear();
-	for (unsigned long i = 0;i < names.length();i++)
-	{
-		string tmp_str(names[i]);
-		box[insert_elt].attr_names.push_back(tmp_str);
-	}
+    box[insert_elt].attr_names.clear();
+    for (unsigned long i = 0; i < names.length(); i++)
+    {
+        string tmp_str(names[i]);
+        box[insert_elt].attr_names.push_back(tmp_str);
+    }
 
 #ifdef _TG_WINDOWS_
-//
-// Note that the exact conversion between milli-sec and u-sec will be done only when data is send back to user.
-// This save some times in unnecessary computation
-//
-	struct _timeb t;
-	_ftime(&t);
+    //
+    // Note that the exact conversion between milli-sec and u-sec will be done only when data is send back to user.
+    // This save some times in unnecessary computation
+    //
+        struct _timeb t;
+        _ftime(&t);
 
-	box[insert_elt].when.tv_usec = (long)t.millitm;
-	box[insert_elt].when.tv_sec = (unsigned long)t.time;
+        box[insert_elt].when.tv_usec = (long)t.millitm;
+        box[insert_elt].when.tv_sec = (unsigned long)t.time;
 #else
-	struct timezone tz;
-	gettimeofday(&box[insert_elt].when,&tz);
+    struct timezone tz;
+    gettimeofday(&box[insert_elt].when, &tz);
 #endif
 
 //
 // get client address
 //
 
-	get_client_host();
+    get_client_host();
 
 //
 // manage insert and read indexes but before changing indexex, memorize if the request is done by polling or user
@@ -645,17 +648,17 @@ void BlackBox::insert_attr(const Tango::DevVarStringArray &names,const ClntIdent
         box[insert_elt].host_ip_str[0] == 'i')
         poll_user = true;
 
-	inc_indexes();
+    inc_indexes();
 
 //
 // If request is executed due to polling or from a user thread, simply return
 //
 
-	if (poll_user == true)
-	{
-		sync.unlock();
-		return;
-	}
+    if (poll_user == true)
+    {
+        sync.unlock();
+        return;
+    }
 
     omni_thread::value_t *ip = omni_thread::self()->get_value(key);
 
@@ -663,60 +666,60 @@ void BlackBox::insert_attr(const Tango::DevVarStringArray &names,const ClntIdent
 // Add client ident info into the client_addr instance and into the box
 //
 
-	add_cl_ident(cl_id,static_cast<client_addr *>(ip));
-	update_client_host(static_cast<client_addr *>(ip));
+    add_cl_ident(cl_id, static_cast<client_addr *>(ip));
+    update_client_host(static_cast<client_addr *>(ip));
 
 //
 // Release mutex
 //
 
-	sync.unlock();
+    sync.unlock();
 }
 
-void BlackBox::insert_attr(const char *name,const ClntIdent &cl_id,TANGO_UNUSED(long vers))
+void BlackBox::insert_attr(const char *name, const ClntIdent &cl_id, TANGO_UNUSED(long vers))
 {
 
 //
 // Take mutex
 //
 
-	sync.lock();
+    sync.lock();
 
 //
 // Insert elt in the box
 //
 
-	box[insert_elt].req_type = Req_Operation;
-	box[insert_elt].attr_type = Attr_Unknown;
+    box[insert_elt].req_type = Req_Operation;
+    box[insert_elt].attr_type = Attr_Unknown;
 
-	box[insert_elt].op_type = Op_Read_Pipe_5;
-	box[insert_elt].client_ident = false;
+    box[insert_elt].op_type = Op_Read_Pipe_5;
+    box[insert_elt].client_ident = false;
 
 
-	box[insert_elt].attr_names.clear();
-	string tmp_str(name);
-	box[insert_elt].attr_names.push_back(tmp_str);
+    box[insert_elt].attr_names.clear();
+    string tmp_str(name);
+    box[insert_elt].attr_names.push_back(tmp_str);
 
 #ifdef _TG_WINDOWS_
-//
-// Note that the exact conversion between milli-sec and u-sec will be done only when data is send back to user.
-// This save some times in unnecessary computation
-//
-	struct _timeb t;
-	_ftime(&t);
+    //
+    // Note that the exact conversion between milli-sec and u-sec will be done only when data is send back to user.
+    // This save some times in unnecessary computation
+    //
+        struct _timeb t;
+        _ftime(&t);
 
-	box[insert_elt].when.tv_usec = (long)t.millitm;
-	box[insert_elt].when.tv_sec = (unsigned long)t.time;
+        box[insert_elt].when.tv_usec = (long)t.millitm;
+        box[insert_elt].when.tv_sec = (unsigned long)t.time;
 #else
-	struct timezone tz;
-	gettimeofday(&box[insert_elt].when,&tz);
+    struct timezone tz;
+    gettimeofday(&box[insert_elt].when, &tz);
 #endif
 
 //
 // get client address
 //
 
-	get_client_host();
+    get_client_host();
 
 //
 // manage insert and read indexes
@@ -728,7 +731,7 @@ void BlackBox::insert_attr(const char *name,const ClntIdent &cl_id,TANGO_UNUSED(
         box[insert_elt].host_ip_str[0] == 'i')
         poll_user = true;
 
-	inc_indexes();
+    inc_indexes();
 
 //
 // Add client ident info into the client_addr instance and into the box
@@ -737,7 +740,7 @@ void BlackBox::insert_attr(const char *name,const ClntIdent &cl_id,TANGO_UNUSED(
     if (poll_user == false)
     {
         omni_thread::value_t *ip = omni_thread::self()->get_value(key);
-        add_cl_ident(cl_id,static_cast<client_addr *>(ip));
+        add_cl_ident(cl_id, static_cast<client_addr *>(ip));
         update_client_host(static_cast<client_addr *>(ip));
     }
 
@@ -745,56 +748,56 @@ void BlackBox::insert_attr(const char *name,const ClntIdent &cl_id,TANGO_UNUSED(
 // Release mutex
 //
 
-	sync.unlock();
+    sync.unlock();
 }
 
-void BlackBox::insert_attr(const Tango::DevPipeData &pipe_val,const ClntIdent &cl_id,long vers)
+void BlackBox::insert_attr(const Tango::DevPipeData &pipe_val, const ClntIdent &cl_id, long vers)
 {
 
 //
 // Take mutex
 //
 
-	sync.lock();
+    sync.lock();
 
 //
 // Insert elt in the box
 //
 
-	box[insert_elt].req_type = Req_Operation;
-	box[insert_elt].attr_type = Attr_Unknown;
+    box[insert_elt].req_type = Req_Operation;
+    box[insert_elt].attr_type = Attr_Unknown;
 
-	if (vers == 0)
-		box[insert_elt].op_type = Op_Write_Pipe_5;
-	else
-		box[insert_elt].op_type = Op_Write_Read_Pipe_5;
-	box[insert_elt].client_ident = false;
+    if (vers == 0)
+        box[insert_elt].op_type = Op_Write_Pipe_5;
+    else
+        box[insert_elt].op_type = Op_Write_Read_Pipe_5;
+    box[insert_elt].client_ident = false;
 
 
-	box[insert_elt].attr_names.clear();
-	string tmp_str(pipe_val.name);
-	box[insert_elt].attr_names.push_back(tmp_str);
+    box[insert_elt].attr_names.clear();
+    string tmp_str(pipe_val.name);
+    box[insert_elt].attr_names.push_back(tmp_str);
 
 #ifdef _TG_WINDOWS_
-//
-// Note that the exact conversion between milli-sec and u-sec will be done only when data is send back to user.
-// This save some times in unnecessary computation
-//
-	struct _timeb t;
-	_ftime(&t);
+    //
+    // Note that the exact conversion between milli-sec and u-sec will be done only when data is send back to user.
+    // This save some times in unnecessary computation
+    //
+        struct _timeb t;
+        _ftime(&t);
 
-	box[insert_elt].when.tv_usec = (long)t.millitm;
-	box[insert_elt].when.tv_sec = (unsigned long)t.time;
+        box[insert_elt].when.tv_usec = (long)t.millitm;
+        box[insert_elt].when.tv_sec = (unsigned long)t.time;
 #else
-	struct timezone tz;
-	gettimeofday(&box[insert_elt].when,&tz);
+    struct timezone tz;
+    gettimeofday(&box[insert_elt].when, &tz);
 #endif
 
 //
 // get client address
 //
 
-	get_client_host();
+    get_client_host();
 
 //
 // manage insert and read indexes
@@ -806,7 +809,7 @@ void BlackBox::insert_attr(const Tango::DevPipeData &pipe_val,const ClntIdent &c
         box[insert_elt].host_ip_str[0] == 'i')
         poll_user = true;
 
-	inc_indexes();
+    inc_indexes();
 
 //
 // Add client ident info into the client_addr instance and into the box
@@ -815,7 +818,7 @@ void BlackBox::insert_attr(const Tango::DevPipeData &pipe_val,const ClntIdent &c
     if (poll_user == false)
     {
         omni_thread::value_t *ip = omni_thread::self()->get_value(key);
-        add_cl_ident(cl_id,static_cast<client_addr *>(ip));
+        add_cl_ident(cl_id, static_cast<client_addr *>(ip));
         update_client_host(static_cast<client_addr *>(ip));
     }
 
@@ -823,46 +826,46 @@ void BlackBox::insert_attr(const Tango::DevPipeData &pipe_val,const ClntIdent &c
 // Release mutex
 //
 
-	sync.unlock();
+    sync.unlock();
 }
 
 void BlackBox::insert_attr(const Tango::AttributeValueList &att_list, long vers)
 {
-	sync.lock();
+    sync.lock();
 
-	insert_attr_nl(att_list,vers);
+    insert_attr_nl(att_list, vers);
 
-	sync.unlock();
+    sync.unlock();
 }
 
-void BlackBox::insert_attr(const Tango::AttributeValueList_4 &att_list, const ClntIdent &cl_id,TANGO_UNUSED(long vers))
+void BlackBox::insert_attr(const Tango::AttributeValueList_4 &att_list, const ClntIdent &cl_id, TANGO_UNUSED(long vers))
 {
-	sync.lock();
+    sync.lock();
 
     long old_insert = insert_elt;
-	insert_attr_nl_4(att_list);
+    insert_attr_nl_4(att_list);
 
 //
 // Check if the command is executed due to polling. If true, simply return
 //
 
-	if (box[old_insert].host_ip_str[0] == 'p' ||
+    if (box[old_insert].host_ip_str[0] == 'p' ||
         box[old_insert].host_ip_str[0] == 'u' ||
         box[old_insert].host_ip_str[0] == 'i')
-	{
-		sync.unlock();
-		return;
-	}
+    {
+        sync.unlock();
+        return;
+    }
 
 //
 // Add client ident info into the client_addr instance and into the box
 //
 
-	omni_thread::value_t *ip = omni_thread::self()->get_value(key);
-	add_cl_ident(cl_id,static_cast<client_addr *>(ip));
-	update_client_host(static_cast<client_addr *>(ip));
+    omni_thread::value_t *ip = omni_thread::self()->get_value(key);
+    add_cl_ident(cl_id, static_cast<client_addr *>(ip));
+    update_client_host(static_cast<client_addr *>(ip));
 
-	sync.unlock();
+    sync.unlock();
 }
 
 void BlackBox::insert_attr_nl(const Tango::AttributeValueList &att_list, long vers)
@@ -871,49 +874,49 @@ void BlackBox::insert_attr_nl(const Tango::AttributeValueList &att_list, long ve
 // Insert elt in the box
 //
 
-	box[insert_elt].req_type = Req_Operation;
-	box[insert_elt].attr_type = Attr_Unknown;
-	if (vers == 1)
-		box[insert_elt].op_type = Op_Write_Attr;
-	else if (vers < 4)
-		box[insert_elt].op_type = Op_Write_Attr_3;
-	else
-		box[insert_elt].op_type = Op_Write_Attr_4;
+    box[insert_elt].req_type = Req_Operation;
+    box[insert_elt].attr_type = Attr_Unknown;
+    if (vers == 1)
+        box[insert_elt].op_type = Op_Write_Attr;
+    else if (vers < 4)
+        box[insert_elt].op_type = Op_Write_Attr_3;
+    else
+        box[insert_elt].op_type = Op_Write_Attr_4;
 
-	box[insert_elt].attr_names.clear();
-	for (unsigned long i = 0;i < att_list.length();i++)
-	{
-		string tmp_str(att_list[i].name);
-		box[insert_elt].attr_names.push_back(tmp_str);
-	}
-	box[insert_elt].client_ident = false;
+    box[insert_elt].attr_names.clear();
+    for (unsigned long i = 0; i < att_list.length(); i++)
+    {
+        string tmp_str(att_list[i].name);
+        box[insert_elt].attr_names.push_back(tmp_str);
+    }
+    box[insert_elt].client_ident = false;
 
 #ifdef _TG_WINDOWS_
-//
-// Note that the exact conversion between milli-sec and u-sec will be done only when data is send back to user.
-// This save some times in unnecessary computation
-//
-	struct _timeb t;
-	_ftime(&t);
+    //
+    // Note that the exact conversion between milli-sec and u-sec will be done only when data is send back to user.
+    // This save some times in unnecessary computation
+    //
+        struct _timeb t;
+        _ftime(&t);
 
-	box[insert_elt].when.tv_usec = (long)t.millitm;
-	box[insert_elt].when.tv_sec = (unsigned long)t.time;
+        box[insert_elt].when.tv_usec = (long)t.millitm;
+        box[insert_elt].when.tv_sec = (unsigned long)t.time;
 #else
-	struct timezone tz;
-	gettimeofday(&box[insert_elt].when,&tz);
+    struct timezone tz;
+    gettimeofday(&box[insert_elt].when, &tz);
 #endif
 
 //
 // get client address
 //
 
-	get_client_host();
+    get_client_host();
 
 //
 // manage insert and read indexes
 //
 
-	inc_indexes();
+    inc_indexes();
 }
 
 void BlackBox::insert_attr_nl_4(const Tango::AttributeValueList_4 &att_list)
@@ -922,43 +925,43 @@ void BlackBox::insert_attr_nl_4(const Tango::AttributeValueList_4 &att_list)
 // Insert elt in the box
 //
 
-	box[insert_elt].req_type = Req_Operation;
-	box[insert_elt].attr_type = Attr_Unknown;
-	box[insert_elt].op_type = Op_Write_Attr_4;
+    box[insert_elt].req_type = Req_Operation;
+    box[insert_elt].attr_type = Attr_Unknown;
+    box[insert_elt].op_type = Op_Write_Attr_4;
 
-	box[insert_elt].attr_names.clear();
-	for (unsigned long i = 0;i < att_list.length();i++)
-	{
-		string tmp_str(att_list[i].name);
-		box[insert_elt].attr_names.push_back(tmp_str);
-	}
+    box[insert_elt].attr_names.clear();
+    for (unsigned long i = 0; i < att_list.length(); i++)
+    {
+        string tmp_str(att_list[i].name);
+        box[insert_elt].attr_names.push_back(tmp_str);
+    }
 
 #ifdef _TG_WINDOWS_
-//
-// Note that the exact conversion between milli-sec and u-sec will be done only when data is send back to user.
-// This save some times in unnecessary computation
-//
-	struct _timeb t;
-	_ftime(&t);
+    //
+    // Note that the exact conversion between milli-sec and u-sec will be done only when data is send back to user.
+    // This save some times in unnecessary computation
+    //
+        struct _timeb t;
+        _ftime(&t);
 
-	box[insert_elt].when.tv_usec = (long)t.millitm;
-	box[insert_elt].when.tv_sec = (unsigned long)t.time;
+        box[insert_elt].when.tv_usec = (long)t.millitm;
+        box[insert_elt].when.tv_sec = (unsigned long)t.time;
 #else
-	struct timezone tz;
-	gettimeofday(&box[insert_elt].when,&tz);
+    struct timezone tz;
+    gettimeofday(&box[insert_elt].when, &tz);
 #endif
 
 //
 // get client address
 //
 
-	get_client_host();
+    get_client_host();
 
 //
 // manage insert and read indexes
 //
 
-	inc_indexes();
+    inc_indexes();
 }
 
 //+--------------------------------------------------------------------------------------------------------------------
@@ -979,90 +982,95 @@ void BlackBox::insert_attr_nl_4(const Tango::AttributeValueList_4 &att_list)
 //
 //---------------------------------------------------------------------------------------------------------------------
 
-void BlackBox::insert_wr_attr(const Tango::AttributeValueList_4 &att_list,const Tango::DevVarStringArray &r_names,const ClntIdent &cl_id,long vers)
+void BlackBox::insert_wr_attr(const Tango::AttributeValueList_4 &att_list,
+                              const Tango::DevVarStringArray &r_names,
+                              const ClntIdent &cl_id,
+                              long vers)
 {
-	sync.lock();
+    sync.lock();
 
     long old_insert = insert_elt;
-	insert_attr_wr_nl(att_list,r_names,vers);
+    insert_attr_wr_nl(att_list, r_names, vers);
 
 //
 // If request coming from polling thread or user thread, leave method
 //
 
-	if (box[old_insert].host_ip_str[0] == 'p' ||
+    if (box[old_insert].host_ip_str[0] == 'p' ||
         box[old_insert].host_ip_str[0] == 'u' ||
         box[old_insert].host_ip_str[0] == 'i')
-	{
-		sync.unlock();
-		return;
-	}
+    {
+        sync.unlock();
+        return;
+    }
 
 //
 // Add client ident info into the client_addr instance and into the box
 //
 
-	omni_thread::value_t *ip = omni_thread::self()->get_value(key);
-	add_cl_ident(cl_id,static_cast<client_addr *>(ip));
-	update_client_host(static_cast<client_addr *>(ip));
+    omni_thread::value_t *ip = omni_thread::self()->get_value(key);
+    add_cl_ident(cl_id, static_cast<client_addr *>(ip));
+    update_client_host(static_cast<client_addr *>(ip));
 
-	sync.unlock();
+    sync.unlock();
 }
 
-void BlackBox::insert_attr_wr_nl(const Tango::AttributeValueList_4 &att_list,const Tango::DevVarStringArray &r_names,long vers)
+void BlackBox::insert_attr_wr_nl(const Tango::AttributeValueList_4 &att_list,
+                                 const Tango::DevVarStringArray &r_names,
+                                 long vers)
 {
 //
 // Insert elt in the box
 //
 
-	box[insert_elt].req_type = Req_Operation;
-	box[insert_elt].attr_type = Attr_Unknown;
-	if (vers == 5)
-		box[insert_elt].op_type = Op_Write_Read_Attributes_5;
-	else
-		box[insert_elt].op_type = Op_Write_Read_Attributes_4;
+    box[insert_elt].req_type = Req_Operation;
+    box[insert_elt].attr_type = Attr_Unknown;
+    if (vers == 5)
+        box[insert_elt].op_type = Op_Write_Read_Attributes_5;
+    else
+        box[insert_elt].op_type = Op_Write_Read_Attributes_4;
 
-	box[insert_elt].attr_names.clear();
-	for (unsigned long i = 0;i < att_list.length();i++)
-	{
-		string tmp_str(att_list[i].name);
-		box[insert_elt].attr_names.push_back(tmp_str);
-	}
+    box[insert_elt].attr_names.clear();
+    for (unsigned long i = 0; i < att_list.length(); i++)
+    {
+        string tmp_str(att_list[i].name);
+        box[insert_elt].attr_names.push_back(tmp_str);
+    }
 
-	box[insert_elt].attr_names.push_back(string("/"));
+    box[insert_elt].attr_names.push_back(string("/"));
 
-	for (unsigned long i = 0;i < r_names.length();i++)
-	{
-		string tmp_str(r_names[i]);
-		box[insert_elt].attr_names.push_back(tmp_str);
-	}
+    for (unsigned long i = 0; i < r_names.length(); i++)
+    {
+        string tmp_str(r_names[i]);
+        box[insert_elt].attr_names.push_back(tmp_str);
+    }
 
 #ifdef _TG_WINDOWS_
-//
-// Note that the exact conversion between milli-sec and u-sec will be done only when data is send back to user.
-// This save some times in unnecessary computation
-//
-	struct _timeb t;
-	_ftime(&t);
+    //
+    // Note that the exact conversion between milli-sec and u-sec will be done only when data is send back to user.
+    // This save some times in unnecessary computation
+    //
+        struct _timeb t;
+        _ftime(&t);
 
-	box[insert_elt].when.tv_usec = (long)t.millitm;
-	box[insert_elt].when.tv_sec = (unsigned long)t.time;
+        box[insert_elt].when.tv_usec = (long)t.millitm;
+        box[insert_elt].when.tv_sec = (unsigned long)t.time;
 #else
-	struct timezone tz;
-	gettimeofday(&box[insert_elt].when,&tz);
+    struct timezone tz;
+    gettimeofday(&box[insert_elt].when, &tz);
 #endif
 
 //
 // get client address
 //
 
-	get_client_host();
+    get_client_host();
 
 //
 // manage insert and read indexes
 //
 
-	inc_indexes();
+    inc_indexes();
 }
 
 //+-------------------------------------------------------------------------------------------------------------------
@@ -1079,12 +1087,12 @@ void BlackBox::insert_attr_wr_nl(const Tango::AttributeValueList_4 &att_list,con
 
 void BlackBox::inc_indexes()
 {
-	insert_elt++;
-	if (insert_elt == max_elt)
-		insert_elt = 0;
+    insert_elt++;
+    if (insert_elt == max_elt)
+        insert_elt = 0;
 
-	if (nb_elt != max_elt)
-		nb_elt++;
+    if (nb_elt != max_elt)
+        nb_elt++;
 }
 
 //+-------------------------------------------------------------------------------------------------------------------
@@ -1099,12 +1107,12 @@ void BlackBox::inc_indexes()
 
 void BlackBox::get_client_host()
 {
-	omni_thread *th_id = omni_thread::self();
-	if (th_id == NULL)
-		th_id = omni_thread::create_dummy();
+    omni_thread *th_id = omni_thread::self();
+    if (th_id == NULL)
+        th_id = omni_thread::create_dummy();
 
-	omni_thread::value_t *ip = th_id->get_value(key);
-	if (ip == NULL)
+    omni_thread::value_t *ip = th_id->get_value(key);
+    if (ip == NULL)
     {
         Tango::Util *tg = Tango::Util::instance();
         vector<PollingThreadInfo *> &poll_ths = tg->get_polling_threads_info();
@@ -1115,7 +1123,7 @@ void BlackBox::get_client_host()
             int this_thread_id = th_id->id();
             size_t nb_poll_th = poll_ths.size();
             size_t loop;
-            for (loop = 0;loop < nb_poll_th;loop++)
+            for (loop = 0; loop < nb_poll_th; loop++)
             {
                 if (this_thread_id == poll_ths[loop]->thread_id)
                 {
@@ -1128,20 +1136,20 @@ void BlackBox::get_client_host()
         if (tg->is_svr_starting() == true)
         {
             if (found_thread == true)
-                strcpy(box[insert_elt].host_ip_str,"polling");
+                strcpy(box[insert_elt].host_ip_str, "polling");
             else
-                strcpy(box[insert_elt].host_ip_str,"init");
+                strcpy(box[insert_elt].host_ip_str, "init");
         }
         else
         {
             if (found_thread == true)
-                strcpy(box[insert_elt].host_ip_str,"polling");
+                strcpy(box[insert_elt].host_ip_str, "polling");
             else
-                strcpy(box[insert_elt].host_ip_str,"user thread");
+                strcpy(box[insert_elt].host_ip_str, "user thread");
         }
     }
-	else
-		strcpy(box[insert_elt].host_ip_str,(static_cast<client_addr *>(ip))->client_ip);
+    else
+        strcpy(box[insert_elt].host_ip_str, (static_cast<client_addr *>(ip))->client_ip);
 }
 
 //+-------------------------------------------------------------------------------------------------------------------
@@ -1160,343 +1168,343 @@ void BlackBox::get_client_host()
 
 void BlackBox::build_info_as_str(long index)
 {
-	char date_str[25];
+    char date_str[25];
 //
 // Convert time to a string
 //
 
-	date_ux_to_str(box[index].when,date_str);
-	elt_str = date_str;
+    date_ux_to_str(box[index].when, date_str);
+    elt_str = date_str;
 
 //
 // Add request type and command name in case of
 //
 
-	elt_str = elt_str + " : ";
+    elt_str = elt_str + " : ";
 
-	if (box[index].req_type == Req_Operation)
-	{
-		elt_str = elt_str + "Operation ";
-		unsigned long i;
-		unsigned long nb_in_vect;
+    if (box[index].req_type == Req_Operation)
+    {
+        elt_str = elt_str + "Operation ";
+        unsigned long i;
+        unsigned long nb_in_vect;
 
-		switch (box[index].op_type)
-		{
-		case Op_Command_inout :
-			elt_str = elt_str + "command_inout (cmd = " + box[index].cmd_name + ") from ";
-			add_source(index);
-			break;
+        switch (box[index].op_type)
+        {
+            case Op_Command_inout :
+                elt_str = elt_str + "command_inout (cmd = " + box[index].cmd_name + ") from ";
+                add_source(index);
+                break;
 
-		case Op_Ping :
-			elt_str = elt_str + "ping ";
-			break;
+            case Op_Ping :
+                elt_str = elt_str + "ping ";
+                break;
 
-		case Op_Info :
-			elt_str = elt_str + "info ";
-			break;
+            case Op_Info :
+                elt_str = elt_str + "info ";
+                break;
 
-		case Op_BlackBox :
-			elt_str = elt_str + "blackbox ";
-			break;
+            case Op_BlackBox :
+                elt_str = elt_str + "blackbox ";
+                break;
 
-		case Op_Command_list :
-			elt_str = elt_str + "command_list_query ";
-			break;
+            case Op_Command_list :
+                elt_str = elt_str + "command_list_query ";
+                break;
 
-		case Op_Command :
-			elt_str = elt_str + "command_query ";
-			break;
+            case Op_Command :
+                elt_str = elt_str + "command_query ";
+                break;
 
-		case Op_Get_Attr_Config :
-			elt_str = elt_str + "get_attribute_config ";
-			break;
+            case Op_Get_Attr_Config :
+                elt_str = elt_str + "get_attribute_config ";
+                break;
 
-		case Op_Set_Attr_Config :
-			elt_str = elt_str + "set_attribute_config ";
-			break;
+            case Op_Set_Attr_Config :
+                elt_str = elt_str + "set_attribute_config ";
+                break;
 
-		case Op_Read_Attr :
-			elt_str = elt_str + "read_attributes (";
-			nb_in_vect = box[index].attr_names.size();
-			for (i = 0;i < nb_in_vect;i++)
-			{
-				elt_str = elt_str + box[index].attr_names[i];
-				if (i != nb_in_vect - 1)
-					elt_str = elt_str + ", ";
-			}
-			elt_str = elt_str + ") from ";
-			add_source(index);
-			break;
+            case Op_Read_Attr :
+                elt_str = elt_str + "read_attributes (";
+                nb_in_vect = box[index].attr_names.size();
+                for (i = 0; i < nb_in_vect; i++)
+                {
+                    elt_str = elt_str + box[index].attr_names[i];
+                    if (i != nb_in_vect - 1)
+                        elt_str = elt_str + ", ";
+                }
+                elt_str = elt_str + ") from ";
+                add_source(index);
+                break;
 
-		case Op_Write_Attr :
-			elt_str = elt_str + "write_attributes (";
-			nb_in_vect = box[index].attr_names.size();
-			for (i = 0;i < nb_in_vect;i++)
-			{
-				elt_str = elt_str + box[index].attr_names[i];
-				if (i != nb_in_vect - 1)
-					elt_str = elt_str + ", ";
-			}
-			elt_str = elt_str + ") ";
-			break;
+            case Op_Write_Attr :
+                elt_str = elt_str + "write_attributes (";
+                nb_in_vect = box[index].attr_names.size();
+                for (i = 0; i < nb_in_vect; i++)
+                {
+                    elt_str = elt_str + box[index].attr_names[i];
+                    if (i != nb_in_vect - 1)
+                        elt_str = elt_str + ", ";
+                }
+                elt_str = elt_str + ") ";
+                break;
 
-		case Op_Write_Attr_3 :
-			elt_str = elt_str + "write_attributes_3 (";
-			nb_in_vect = box[index].attr_names.size();
-			for (i = 0;i < nb_in_vect;i++)
-			{
-				elt_str = elt_str + box[index].attr_names[i];
-				if (i != nb_in_vect - 1)
-					elt_str = elt_str + ", ";
-			}
-			elt_str = elt_str + ") ";
-			break;
+            case Op_Write_Attr_3 :
+                elt_str = elt_str + "write_attributes_3 (";
+                nb_in_vect = box[index].attr_names.size();
+                for (i = 0; i < nb_in_vect; i++)
+                {
+                    elt_str = elt_str + box[index].attr_names[i];
+                    if (i != nb_in_vect - 1)
+                        elt_str = elt_str + ", ";
+                }
+                elt_str = elt_str + ") ";
+                break;
 
-		case Op_Command_inout_2 :
-			elt_str = elt_str + "command_inout_2 (cmd = " + box[index].cmd_name + ") from ";
-			add_source(index);
-			break;
+            case Op_Command_inout_2 :
+                elt_str = elt_str + "command_inout_2 (cmd = " + box[index].cmd_name + ") from ";
+                add_source(index);
+                break;
 
-		case Op_Command_list_2 :
-			elt_str = elt_str + "command_list_query_2 ";
-			break;
+            case Op_Command_list_2 :
+                elt_str = elt_str + "command_list_query_2 ";
+                break;
 
-		case Op_Command_2 :
-			elt_str = elt_str + "command_query_2 ";
-			break;
+            case Op_Command_2 :
+                elt_str = elt_str + "command_query_2 ";
+                break;
 
-		case Op_Get_Attr_Config_2 :
-			elt_str = elt_str + "get_attribute_config_2 ";
-			break;
+            case Op_Get_Attr_Config_2 :
+                elt_str = elt_str + "get_attribute_config_2 ";
+                break;
 
-		case Op_Read_Attr_2 :
-			elt_str = elt_str + "read_attributes_2 (";
-			nb_in_vect = box[index].attr_names.size();
-			for (i = 0;i < nb_in_vect;i++)
-			{
-				elt_str = elt_str + box[index].attr_names[i];
-				if (i != nb_in_vect - 1)
-					elt_str = elt_str + ", ";
-			}
-			elt_str = elt_str + ") from ";
-			add_source(index);
-			break;
+            case Op_Read_Attr_2 :
+                elt_str = elt_str + "read_attributes_2 (";
+                nb_in_vect = box[index].attr_names.size();
+                for (i = 0; i < nb_in_vect; i++)
+                {
+                    elt_str = elt_str + box[index].attr_names[i];
+                    if (i != nb_in_vect - 1)
+                        elt_str = elt_str + ", ";
+                }
+                elt_str = elt_str + ") from ";
+                add_source(index);
+                break;
 
-		case Op_Read_Attr_3 :
-			elt_str = elt_str + "read_attributes_3 (";
-			nb_in_vect = box[index].attr_names.size();
-			for (i = 0;i < nb_in_vect;i++)
-			{
-				elt_str = elt_str + box[index].attr_names[i];
-				if (i != nb_in_vect - 1)
-					elt_str = elt_str + ", ";
-			}
-			elt_str = elt_str + ") from ";
-			add_source(index);
-			break;
+            case Op_Read_Attr_3 :
+                elt_str = elt_str + "read_attributes_3 (";
+                nb_in_vect = box[index].attr_names.size();
+                for (i = 0; i < nb_in_vect; i++)
+                {
+                    elt_str = elt_str + box[index].attr_names[i];
+                    if (i != nb_in_vect - 1)
+                        elt_str = elt_str + ", ";
+                }
+                elt_str = elt_str + ") from ";
+                add_source(index);
+                break;
 
-		case Op_Command_inout_history_2 :
-			elt_str = elt_str + "command_inout_history_2 ";
-			break;
+            case Op_Command_inout_history_2 :
+                elt_str = elt_str + "command_inout_history_2 ";
+                break;
 
-		case Op_Read_Attr_history_2 :
-			elt_str = elt_str + "read_attribute_history_2 ";
-			break;
+            case Op_Read_Attr_history_2 :
+                elt_str = elt_str + "read_attribute_history_2 ";
+                break;
 
-		case Op_Read_Attr_history_3 :
-			elt_str = elt_str + "read_attribute_history_3 ";
-			break;
+            case Op_Read_Attr_history_3 :
+                elt_str = elt_str + "read_attribute_history_3 ";
+                break;
 
-		case Op_Info_3 :
-			elt_str = elt_str + "info_3 ";
-			break;
+            case Op_Info_3 :
+                elt_str = elt_str + "info_3 ";
+                break;
 
-		case Op_Get_Attr_Config_3 :
-			elt_str = elt_str + "get_attribute_config_3 ";
-			break;
+            case Op_Get_Attr_Config_3 :
+                elt_str = elt_str + "get_attribute_config_3 ";
+                break;
 
-		case Op_Set_Attr_Config_3 :
-			elt_str = elt_str + "set_attribute_config_3 ";
-			break;
+            case Op_Set_Attr_Config_3 :
+                elt_str = elt_str + "set_attribute_config_3 ";
+                break;
 
-		case Op_Read_Attr_history_4 :
-			elt_str = elt_str + "read_attribute_history_4 ";
-			break;
+            case Op_Read_Attr_history_4 :
+                elt_str = elt_str + "read_attribute_history_4 ";
+                break;
 
-		case Op_Command_inout_history_4 :
-			elt_str = elt_str + "command_inout_history_4 ";
-			break;
+            case Op_Command_inout_history_4 :
+                elt_str = elt_str + "command_inout_history_4 ";
+                break;
 
-		case Op_Command_inout_4 :
-			elt_str = elt_str + "command_inout_4 (cmd = " + box[index].cmd_name + ") from ";
-			add_source(index);
-			break;
+            case Op_Command_inout_4 :
+                elt_str = elt_str + "command_inout_4 (cmd = " + box[index].cmd_name + ") from ";
+                add_source(index);
+                break;
 
-		case Op_Read_Attr_4 :
-			elt_str = elt_str + "read_attributes_4 (";
-			nb_in_vect = box[index].attr_names.size();
-			for (i = 0;i < nb_in_vect;i++)
-			{
-				elt_str = elt_str + box[index].attr_names[i];
-				if (i != nb_in_vect - 1)
-					elt_str = elt_str + ", ";
-			}
-			elt_str = elt_str + ") from ";
-			add_source(index);
-			break;
+            case Op_Read_Attr_4 :
+                elt_str = elt_str + "read_attributes_4 (";
+                nb_in_vect = box[index].attr_names.size();
+                for (i = 0; i < nb_in_vect; i++)
+                {
+                    elt_str = elt_str + box[index].attr_names[i];
+                    if (i != nb_in_vect - 1)
+                        elt_str = elt_str + ", ";
+                }
+                elt_str = elt_str + ") from ";
+                add_source(index);
+                break;
 
-		case Op_Write_Attr_4 :
-			elt_str = elt_str + "write_attributes_4 (";
-			nb_in_vect = box[index].attr_names.size();
-			for (i = 0;i < nb_in_vect;i++)
-			{
-				elt_str = elt_str + box[index].attr_names[i];
-				if (i != nb_in_vect - 1)
-					elt_str = elt_str + ", ";
-			}
-			elt_str = elt_str + ") ";
-			break;
+            case Op_Write_Attr_4 :
+                elt_str = elt_str + "write_attributes_4 (";
+                nb_in_vect = box[index].attr_names.size();
+                for (i = 0; i < nb_in_vect; i++)
+                {
+                    elt_str = elt_str + box[index].attr_names[i];
+                    if (i != nb_in_vect - 1)
+                        elt_str = elt_str + ", ";
+                }
+                elt_str = elt_str + ") ";
+                break;
 
-		case Op_Set_Attr_Config_4 :
-			elt_str = elt_str + "set_attribute_config_4 ";
-			break;
+            case Op_Set_Attr_Config_4 :
+                elt_str = elt_str + "set_attribute_config_4 ";
+                break;
 
-		case Op_Write_Read_Attributes_4 :
-			elt_str = elt_str + "write_read_attributes_4 (";
-			nb_in_vect = box[index].attr_names.size();
-			for (i = 0;i < nb_in_vect;i++)
-			{
-				elt_str = elt_str + box[index].attr_names[i];
-				if (i != nb_in_vect - 1)
-					elt_str = elt_str + ", ";
-			}
-			elt_str = elt_str + ") ";
-			break;
+            case Op_Write_Read_Attributes_4 :
+                elt_str = elt_str + "write_read_attributes_4 (";
+                nb_in_vect = box[index].attr_names.size();
+                for (i = 0; i < nb_in_vect; i++)
+                {
+                    elt_str = elt_str + box[index].attr_names[i];
+                    if (i != nb_in_vect - 1)
+                        elt_str = elt_str + ", ";
+                }
+                elt_str = elt_str + ") ";
+                break;
 
-		case Op_Get_Attr_Config_5 :
-			elt_str = elt_str + "get_attribute_config_5 ";
-			break;
+            case Op_Get_Attr_Config_5 :
+                elt_str = elt_str + "get_attribute_config_5 ";
+                break;
 
-		case Op_Set_Attr_Config_5 :
-			elt_str = elt_str + "set_attribute_config_5 ";
-			break;
+            case Op_Set_Attr_Config_5 :
+                elt_str = elt_str + "set_attribute_config_5 ";
+                break;
 
-		case Op_Read_Attr_5 :
-			elt_str = elt_str + "read_attributes_5 (";
-			nb_in_vect = box[index].attr_names.size();
-			for (i = 0;i < nb_in_vect;i++)
-			{
-				elt_str = elt_str + box[index].attr_names[i];
-				if (i != nb_in_vect - 1)
-					elt_str = elt_str + ", ";
-			}
-			elt_str = elt_str + ") from ";
-			add_source(index);
-			break;
+            case Op_Read_Attr_5 :
+                elt_str = elt_str + "read_attributes_5 (";
+                nb_in_vect = box[index].attr_names.size();
+                for (i = 0; i < nb_in_vect; i++)
+                {
+                    elt_str = elt_str + box[index].attr_names[i];
+                    if (i != nb_in_vect - 1)
+                        elt_str = elt_str + ", ";
+                }
+                elt_str = elt_str + ") from ";
+                add_source(index);
+                break;
 
-		case Op_Write_Read_Attributes_5 :
-			elt_str = elt_str + "write_read_attributes_5 (";
-			nb_in_vect = box[index].attr_names.size();
-			for (i = 0;i < nb_in_vect;i++)
-			{
-				elt_str = elt_str + box[index].attr_names[i];
-				if (i != nb_in_vect - 1 && box[index].attr_names[i] != "/")
-				{
-					if (box[index].attr_names[i + 1] != "/")
-						elt_str = elt_str + ", ";
-				}
-			}
-			elt_str = elt_str + ") ";
-			break;
+            case Op_Write_Read_Attributes_5 :
+                elt_str = elt_str + "write_read_attributes_5 (";
+                nb_in_vect = box[index].attr_names.size();
+                for (i = 0; i < nb_in_vect; i++)
+                {
+                    elt_str = elt_str + box[index].attr_names[i];
+                    if (i != nb_in_vect - 1 && box[index].attr_names[i] != "/")
+                    {
+                        if (box[index].attr_names[i + 1] != "/")
+                            elt_str = elt_str + ", ";
+                    }
+                }
+                elt_str = elt_str + ") ";
+                break;
 
-		case Op_Read_Attr_history_5 :
-			elt_str = elt_str + "read_attribute_history_5 ";
-			break;
+            case Op_Read_Attr_history_5 :
+                elt_str = elt_str + "read_attribute_history_5 ";
+                break;
 
-		case Op_Get_Pipe_Config_5 :
-			elt_str = elt_str + "get_pipe_config_5 ";
-			break;
+            case Op_Get_Pipe_Config_5 :
+                elt_str = elt_str + "get_pipe_config_5 ";
+                break;
 
-		case Op_Set_Pipe_Config_5 :
-			elt_str = elt_str + "set_pipe_config_5 ";
-			break;
+            case Op_Set_Pipe_Config_5 :
+                elt_str = elt_str + "set_pipe_config_5 ";
+                break;
 
-		case Op_Read_Pipe_5 :
-			elt_str = elt_str + "read_pipe_5 (";
-			nb_in_vect = box[index].attr_names.size();
-			for (i = 0;i < nb_in_vect;i++)
-			{
-				elt_str = elt_str + box[index].attr_names[i];
-				if (i != nb_in_vect - 1)
-					elt_str = elt_str + ", ";
-			}
-			elt_str = elt_str + ") ";
-			break;
+            case Op_Read_Pipe_5 :
+                elt_str = elt_str + "read_pipe_5 (";
+                nb_in_vect = box[index].attr_names.size();
+                for (i = 0; i < nb_in_vect; i++)
+                {
+                    elt_str = elt_str + box[index].attr_names[i];
+                    if (i != nb_in_vect - 1)
+                        elt_str = elt_str + ", ";
+                }
+                elt_str = elt_str + ") ";
+                break;
 
-		case Op_Write_Pipe_5 :
-			elt_str = elt_str + "write_pipe_5 (";
-			nb_in_vect = box[index].attr_names.size();
-			for (i = 0;i < nb_in_vect;i++)
-			{
-				elt_str = elt_str + box[index].attr_names[i];
-				if (i != nb_in_vect - 1)
-					elt_str = elt_str + ", ";
-			}
-			elt_str = elt_str + ") ";
-			break;
+            case Op_Write_Pipe_5 :
+                elt_str = elt_str + "write_pipe_5 (";
+                nb_in_vect = box[index].attr_names.size();
+                for (i = 0; i < nb_in_vect; i++)
+                {
+                    elt_str = elt_str + box[index].attr_names[i];
+                    if (i != nb_in_vect - 1)
+                        elt_str = elt_str + ", ";
+                }
+                elt_str = elt_str + ") ";
+                break;
 
-		case Op_Write_Read_Pipe_5 :
-			elt_str = elt_str + "write_read_pipe_5 (";
-			nb_in_vect = box[index].attr_names.size();
-			for (i = 0;i < nb_in_vect;i++)
-			{
-				elt_str = elt_str + box[index].attr_names[i];
-				if (i != nb_in_vect - 1)
-					elt_str = elt_str + ", ";
-			}
-			elt_str = elt_str + ") ";
-			break;
+            case Op_Write_Read_Pipe_5 :
+                elt_str = elt_str + "write_read_pipe_5 (";
+                nb_in_vect = box[index].attr_names.size();
+                for (i = 0; i < nb_in_vect; i++)
+                {
+                    elt_str = elt_str + box[index].attr_names[i];
+                    if (i != nb_in_vect - 1)
+                        elt_str = elt_str + ", ";
+                }
+                elt_str = elt_str + ") ";
+                break;
 
-		case Op_Unknown :
-			elt_str = elt_str + "unknown operation !!!!!";
-			return;
-		}
-	}
-	else if (box[index].req_type == Req_Attribute)
-	{
-		elt_str = elt_str + "Attribute ";
-		switch (box[index].attr_type)
-		{
-		case Attr_Name :
-			elt_str = elt_str + "name ";
-			break;
+            case Op_Unknown :
+                elt_str = elt_str + "unknown operation !!!!!";
+                return;
+        }
+    }
+    else if (box[index].req_type == Req_Attribute)
+    {
+        elt_str = elt_str + "Attribute ";
+        switch (box[index].attr_type)
+        {
+            case Attr_Name :
+                elt_str = elt_str + "name ";
+                break;
 
-		case Attr_Description :
-			elt_str = elt_str + "description ";
-			break;
+            case Attr_Description :
+                elt_str = elt_str + "description ";
+                break;
 
-		case Attr_Status :
-			elt_str = elt_str + "status ";
-			break;
+            case Attr_Status :
+                elt_str = elt_str + "status ";
+                break;
 
-		case Attr_State :
-			elt_str = elt_str + "state ";
-			break;
+            case Attr_State :
+                elt_str = elt_str + "state ";
+                break;
 
-		case Attr_AdmName :
-			elt_str = elt_str + "adm_name ";
-			break;
+            case Attr_AdmName :
+                elt_str = elt_str + "adm_name ";
+                break;
 
-		case Attr_Unknown :
-			elt_str = elt_str + "unknown attribute !!!!!";
-			return;
-		}
-	}
-	else
-	{
-		elt_str = elt_str + "Unknown CORBA request type !!!!!";
-		return;
-	}
+            case Attr_Unknown :
+                elt_str = elt_str + "unknown attribute !!!!!";
+                return;
+        }
+    }
+    else
+    {
+        elt_str = elt_str + "Unknown CORBA request type !!!!!";
+        return;
+    }
 
 //
 // Add client host name.
@@ -1504,158 +1512,158 @@ void BlackBox::build_info_as_str(long index)
 // Return in case of badly formed address
 //
 
-	if ((box[index].host_ip_str[0] != '\0') &&
-	    (box[index].host_ip_str[0] != 'p') &&
-		(box[index].host_ip_str[5] != 'u') &&
+    if ((box[index].host_ip_str[0] != '\0') &&
+        (box[index].host_ip_str[0] != 'p') &&
+        (box[index].host_ip_str[5] != 'u') &&
         (box[index].host_ip_str[0] != 'i') &&
         (box[index].host_ip_str[0] != 'u'))
-	{
-		bool ipv6=false;
-		string omni_addr = box[index].host_ip_str;
-		string::size_type pos;
-		if ((pos = omni_addr.find(':')) == string::npos)
-			return;
-		pos++;
-		if ((pos = omni_addr.find(':',pos)) == string::npos)
-			return;
-		pos++;
-		string ip_str = omni_addr.substr(pos);
-		if (ip_str[0] == '[')
-			ipv6 = true;
+    {
+        bool ipv6 = false;
+        string omni_addr = box[index].host_ip_str;
+        string::size_type pos;
+        if ((pos = omni_addr.find(':')) == string::npos)
+            return;
+        pos++;
+        if ((pos = omni_addr.find(':', pos)) == string::npos)
+            return;
+        pos++;
+        string ip_str = omni_addr.substr(pos);
+        if (ip_str[0] == '[')
+            ipv6 = true;
 
-		string full_ip_str;
-		if (ipv6 == false)
-		{
-			if ((pos = ip_str.find(':')) == string::npos)
-				return;
-			full_ip_str = ip_str.substr(0,pos);
-		}
-		else
-		{
-			if ((pos = ip_str.find(':')) == string::npos)
-				return;
-			pos++;
-			if ((pos = ip_str.find(':',pos)) == string::npos)
-				return;
-			pos++;
-			if ((pos = ip_str.find(':',pos)) == string::npos)
-				return;
-			pos++;
-			string tmp_ip = ip_str.substr(pos);
-			if ((pos = tmp_ip.find(']')) == string::npos)
-				return;
-			full_ip_str = tmp_ip.substr(0,pos);
-		}
+        string full_ip_str;
+        if (ipv6 == false)
+        {
+            if ((pos = ip_str.find(':')) == string::npos)
+                return;
+            full_ip_str = ip_str.substr(0, pos);
+        }
+        else
+        {
+            if ((pos = ip_str.find(':')) == string::npos)
+                return;
+            pos++;
+            if ((pos = ip_str.find(':', pos)) == string::npos)
+                return;
+            pos++;
+            if ((pos = ip_str.find(':', pos)) == string::npos)
+                return;
+            pos++;
+            string tmp_ip = ip_str.substr(pos);
+            if ((pos = tmp_ip.find(']')) == string::npos)
+                return;
+            full_ip_str = tmp_ip.substr(0, pos);
+        }
 
-		if ((pos = full_ip_str.find('.')) == string::npos)
-			return;
-		string ip1_str = full_ip_str.substr(0,pos);
-		string::size_type old_pos;
-		pos++;
-		old_pos = pos;
-		if ((pos = full_ip_str.find('.',pos)) == string::npos)
-			return;
-		string ip2_str = full_ip_str.substr(old_pos,pos - old_pos);
-		pos++;
-		old_pos = pos;
-		if ((pos = full_ip_str.find('.',pos)) == string::npos)
-			return;
-		string ip3_str = full_ip_str.substr(old_pos,pos - old_pos);
-		pos++;
-		string ip4_str = full_ip_str.substr(pos);
+        if ((pos = full_ip_str.find('.')) == string::npos)
+            return;
+        string ip1_str = full_ip_str.substr(0, pos);
+        string::size_type old_pos;
+        pos++;
+        old_pos = pos;
+        if ((pos = full_ip_str.find('.', pos)) == string::npos)
+            return;
+        string ip2_str = full_ip_str.substr(old_pos, pos - old_pos);
+        pos++;
+        old_pos = pos;
+        if ((pos = full_ip_str.find('.', pos)) == string::npos)
+            return;
+        string ip3_str = full_ip_str.substr(old_pos, pos - old_pos);
+        pos++;
+        string ip4_str = full_ip_str.substr(pos);
 
 //
 // Finally, get host name
 //
 
-		struct sockaddr_in si;
-		si.sin_family = AF_INET;
-		si.sin_port = 0;
+        struct sockaddr_in si;
+        si.sin_family = AF_INET;
+        si.sin_port = 0;
 #ifdef _TG_WINDOWS_
-		int slen = sizeof(si);
-		WSAStringToAddress((char *)full_ip_str.c_str(),AF_INET,NULL,(SOCKADDR *)&si,&slen);
+        int slen = sizeof(si);
+        WSAStringToAddress((char *)full_ip_str.c_str(),AF_INET,NULL,(SOCKADDR *)&si,&slen);
 #else
-		inet_pton(AF_INET,full_ip_str.c_str(),&si.sin_addr);
+        inet_pton(AF_INET, full_ip_str.c_str(), &si.sin_addr);
 #endif
 
-		char host[512];
+        char host[512];
 
-		int res = getnameinfo((const sockaddr *)&si,sizeof(si),host,512,0,0,0);
+        int res = getnameinfo((const sockaddr *) &si, sizeof(si), host, 512, 0, 0, 0);
 #ifdef _TG_WINDOWS_
-		for (int i = 0;i < ::strlen(host);i++)
-			host[i] = ::tolower(host[i]);
+        for (int i = 0;i < ::strlen(host);i++)
+            host[i] = ::tolower(host[i]);
 #endif
 
-		if (res == 0)
-		{
-			elt_str = elt_str + "requested from ";
-			elt_str = elt_str + host;
-		}
-		else
-		{
-			elt_str = elt_str + "requested from ";
-			elt_str = elt_str + full_ip_str;
-		}
+        if (res == 0)
+        {
+            elt_str = elt_str + "requested from ";
+            elt_str = elt_str + host;
+        }
+        else
+        {
+            elt_str = elt_str + "requested from ";
+            elt_str = elt_str + full_ip_str;
+        }
 
 //
 // Add client identification if available
 //
 
-		if (box[index].client_ident == true)
-		{
-			if (box[index].client_lang == Tango::CPP)
-			{
-				elt_str = elt_str + " (CPP/Python client with PID ";
-				TangoSys_MemStream o;
-				o << box[index].client_pid;
-				elt_str = elt_str + o.str() + ")";
-			}
-			else
-			{
-				elt_str = elt_str + " (Java client with main class ";
-				elt_str = elt_str + box[index].java_main_class + ")";
-			}
-		}
-	}
-	else if (box[index].host_ip_str[5] == 'u')
-	{
-		Tango::Util *tg = Tango::Util::instance();
-		elt_str = elt_str + "requested from " + tg->get_host_name();
+        if (box[index].client_ident == true)
+        {
+            if (box[index].client_lang == Tango::CPP)
+            {
+                elt_str = elt_str + " (CPP/Python client with PID ";
+                TangoSys_MemStream o;
+                o << box[index].client_pid;
+                elt_str = elt_str + o.str() + ")";
+            }
+            else
+            {
+                elt_str = elt_str + " (Java client with main class ";
+                elt_str = elt_str + box[index].java_main_class + ")";
+            }
+        }
+    }
+    else if (box[index].host_ip_str[5] == 'u')
+    {
+        Tango::Util *tg = Tango::Util::instance();
+        elt_str = elt_str + "requested from " + tg->get_host_name();
 
 //
 // Add client identification if available
 //
 
-		if (box[index].client_ident == true)
-		{
-			if (box[index].client_lang == Tango::CPP)
-			{
-				elt_str = elt_str + " (CPP/Python client with PID ";
-				TangoSys_MemStream o;
-				o << box[index].client_pid;
-				elt_str = elt_str + o.str() + ")";
-			}
-			else
-			{
-				elt_str = elt_str + " (Java client with main class ";
-				elt_str = elt_str + box[index].java_main_class + ")";
-			}
-		}
-	}
-	else if (box[index].host_ip_str[0] == 'p')
-	{
+        if (box[index].client_ident == true)
+        {
+            if (box[index].client_lang == Tango::CPP)
+            {
+                elt_str = elt_str + " (CPP/Python client with PID ";
+                TangoSys_MemStream o;
+                o << box[index].client_pid;
+                elt_str = elt_str + o.str() + ")";
+            }
+            else
+            {
+                elt_str = elt_str + " (Java client with main class ";
+                elt_str = elt_str + box[index].java_main_class + ")";
+            }
+        }
+    }
+    else if (box[index].host_ip_str[0] == 'p')
+    {
         elt_str = elt_str + "requested from polling";
-	}
-	else if (box[index].host_ip_str[0] == 'i')
-	{
+    }
+    else if (box[index].host_ip_str[0] == 'i')
+    {
         elt_str = elt_str + "requested during device server process init sequence";
-	}
-	else if (box[index].host_ip_str[0] == 'u')
-	{
+    }
+    else if (box[index].host_ip_str[0] == 'u')
+    {
         elt_str = elt_str + "requested from user thread";
-	}
+    }
 
-	return;
+    return;
 }
 
 //+-------------------------------------------------------------------------------------------------------------------
@@ -1674,24 +1682,24 @@ void BlackBox::build_info_as_str(long index)
 
 void BlackBox::add_source(long index)
 {
-	switch (box[index].source)
-	{
-	case DEV :
-		elt_str = elt_str + "device ";
-		break;
+    switch (box[index].source)
+    {
+        case DEV :
+            elt_str = elt_str + "device ";
+            break;
 
-	case CACHE :
-		elt_str = elt_str + "cache ";
-		break;
+        case CACHE :
+            elt_str = elt_str + "cache ";
+            break;
 
-	case CACHE_DEV :
-		elt_str = elt_str + "cache_device ";
-		break;
+        case CACHE_DEV :
+            elt_str = elt_str + "cache_device ";
+            break;
 
-	default :
-		elt_str = elt_str + "unknown source (!) ";
-		break;
-	}
+        default :
+            elt_str = elt_str + "unknown source (!) ";
+            break;
+    }
 }
 
 //+-------------------------------------------------------------------------------------------------------------------
@@ -1716,81 +1724,81 @@ Tango::DevVarStringArray *BlackBox::read(long wanted_elt)
 // Take mutex
 //
 
-	sync.lock();
+    sync.lock();
 
 //
 // Throw exeception if the wanted element is stupid and if there is no element stored in the black box
 //
 
-	if (wanted_elt <= 0)
-	{
-		sync.unlock();
+    if (wanted_elt <= 0)
+    {
+        sync.unlock();
 
-		Except::throw_exception((const char *)API_BlackBoxArgument,
-				      (const char *)"Argument to read black box out of range",
-				      (const char *)"BlackBox::read");
-	}
-	if (nb_elt == 0)
-	{
-		sync.unlock();
+        Except::throw_exception((const char *) API_BlackBoxArgument,
+                                (const char *) "Argument to read black box out of range",
+                                (const char *) "BlackBox::read");
+    }
+    if (nb_elt == 0)
+    {
+        sync.unlock();
 
-		Except::throw_exception((const char *)API_BlackBoxEmpty,
-				      (const char *)"Nothing stored yet in black-box",
-				      (const char *)"BlackBox::read");
-	}
+        Except::throw_exception((const char *) API_BlackBoxEmpty,
+                                (const char *) "Nothing stored yet in black-box",
+                                (const char *) "BlackBox::read");
+    }
 
 //
 // Limit wanted element to a reasonable value
 //
 
-	if (wanted_elt > max_elt)
-		wanted_elt = max_elt;
+    if (wanted_elt > max_elt)
+        wanted_elt = max_elt;
 
-	if (wanted_elt > nb_elt)
-		wanted_elt = nb_elt;
+    if (wanted_elt > nb_elt)
+        wanted_elt = nb_elt;
 
 //
 // Read black box elements
 //
 
-	Tango::DevVarStringArray *ret = NULL;
-	try
-	{
+    Tango::DevVarStringArray *ret = NULL;
+    try
+    {
 
-		ret = new Tango::DevVarStringArray(wanted_elt);
-                ret->length(wanted_elt);
+        ret = new Tango::DevVarStringArray(wanted_elt);
+        ret->length(wanted_elt);
 
-		long read_index;
-		if (insert_elt == 0)
-			read_index = max_elt - 1;
-		else
-			read_index = insert_elt - 1;
-		for (long i = 0;i < wanted_elt;i++)
-		{
-			build_info_as_str(read_index);
-			(*ret)[i] = elt_str.c_str();
+        long read_index;
+        if (insert_elt == 0)
+            read_index = max_elt - 1;
+        else
+            read_index = insert_elt - 1;
+        for (long i = 0; i < wanted_elt; i++)
+        {
+            build_info_as_str(read_index);
+            (*ret)[i] = elt_str.c_str();
 
-			read_index--;
-			if (read_index < 0)
-				read_index = max_elt - 1;
-		}
-	}
-	catch (bad_alloc &)
-	{
-		sync.unlock();
+            read_index--;
+            if (read_index < 0)
+                read_index = max_elt - 1;
+        }
+    }
+    catch (bad_alloc &)
+    {
+        sync.unlock();
 
-		Except::throw_exception((const char *)API_MemoryAllocation,
-				      (const char *)"Can't allocate memory in server",
-				      (const char *)"BlackBox::read");
-	}
+        Except::throw_exception((const char *) API_MemoryAllocation,
+                                (const char *) "Can't allocate memory in server",
+                                (const char *) "BlackBox::read");
+    }
 
 //
 // Release mutex
 //
 
-	sync.unlock();
+    sync.unlock();
 
-	return(ret);
+    return (ret);
 }
 
 //+------------------------------------------------------------------------------------------------------------------
@@ -1810,11 +1818,11 @@ Tango::DevVarStringArray *BlackBox::read(long wanted_elt)
 //
 //--------------------------------------------------------------------------------------------------------------------
 
-void BlackBox::date_ux_to_str(timeval &ux_date,char *str_date)
+void BlackBox::date_ux_to_str(timeval &ux_date, char *str_date)
 {
-	long i;
-	char month[5];
-	char unix_date[40];
+    long i;
+    char month[5];
+    char unix_date[40];
 
 /* Convert UNIX date to a string in UNIX format */
 
@@ -1822,86 +1830,94 @@ void BlackBox::date_ux_to_str(timeval &ux_date,char *str_date)
 #ifdef _TG_WINDOWS_
     ctime_s(unix_date,40,&tmp_val);
 #else
-    ctime_r(&tmp_val,unix_date);
+    ctime_r(&tmp_val, unix_date);
 #endif
-	unix_date[strlen(unix_date) - 1] = '\0';
+    unix_date[strlen(unix_date) - 1] = '\0';
 
 /* Copy day */
 
-	for (i = 0;i < 2;i++)
-		str_date[i] = unix_date[i + 8];
-	str_date[2] = '/';
-	str_date[3] = '\0';
-	if (str_date[0] == ' ')
-		str_date[0] = '0';
+    for (i = 0; i < 2; i++)
+        str_date[i] = unix_date[i + 8];
+    str_date[2] = '/';
+    str_date[3] = '\0';
+    if (str_date[0] == ' ')
+        str_date[0] = '0';
 
 /* Copy month */
 
-	for (i = 0;i < 3;i++)
-		month[i] = unix_date[i + 4];
-	month[3] = '\0';
+    for (i = 0; i < 3; i++)
+        month[i] = unix_date[i + 4];
+    month[3] = '\0';
 
-	switch(month[0])
-	{
-		case 'J' : if (month[1] == 'u')
-			   {
-				if (month[2] == 'n')
-					strcat(str_date,"06/");
-				else
-					strcat(str_date,"07/");
-			   }
-			   else
-				strcat(str_date,"01/");
-			   break;
+    switch (month[0])
+    {
+        case 'J' :
+            if (month[1] == 'u')
+            {
+                if (month[2] == 'n')
+                    strcat(str_date, "06/");
+                else
+                    strcat(str_date, "07/");
+            }
+            else
+                strcat(str_date, "01/");
+            break;
 
-		case 'F' : strcat(str_date,"02/");
-			   break;
+        case 'F' :
+            strcat(str_date, "02/");
+            break;
 
-		case 'M' : if (month[2] == 'r')
-				strcat(str_date,"03/");
-			   else
-				strcat(str_date,"05/");
-			   break;
+        case 'M' :
+            if (month[2] == 'r')
+                strcat(str_date, "03/");
+            else
+                strcat(str_date, "05/");
+            break;
 
-		case 'A' : if (month[1] == 'p')
-				strcat(str_date,"04/");
-			   else
-				strcat(str_date,"08/");
-			   break;
+        case 'A' :
+            if (month[1] == 'p')
+                strcat(str_date, "04/");
+            else
+                strcat(str_date, "08/");
+            break;
 
-		case 'S' : strcat(str_date,"09/");
-			   break;
+        case 'S' :
+            strcat(str_date, "09/");
+            break;
 
-		case 'O' : strcat(str_date,"10/");
-		           break;
+        case 'O' :
+            strcat(str_date, "10/");
+            break;
 
-		case 'N' : strcat(str_date,"11/");
-			   break;
+        case 'N' :
+            strcat(str_date, "11/");
+            break;
 
-		case 'D' : strcat(str_date,"12/");
-			   break;
-	}
+        case 'D' :
+            strcat(str_date, "12/");
+            break;
+    }
 
-	str_date[6] = '\0';
+    str_date[6] = '\0';
 
 /* Copy year */
 
-	strcat(str_date,&(unix_date[20]));
-	str_date[10] = '\0';
+    strcat(str_date, &(unix_date[20]));
+    str_date[10] = '\0';
 
 /* Copy date remaining */
 
-	strcat(str_date," ");
-	for (i = 0;i < 8;i++)
-		str_date[i + 11] = unix_date[i + 11];
-	str_date[19] = '\0';
+    strcat(str_date, " ");
+    for (i = 0; i < 8; i++)
+        str_date[i + 11] = unix_date[i + 11];
+    str_date[19] = '\0';
 
 /* Add milliseconds */
 
 #ifdef _TG_WINDOWS_
-	sprintf(&(str_date[19]),":%.2d",(int)(ux_date.tv_usec/10));
+    sprintf(&(str_date[19]),":%.2d",(int)(ux_date.tv_usec/10));
 #else
-	sprintf(&(str_date[19]),":%.2d",(int)(ux_date.tv_usec/10000));
+    sprintf(&(str_date[19]), ":%.2d", (int) (ux_date.tv_usec / 10000));
 #endif
 
 }
@@ -1918,13 +1934,13 @@ void BlackBox::date_ux_to_str(timeval &ux_date,char *str_date)
 
 client_addr::client_addr(const client_addr &rhs)
 {
-	client_ident = rhs.client_ident;
-	client_lang = rhs.client_lang;
-	client_pid = rhs.client_pid;
-	java_main_class = rhs.java_main_class;
-	java_ident[0] = rhs.java_ident[0];
-	java_ident[1] = rhs.java_ident[1];
-	memcpy(client_ip,rhs.client_ip,IP_ADDR_BUFFER_SIZE);
+    client_ident = rhs.client_ident;
+    client_lang = rhs.client_lang;
+    client_pid = rhs.client_pid;
+    java_main_class = rhs.java_main_class;
+    java_ident[0] = rhs.java_ident[0];
+    java_ident[1] = rhs.java_ident[1];
+    memcpy(client_ip, rhs.client_ip, IP_ADDR_BUFFER_SIZE);
 }
 
 //+------------------------------------------------------------------------------------------------------------------
@@ -1937,19 +1953,19 @@ client_addr::client_addr(const client_addr &rhs)
 //
 //-------------------------------------------------------------------------------------------------------------------
 
-client_addr & client_addr::operator=(const client_addr &rhs)
+client_addr &client_addr::operator=(const client_addr &rhs)
 {
-	if (this == &rhs)
-		return *this;
+    if (this == &rhs)
+        return *this;
 
-	client_ident = rhs.client_ident;
-	client_lang = rhs.client_lang;
-	client_pid = rhs.client_pid;
-	java_main_class = rhs.java_main_class;
-	java_ident[0] = rhs.java_ident[0];
-	java_ident[1] = rhs.java_ident[1];
-	memcpy(client_ip,rhs.client_ip,IP_ADDR_BUFFER_SIZE);
-	return *this;
+    client_ident = rhs.client_ident;
+    client_lang = rhs.client_lang;
+    client_pid = rhs.client_pid;
+    java_main_class = rhs.java_main_class;
+    java_ident[0] = rhs.java_ident[0];
+    java_ident[1] = rhs.java_ident[1];
+    memcpy(client_ip, rhs.client_ip, IP_ADDR_BUFFER_SIZE);
+    return *this;
 }
 
 //+-------------------------------------------------------------------------------------------------------------------
@@ -1964,37 +1980,37 @@ client_addr & client_addr::operator=(const client_addr &rhs)
 
 bool client_addr::operator==(const client_addr &rhs)
 {
-	if (client_ident != rhs.client_ident)
-		return false;
+    if (client_ident != rhs.client_ident)
+        return false;
 
-	if (client_lang != rhs.client_lang)
-		return false;
-	else
-	{
-		if (client_lang == Tango::CPP)
-		{
-			if (client_pid != rhs.client_pid)
-				return false;
-
-			char *tmp = client_ip;
-			const char *rhs_tmp = rhs.client_ip;
-
-			if (strlen(tmp) != strlen(rhs_tmp))
+    if (client_lang != rhs.client_lang)
+        return false;
+    else
+    {
+        if (client_lang == Tango::CPP)
+        {
+            if (client_pid != rhs.client_pid)
                 return false;
 
-			if (strcmp(tmp,rhs_tmp) != 0)
-                return false;
-		}
-		else
-		{
-			if (java_ident[0] != rhs.java_ident[0])
-				return false;
-			if (java_ident[1] != rhs.java_ident[1])
-				return false;
-		}
-	}
+            char *tmp = client_ip;
+            const char *rhs_tmp = rhs.client_ip;
 
-	return true;
+            if (strlen(tmp) != strlen(rhs_tmp))
+                return false;
+
+            if (strcmp(tmp, rhs_tmp) != 0)
+                return false;
+        }
+        else
+        {
+            if (java_ident[0] != rhs.java_ident[0])
+                return false;
+            if (java_ident[1] != rhs.java_ident[1])
+                return false;
+        }
+    }
+
+    return true;
 }
 
 //+------------------------------------------------------------------------------------------------------------------
@@ -2009,37 +2025,37 @@ bool client_addr::operator==(const client_addr &rhs)
 
 bool client_addr::operator!=(const client_addr &rhs)
 {
-	if (client_ident != rhs.client_ident)
-		return true;
+    if (client_ident != rhs.client_ident)
+        return true;
 
-	if (client_lang != rhs.client_lang)
-		return true;
-	else
-	{
-		if (client_lang == Tango::CPP)
-		{
-			if (client_pid != rhs.client_pid)
-				return true;
+    if (client_lang != rhs.client_lang)
+        return true;
+    else
+    {
+        if (client_lang == Tango::CPP)
+        {
+            if (client_pid != rhs.client_pid)
+                return true;
 
-			char *tmp = client_ip;
-			const char *rhs_tmp = rhs.client_ip;
+            char *tmp = client_ip;
+            const char *rhs_tmp = rhs.client_ip;
 
-			if (strlen(tmp) != strlen(rhs_tmp))
-				return true;
+            if (strlen(tmp) != strlen(rhs_tmp))
+                return true;
 
-			if (strcmp(tmp,rhs_tmp) != 0)
-				return true;
-		}
-		else
-		{
-			if (java_ident[0] != rhs.java_ident[0])
-				return true;
-			if (java_ident[1] != rhs.java_ident[1])
-				return true;
-		}
-	}
+            if (strcmp(tmp, rhs_tmp) != 0)
+                return true;
+        }
+        else
+        {
+            if (java_ident[0] != rhs.java_ident[0])
+                return true;
+            if (java_ident[1] != rhs.java_ident[1])
+                return true;
+        }
+    }
 
-	return false;
+    return false;
 }
 
 //+--------------------------------------------------------------------------------------------------------------------
@@ -2054,80 +2070,80 @@ bool client_addr::operator!=(const client_addr &rhs)
 
 int client_addr::client_ip_2_client_name(string &cl_host_name) const
 {
-	int ret = 0;
-	string client_ip_str(client_ip);
+    int ret = 0;
+    string client_ip_str(client_ip);
 
-	string::size_type pos;
-	if ((pos = client_ip_str.find(':')) == string::npos)
-		ret = -1;
-	else
-	{
-		pos++;
-		if ((pos = client_ip_str.find(':',pos)) == string::npos)
-			ret = -1;
-		else
-		{
-			pos++;
-			string ip_str = client_ip_str.substr(pos);
-			if ((pos = ip_str.find(':')) == string::npos)
-				ret = -1;
-			else
-			{
-				string full_ip_str = ip_str.substr(0,pos);
+    string::size_type pos;
+    if ((pos = client_ip_str.find(':')) == string::npos)
+        ret = -1;
+    else
+    {
+        pos++;
+        if ((pos = client_ip_str.find(':', pos)) == string::npos)
+            ret = -1;
+        else
+        {
+            pos++;
+            string ip_str = client_ip_str.substr(pos);
+            if ((pos = ip_str.find(':')) == string::npos)
+                ret = -1;
+            else
+            {
+                string full_ip_str = ip_str.substr(0, pos);
 
-				if ((pos = full_ip_str.find('.')) == string::npos)
-					ret = -1;
-				else
-				{
-					string ip1_str = full_ip_str.substr(0,pos);
+                if ((pos = full_ip_str.find('.')) == string::npos)
+                    ret = -1;
+                else
+                {
+                    string ip1_str = full_ip_str.substr(0, pos);
 
-					string::size_type old_pos;
-					pos++;
-					old_pos = pos;
-					if ((pos = full_ip_str.find('.',pos)) == string::npos)
-						ret = -1;
-					else
-					{
-						string ip2_str = full_ip_str.substr(old_pos,pos - old_pos);
-						pos++;
-						old_pos = pos;
-						if ((pos = full_ip_str.find('.',pos)) == string::npos)
-							ret = -1 ;
-						else
-						{
-							string ip3_str = full_ip_str.substr(old_pos,pos - old_pos);
-							pos++;
-							string ip4_str = full_ip_str.substr(pos);
+                    string::size_type old_pos;
+                    pos++;
+                    old_pos = pos;
+                    if ((pos = full_ip_str.find('.', pos)) == string::npos)
+                        ret = -1;
+                    else
+                    {
+                        string ip2_str = full_ip_str.substr(old_pos, pos - old_pos);
+                        pos++;
+                        old_pos = pos;
+                        if ((pos = full_ip_str.find('.', pos)) == string::npos)
+                            ret = -1;
+                        else
+                        {
+                            string ip3_str = full_ip_str.substr(old_pos, pos - old_pos);
+                            pos++;
+                            string ip4_str = full_ip_str.substr(pos);
 
-							struct sockaddr_in si;
-							si.sin_family = AF_INET;
-							si.sin_port = 0;
+                            struct sockaddr_in si;
+                            si.sin_family = AF_INET;
+                            si.sin_port = 0;
 #ifdef _TG_WINDOWS_
-							int slen = sizeof(si);
-							WSAStringToAddress((char *)full_ip_str.c_str(),AF_INET,NULL,(SOCKADDR *)&si,&slen);
+                            int slen = sizeof(si);
+                            WSAStringToAddress((char *)full_ip_str.c_str(),AF_INET,NULL,(SOCKADDR *)&si,&slen);
 #else
-							inet_pton(AF_INET,full_ip_str.c_str(),&si.sin_addr);
+                            inet_pton(AF_INET, full_ip_str.c_str(), &si.sin_addr);
 #endif
 
-							char host[512];
+                            char host[512];
 
-							int res = getnameinfo((const sockaddr *)&si,sizeof(si),host,512,0,0,0);
+                            int res = getnameinfo((const sockaddr *) &si, sizeof(si), host, 512, 0, 0, 0);
 
-							if (res == 0)
-							{
-								cl_host_name = host;
-								ret = 0;
-							}
-							else
-								ret = -1;
-						}
-					}
-				}
-			}
-		}
-	}
+                            if (res == 0)
+                            {
+                                cl_host_name = host;
+                                ret = 0;
+                            }
+                            else
+                                ret = -1;
+                        }
+                    }
+                }
+            }
+        }
+    }
 
-	return ret;
+    return ret;
 }
 
 
@@ -2140,34 +2156,33 @@ int client_addr::client_ip_2_client_name(string &cl_host_name) const
 //
 //--------------------------------------------------------------------------------------------------------------------
 
-ostream &operator<<(ostream &o_str,const client_addr &ca)
+ostream &operator<<(ostream &o_str, const client_addr &ca)
 {
-	if (ca.client_ident == false)
-		o_str << "Client identification not available";
-	else
-	{
-		if (ca.client_lang == Tango::CPP)
-		{
-			string cl_name;
-			o_str << "CPP or Python client with PID " << ca.client_pid << " from host ";
-			if (ca.client_ip_2_client_name(cl_name) == 0)
-				o_str << cl_name;
-			else
-				o_str << ca.client_ip;
-		}
-		else
-		{
-			o_str << "JAVA client class " << ca.java_main_class << " from host ";
-			string cl_name;
-			if (ca.client_ip_2_client_name(cl_name) == 0)
-				o_str << cl_name;
-			else
-				o_str << ca.client_ip;
-		}
-	}
+    if (ca.client_ident == false)
+        o_str << "Client identification not available";
+    else
+    {
+        if (ca.client_lang == Tango::CPP)
+        {
+            string cl_name;
+            o_str << "CPP or Python client with PID " << ca.client_pid << " from host ";
+            if (ca.client_ip_2_client_name(cl_name) == 0)
+                o_str << cl_name;
+            else
+                o_str << ca.client_ip;
+        }
+        else
+        {
+            o_str << "JAVA client class " << ca.java_main_class << " from host ";
+            string cl_name;
+            if (ca.client_ip_2_client_name(cl_name) == 0)
+                o_str << cl_name;
+            else
+                o_str << ca.client_ip;
+        }
+    }
 
-	return o_str;
+    return o_str;
 }
-
 
 } // End of Tango namespace

--- a/cppapi/server/blackbox.cpp
+++ b/cppapi/server/blackbox.cpp
@@ -240,11 +240,17 @@ void BlackBox::insert_cmd_nl(const char *cmd, long vers, DevSource sour)
     box[insert_elt].req_type = Req_Operation;
     box[insert_elt].attr_type = Attr_Unknown;
     if (vers == 1)
+    {
         box[insert_elt].op_type = Op_Command_inout;
+    }
     else if (vers <= 3)
+    {
         box[insert_elt].op_type = Op_Command_inout_2;
+    }
     else
+    {
         box[insert_elt].op_type = Op_Command_inout_4;
+    }
     box[insert_elt].cmd_name = cmd;
     box[insert_elt].source = sour;
     box[insert_elt].client_ident = false;
@@ -355,7 +361,9 @@ void BlackBox::add_cl_ident(const ClntIdent &cl_ident, client_addr *cl_addr)
         {
             string::size_type pos = str.find(' ');
             if (pos != string::npos)
+            {
                 cl_addr->client_ip[pos] = '\0';
+            }
         }
     }
     else
@@ -385,9 +393,13 @@ void BlackBox::update_client_host(client_addr *ip)
 {
     long local_insert_elt = insert_elt;
     if (local_insert_elt == 0)
+    {
         local_insert_elt = max_elt - 1;
+    }
     else
+    {
         local_insert_elt--;
+    }
 
     box[local_insert_elt].client_ident = true;
     box[local_insert_elt].client_lang = ip->client_lang;
@@ -601,9 +613,13 @@ void BlackBox::insert_attr(const Tango::DevVarStringArray &names, const ClntIden
     box[insert_elt].attr_type = Attr_Unknown;
 
     if (vers == 5)
+    {
         box[insert_elt].op_type = Op_Read_Attr_5;
+    }
     else
+    {
         box[insert_elt].op_type = Op_Read_Attr_4;
+    }
 
     box[insert_elt].source = sour;
     box[insert_elt].client_ident = false;
@@ -646,7 +662,9 @@ void BlackBox::insert_attr(const Tango::DevVarStringArray &names, const ClntIden
     if (box[insert_elt].host_ip_str[0] == 'p' ||
         box[insert_elt].host_ip_str[0] == 'u' ||
         box[insert_elt].host_ip_str[0] == 'i')
+    {
         poll_user = true;
+    }
 
     inc_indexes();
 
@@ -729,7 +747,9 @@ void BlackBox::insert_attr(const char *name, const ClntIdent &cl_id, TANGO_UNUSE
     if (box[insert_elt].host_ip_str[0] == 'p' ||
         box[insert_elt].host_ip_str[0] == 'u' ||
         box[insert_elt].host_ip_str[0] == 'i')
+    {
         poll_user = true;
+    }
 
     inc_indexes();
 
@@ -768,9 +788,13 @@ void BlackBox::insert_attr(const Tango::DevPipeData &pipe_val, const ClntIdent &
     box[insert_elt].attr_type = Attr_Unknown;
 
     if (vers == 0)
+    {
         box[insert_elt].op_type = Op_Write_Pipe_5;
+    }
     else
+    {
         box[insert_elt].op_type = Op_Write_Read_Pipe_5;
+    }
     box[insert_elt].client_ident = false;
 
 
@@ -807,7 +831,9 @@ void BlackBox::insert_attr(const Tango::DevPipeData &pipe_val, const ClntIdent &
     if (box[insert_elt].host_ip_str[0] == 'p' ||
         box[insert_elt].host_ip_str[0] == 'u' ||
         box[insert_elt].host_ip_str[0] == 'i')
+    {
         poll_user = true;
+    }
 
     inc_indexes();
 
@@ -877,11 +903,17 @@ void BlackBox::insert_attr_nl(const Tango::AttributeValueList &att_list, long ve
     box[insert_elt].req_type = Req_Operation;
     box[insert_elt].attr_type = Attr_Unknown;
     if (vers == 1)
+    {
         box[insert_elt].op_type = Op_Write_Attr;
+    }
     else if (vers < 4)
+    {
         box[insert_elt].op_type = Op_Write_Attr_3;
+    }
     else
+    {
         box[insert_elt].op_type = Op_Write_Attr_4;
+    }
 
     box[insert_elt].attr_names.clear();
     for (unsigned long i = 0; i < att_list.length(); i++)
@@ -1026,9 +1058,13 @@ void BlackBox::insert_attr_wr_nl(const Tango::AttributeValueList_4 &att_list,
     box[insert_elt].req_type = Req_Operation;
     box[insert_elt].attr_type = Attr_Unknown;
     if (vers == 5)
+    {
         box[insert_elt].op_type = Op_Write_Read_Attributes_5;
+    }
     else
+    {
         box[insert_elt].op_type = Op_Write_Read_Attributes_4;
+    }
 
     box[insert_elt].attr_names.clear();
     for (unsigned long i = 0; i < att_list.length(); i++)
@@ -1089,10 +1125,14 @@ void BlackBox::inc_indexes()
 {
     insert_elt++;
     if (insert_elt == max_elt)
+    {
         insert_elt = 0;
+    }
 
     if (nb_elt != max_elt)
+    {
         nb_elt++;
+    }
 }
 
 //+-------------------------------------------------------------------------------------------------------------------
@@ -1109,7 +1149,9 @@ void BlackBox::get_client_host()
 {
     omni_thread *th_id = omni_thread::self();
     if (th_id == NULL)
+    {
         th_id = omni_thread::create_dummy();
+    }
 
     omni_thread::value_t *ip = th_id->get_value(key);
     if (ip == NULL)
@@ -1136,20 +1178,30 @@ void BlackBox::get_client_host()
         if (tg->is_svr_starting() == true)
         {
             if (found_thread == true)
+            {
                 strcpy(box[insert_elt].host_ip_str, "polling");
+            }
             else
+            {
                 strcpy(box[insert_elt].host_ip_str, "init");
+            }
         }
         else
         {
             if (found_thread == true)
+            {
                 strcpy(box[insert_elt].host_ip_str, "polling");
+            }
             else
+            {
                 strcpy(box[insert_elt].host_ip_str, "user thread");
+            }
         }
     }
     else
+    {
         strcpy(box[insert_elt].host_ip_str, (static_cast<client_addr *>(ip))->client_ip);
+    }
 }
 
 //+-------------------------------------------------------------------------------------------------------------------
@@ -1230,7 +1282,9 @@ void BlackBox::build_info_as_str(long index)
                 {
                     elt_str = elt_str + box[index].attr_names[i];
                     if (i != nb_in_vect - 1)
+                    {
                         elt_str = elt_str + ", ";
+                    }
                 }
                 elt_str = elt_str + ") from ";
                 add_source(index);
@@ -1243,7 +1297,9 @@ void BlackBox::build_info_as_str(long index)
                 {
                     elt_str = elt_str + box[index].attr_names[i];
                     if (i != nb_in_vect - 1)
+                    {
                         elt_str = elt_str + ", ";
+                    }
                 }
                 elt_str = elt_str + ") ";
                 break;
@@ -1255,7 +1311,9 @@ void BlackBox::build_info_as_str(long index)
                 {
                     elt_str = elt_str + box[index].attr_names[i];
                     if (i != nb_in_vect - 1)
+                    {
                         elt_str = elt_str + ", ";
+                    }
                 }
                 elt_str = elt_str + ") ";
                 break;
@@ -1284,7 +1342,9 @@ void BlackBox::build_info_as_str(long index)
                 {
                     elt_str = elt_str + box[index].attr_names[i];
                     if (i != nb_in_vect - 1)
+                    {
                         elt_str = elt_str + ", ";
+                    }
                 }
                 elt_str = elt_str + ") from ";
                 add_source(index);
@@ -1297,7 +1357,9 @@ void BlackBox::build_info_as_str(long index)
                 {
                     elt_str = elt_str + box[index].attr_names[i];
                     if (i != nb_in_vect - 1)
+                    {
                         elt_str = elt_str + ", ";
+                    }
                 }
                 elt_str = elt_str + ") from ";
                 add_source(index);
@@ -1347,7 +1409,9 @@ void BlackBox::build_info_as_str(long index)
                 {
                     elt_str = elt_str + box[index].attr_names[i];
                     if (i != nb_in_vect - 1)
+                    {
                         elt_str = elt_str + ", ";
+                    }
                 }
                 elt_str = elt_str + ") from ";
                 add_source(index);
@@ -1360,7 +1424,9 @@ void BlackBox::build_info_as_str(long index)
                 {
                     elt_str = elt_str + box[index].attr_names[i];
                     if (i != nb_in_vect - 1)
+                    {
                         elt_str = elt_str + ", ";
+                    }
                 }
                 elt_str = elt_str + ") ";
                 break;
@@ -1376,7 +1442,9 @@ void BlackBox::build_info_as_str(long index)
                 {
                     elt_str = elt_str + box[index].attr_names[i];
                     if (i != nb_in_vect - 1)
+                    {
                         elt_str = elt_str + ", ";
+                    }
                 }
                 elt_str = elt_str + ") ";
                 break;
@@ -1396,7 +1464,9 @@ void BlackBox::build_info_as_str(long index)
                 {
                     elt_str = elt_str + box[index].attr_names[i];
                     if (i != nb_in_vect - 1)
+                    {
                         elt_str = elt_str + ", ";
+                    }
                 }
                 elt_str = elt_str + ") from ";
                 add_source(index);
@@ -1411,7 +1481,9 @@ void BlackBox::build_info_as_str(long index)
                     if (i != nb_in_vect - 1 && box[index].attr_names[i] != "/")
                     {
                         if (box[index].attr_names[i + 1] != "/")
+                        {
                             elt_str = elt_str + ", ";
+                        }
                     }
                 }
                 elt_str = elt_str + ") ";
@@ -1436,7 +1508,9 @@ void BlackBox::build_info_as_str(long index)
                 {
                     elt_str = elt_str + box[index].attr_names[i];
                     if (i != nb_in_vect - 1)
+                    {
                         elt_str = elt_str + ", ";
+                    }
                 }
                 elt_str = elt_str + ") ";
                 break;
@@ -1448,7 +1522,9 @@ void BlackBox::build_info_as_str(long index)
                 {
                     elt_str = elt_str + box[index].attr_names[i];
                     if (i != nb_in_vect - 1)
+                    {
                         elt_str = elt_str + ", ";
+                    }
                 }
                 elt_str = elt_str + ") ";
                 break;
@@ -1460,7 +1536,9 @@ void BlackBox::build_info_as_str(long index)
                 {
                     elt_str = elt_str + box[index].attr_names[i];
                     if (i != nb_in_vect - 1)
+                    {
                         elt_str = elt_str + ", ";
+                    }
                 }
                 elt_str = elt_str + ") ";
                 break;
@@ -1522,52 +1600,74 @@ void BlackBox::build_info_as_str(long index)
         string omni_addr = box[index].host_ip_str;
         string::size_type pos;
         if ((pos = omni_addr.find(':')) == string::npos)
+        {
             return;
+        }
         pos++;
         if ((pos = omni_addr.find(':', pos)) == string::npos)
+        {
             return;
+        }
         pos++;
         string ip_str = omni_addr.substr(pos);
         if (ip_str[0] == '[')
+        {
             ipv6 = true;
+        }
 
         string full_ip_str;
         if (ipv6 == false)
         {
             if ((pos = ip_str.find(':')) == string::npos)
+            {
                 return;
+            }
             full_ip_str = ip_str.substr(0, pos);
         }
         else
         {
             if ((pos = ip_str.find(':')) == string::npos)
+            {
                 return;
+            }
             pos++;
             if ((pos = ip_str.find(':', pos)) == string::npos)
+            {
                 return;
+            }
             pos++;
             if ((pos = ip_str.find(':', pos)) == string::npos)
+            {
                 return;
+            }
             pos++;
             string tmp_ip = ip_str.substr(pos);
             if ((pos = tmp_ip.find(']')) == string::npos)
+            {
                 return;
+            }
             full_ip_str = tmp_ip.substr(0, pos);
         }
 
         if ((pos = full_ip_str.find('.')) == string::npos)
+        {
             return;
+        }
         string ip1_str = full_ip_str.substr(0, pos);
         string::size_type old_pos;
         pos++;
         old_pos = pos;
         if ((pos = full_ip_str.find('.', pos)) == string::npos)
+        {
             return;
+        }
         string ip2_str = full_ip_str.substr(old_pos, pos - old_pos);
         pos++;
         old_pos = pos;
         if ((pos = full_ip_str.find('.', pos)) == string::npos)
+        {
             return;
+        }
         string ip3_str = full_ip_str.substr(old_pos, pos - old_pos);
         pos++;
         string ip4_str = full_ip_str.substr(pos);
@@ -1752,10 +1852,14 @@ Tango::DevVarStringArray *BlackBox::read(long wanted_elt)
 //
 
     if (wanted_elt > max_elt)
+    {
         wanted_elt = max_elt;
+    }
 
     if (wanted_elt > nb_elt)
+    {
         wanted_elt = nb_elt;
+    }
 
 //
 // Read black box elements
@@ -1770,9 +1874,13 @@ Tango::DevVarStringArray *BlackBox::read(long wanted_elt)
 
         long read_index;
         if (insert_elt == 0)
+        {
             read_index = max_elt - 1;
+        }
         else
+        {
             read_index = insert_elt - 1;
+        }
         for (long i = 0; i < wanted_elt; i++)
         {
             build_info_as_str(read_index);
@@ -1780,7 +1888,9 @@ Tango::DevVarStringArray *BlackBox::read(long wanted_elt)
 
             read_index--;
             if (read_index < 0)
+            {
                 read_index = max_elt - 1;
+            }
         }
     }
     catch (bad_alloc &)
@@ -1837,16 +1947,22 @@ void BlackBox::date_ux_to_str(timeval &ux_date, char *str_date)
 /* Copy day */
 
     for (i = 0; i < 2; i++)
+    {
         str_date[i] = unix_date[i + 8];
+    }
     str_date[2] = '/';
     str_date[3] = '\0';
     if (str_date[0] == ' ')
+    {
         str_date[0] = '0';
+    }
 
 /* Copy month */
 
     for (i = 0; i < 3; i++)
+    {
         month[i] = unix_date[i + 4];
+    }
     month[3] = '\0';
 
     switch (month[0])
@@ -1855,12 +1971,18 @@ void BlackBox::date_ux_to_str(timeval &ux_date, char *str_date)
             if (month[1] == 'u')
             {
                 if (month[2] == 'n')
+                {
                     strcat(str_date, "06/");
+                }
                 else
+                {
                     strcat(str_date, "07/");
+                }
             }
             else
+            {
                 strcat(str_date, "01/");
+            }
             break;
 
         case 'F' :
@@ -1869,16 +1991,24 @@ void BlackBox::date_ux_to_str(timeval &ux_date, char *str_date)
 
         case 'M' :
             if (month[2] == 'r')
+            {
                 strcat(str_date, "03/");
+            }
             else
+            {
                 strcat(str_date, "05/");
+            }
             break;
 
         case 'A' :
             if (month[1] == 'p')
+            {
                 strcat(str_date, "04/");
+            }
             else
+            {
                 strcat(str_date, "08/");
+            }
             break;
 
         case 'S' :
@@ -1909,7 +2039,9 @@ void BlackBox::date_ux_to_str(timeval &ux_date, char *str_date)
 
     strcat(str_date, " ");
     for (i = 0; i < 8; i++)
+    {
         str_date[i + 11] = unix_date[i + 11];
+    }
     str_date[19] = '\0';
 
 /* Add milliseconds */
@@ -1956,7 +2088,9 @@ client_addr::client_addr(const client_addr &rhs)
 client_addr &client_addr::operator=(const client_addr &rhs)
 {
     if (this == &rhs)
+    {
         return *this;
+    }
 
     client_ident = rhs.client_ident;
     client_lang = rhs.client_lang;
@@ -1981,32 +2115,46 @@ client_addr &client_addr::operator=(const client_addr &rhs)
 bool client_addr::operator==(const client_addr &rhs)
 {
     if (client_ident != rhs.client_ident)
+    {
         return false;
+    }
 
     if (client_lang != rhs.client_lang)
+    {
         return false;
+    }
     else
     {
         if (client_lang == Tango::CPP)
         {
             if (client_pid != rhs.client_pid)
+            {
                 return false;
+            }
 
             char *tmp = client_ip;
             const char *rhs_tmp = rhs.client_ip;
 
             if (strlen(tmp) != strlen(rhs_tmp))
+            {
                 return false;
+            }
 
             if (strcmp(tmp, rhs_tmp) != 0)
+            {
                 return false;
+            }
         }
         else
         {
             if (java_ident[0] != rhs.java_ident[0])
+            {
                 return false;
+            }
             if (java_ident[1] != rhs.java_ident[1])
+            {
                 return false;
+            }
         }
     }
 
@@ -2026,32 +2174,46 @@ bool client_addr::operator==(const client_addr &rhs)
 bool client_addr::operator!=(const client_addr &rhs)
 {
     if (client_ident != rhs.client_ident)
+    {
         return true;
+    }
 
     if (client_lang != rhs.client_lang)
+    {
         return true;
+    }
     else
     {
         if (client_lang == Tango::CPP)
         {
             if (client_pid != rhs.client_pid)
+            {
                 return true;
+            }
 
             char *tmp = client_ip;
             const char *rhs_tmp = rhs.client_ip;
 
             if (strlen(tmp) != strlen(rhs_tmp))
+            {
                 return true;
+            }
 
             if (strcmp(tmp, rhs_tmp) != 0)
+            {
                 return true;
+            }
         }
         else
         {
             if (java_ident[0] != rhs.java_ident[0])
+            {
                 return true;
+            }
             if (java_ident[1] != rhs.java_ident[1])
+            {
                 return true;
+            }
         }
     }
 
@@ -2075,24 +2237,32 @@ int client_addr::client_ip_2_client_name(string &cl_host_name) const
 
     string::size_type pos;
     if ((pos = client_ip_str.find(':')) == string::npos)
+    {
         ret = -1;
+    }
     else
     {
         pos++;
         if ((pos = client_ip_str.find(':', pos)) == string::npos)
+        {
             ret = -1;
+        }
         else
         {
             pos++;
             string ip_str = client_ip_str.substr(pos);
             if ((pos = ip_str.find(':')) == string::npos)
+            {
                 ret = -1;
+            }
             else
             {
                 string full_ip_str = ip_str.substr(0, pos);
 
                 if ((pos = full_ip_str.find('.')) == string::npos)
+                {
                     ret = -1;
+                }
                 else
                 {
                     string ip1_str = full_ip_str.substr(0, pos);
@@ -2101,14 +2271,18 @@ int client_addr::client_ip_2_client_name(string &cl_host_name) const
                     pos++;
                     old_pos = pos;
                     if ((pos = full_ip_str.find('.', pos)) == string::npos)
+                    {
                         ret = -1;
+                    }
                     else
                     {
                         string ip2_str = full_ip_str.substr(old_pos, pos - old_pos);
                         pos++;
                         old_pos = pos;
                         if ((pos = full_ip_str.find('.', pos)) == string::npos)
+                        {
                             ret = -1;
+                        }
                         else
                         {
                             string ip3_str = full_ip_str.substr(old_pos, pos - old_pos);
@@ -2135,7 +2309,9 @@ int client_addr::client_ip_2_client_name(string &cl_host_name) const
                                 ret = 0;
                             }
                             else
+                            {
                                 ret = -1;
+                            }
                         }
                     }
                 }
@@ -2159,7 +2335,9 @@ int client_addr::client_ip_2_client_name(string &cl_host_name) const
 ostream &operator<<(ostream &o_str, const client_addr &ca)
 {
     if (ca.client_ident == false)
+    {
         o_str << "Client identification not available";
+    }
     else
     {
         if (ca.client_lang == Tango::CPP)
@@ -2167,18 +2345,26 @@ ostream &operator<<(ostream &o_str, const client_addr &ca)
             string cl_name;
             o_str << "CPP or Python client with PID " << ca.client_pid << " from host ";
             if (ca.client_ip_2_client_name(cl_name) == 0)
+            {
                 o_str << cl_name;
+            }
             else
+            {
                 o_str << ca.client_ip;
+            }
         }
         else
         {
             o_str << "JAVA client class " << ca.java_main_class << " from host ";
             string cl_name;
             if (ca.client_ip_2_client_name(cl_name) == 0)
+            {
                 o_str << cl_name;
+            }
             else
+            {
                 o_str << ca.client_ip;
+            }
         }
     }
 

--- a/cppapi/server/device.cpp
+++ b/cppapi/server/device.cpp
@@ -919,7 +919,7 @@ vector<PollObj *>::iterator DeviceImpl::get_polled_obj_by_type_name(
 //
 
 // exclude the return value for VC8+
-#if !defined(_TG_WINDOWS_) || (defined(_MSC_VER) && _MSC_VER < 1400)
+#if not defined(_TG_WINDOWS_) || (defined(_MSC_VER) && _MSC_VER < 1400)
     return (vector<PollObj *>::iterator) NULL;
 #endif
 }
@@ -1065,7 +1065,7 @@ long DeviceImpl::get_attr_poll_ring_depth(string &attr_name)
             {
                 TangoSys_MemStream s;
                 s << attr_poll_ring_depth[k + 1];
-                if (!(s >> ret))
+                if (not(s >> ret))
                 {
                     TangoSys_OMemStream o;
                     o << "System property attr_poll_ring_depth for device " << device_name << " has wrong syntax"

--- a/cppapi/server/device.cpp
+++ b/cppapi/server/device.cpp
@@ -244,7 +244,9 @@ void DeviceImpl::stop_polling(bool with_db_upd)
 
     vector<PollingThreadInfo *> &v_th_info = tg->get_polling_threads_info();
     if (v_th_info.empty() == true)
+    {
         return;
+    }
 
 //
 // Find out which thread is in charge of the device.
@@ -324,9 +326,13 @@ void DeviceImpl::stop_polling(bool with_db_upd)
     {
         pos = conf_entry.find(device_name_lower);
         if ((pos + device_name_lower.size()) != conf_entry.size())
+        {
             conf_entry.erase(pos, device_name_lower.size() + 1);
+        }
         else
+        {
             conf_entry.erase(pos - 1);
+        }
     }
     else
     {
@@ -457,7 +463,9 @@ DeviceImpl::~DeviceImpl()
     vector<DeviceImpl *> &dev_vect = get_device_class()->get_device_list();
     vector<DeviceImpl *>::iterator ite = find(dev_vect.begin(), dev_vect.end(), this);
     if (ite != dev_vect.end())
+    {
         *ite = NULL;
+    }
 
     cout4 << "Leaving DeviceImpl destructor for device " << device_name << endl;
 }
@@ -483,9 +491,13 @@ void DeviceImpl::black_box_create()
     try
     {
         if (blackbox_depth == 0)
+        {
             blackbox_ptr = new BlackBox();
+        }
         else
+        {
             blackbox_ptr = new BlackBox(blackbox_depth);
+        }
     }
     catch (bad_alloc &)
     {
@@ -554,9 +566,13 @@ void DeviceImpl::get_dev_system_resource()
         }
 
         if (db_data[0].is_empty() == false)
+        {
             db_data[0] >> blackbox_depth;
+        }
         if (db_data[1].is_empty() == false)
+        {
             db_data[1] >> desc;
+        }
         if (db_data[2].is_empty() == false)
         {
             long tmp_depth;
@@ -564,13 +580,21 @@ void DeviceImpl::get_dev_system_resource()
             set_poll_ring_depth(tmp_depth);
         }
         if (db_data[3].is_empty() == false)
+        {
             db_data[3] >> get_polled_cmd();
+        }
         if (db_data[4].is_empty() == false)
+        {
             db_data[4] >> get_polled_attr();
+        }
         if (db_data[5].is_empty() == false)
+        {
             db_data[5] >> get_non_auto_polled_cmd();
+        }
         if (db_data[6].is_empty() == false)
+        {
             db_data[6] >> get_non_auto_polled_attr();
+        }
         if (db_data[7].is_empty() == false)
         {
             long tmp_poll;
@@ -578,7 +602,9 @@ void DeviceImpl::get_dev_system_resource()
             set_poll_old_factor(tmp_poll);
         }
         else
+        {
             set_poll_old_factor(DEFAULT_POLL_OLD_FACTOR);
+        }
         if (db_data[8].is_empty() == false)
         {
             db_data[8] >> cmd_poll_ring_depth;
@@ -593,10 +619,12 @@ void DeviceImpl::get_dev_system_resource()
                                         (const char *) "DeviceImpl::get_dev_system_resource()");
             }
             for (unsigned int i = 0; i < nb_prop; i = i + 2)
+            {
                 transform(cmd_poll_ring_depth[i].begin(),
                           cmd_poll_ring_depth[i].end(),
                           cmd_poll_ring_depth[i].begin(),
                           ::tolower);
+            }
         }
         if (db_data[9].is_empty() == false)
         {
@@ -612,10 +640,12 @@ void DeviceImpl::get_dev_system_resource()
                                         (const char *) "DeviceImpl::get_dev_system_resource()");
             }
             for (unsigned int i = 0; i < nb_prop; i = i + 2)
+            {
                 transform(attr_poll_ring_depth[i].begin(),
                           attr_poll_ring_depth[i].end(),
                           attr_poll_ring_depth[i].begin(),
                           ::tolower);
+            }
         }
 
 //
@@ -623,7 +653,9 @@ void DeviceImpl::get_dev_system_resource()
 //
 
         if (db_data[10].is_empty() == false)
+        {
             db_data[10] >> min_poll_period;
+        }
 
         if (db_data[11].is_empty() == false)
         {
@@ -639,10 +671,12 @@ void DeviceImpl::get_dev_system_resource()
                                         (const char *) "DeviceImpl::get_dev_system_resource()");
             }
             for (unsigned int i = 0; i < nb_prop; i = i + 2)
+            {
                 transform(cmd_min_poll_period[i].begin(),
                           cmd_min_poll_period[i].end(),
                           cmd_min_poll_period[i].begin(),
                           ::tolower);
+            }
         }
 
         if (db_data[12].is_empty() == false)
@@ -659,10 +693,12 @@ void DeviceImpl::get_dev_system_resource()
                                         (const char *) "DeviceImpl::get_dev_system_resource()");
             }
             for (unsigned int i = 0; i < nb_prop; i = i + 2)
+            {
                 transform(attr_min_poll_period[i].begin(),
                           attr_min_poll_period[i].end(),
                           attr_min_poll_period[i].begin(),
                           ::tolower);
+            }
         }
 
 //
@@ -671,7 +707,9 @@ void DeviceImpl::get_dev_system_resource()
 //
 
         if ((get_polled_cmd()).size() != 0)
+        {
             poll_lists_2_v5();
+        }
     }
 }
 
@@ -915,9 +953,13 @@ long DeviceImpl::get_cmd_poll_ring_depth(string &cmd_name)
 // No specific depth defined
 //
         if (poll_ring_depth == 0)
+        {
             ret = DefaultPollRingDepth;
+        }
         else
+        {
             ret = poll_ring_depth;
+        }
     }
     else
     {
@@ -951,9 +993,13 @@ long DeviceImpl::get_cmd_poll_ring_depth(string &cmd_name)
 //
 
             if (poll_ring_depth == 0)
+            {
                 ret = DefaultPollRingDepth;
+            }
             else
+            {
                 ret = poll_ring_depth;
+            }
         }
     }
 
@@ -997,9 +1043,13 @@ long DeviceImpl::get_attr_poll_ring_depth(string &attr_name)
 //
 
             if (poll_ring_depth == 0)
+            {
                 ret = DefaultPollRingDepth;
+            }
             else
+            {
                 ret = poll_ring_depth;
+            }
         }
     }
     else
@@ -1040,9 +1090,13 @@ long DeviceImpl::get_attr_poll_ring_depth(string &attr_name)
 //
 
                 if (poll_ring_depth == 0)
+                {
                     ret = DefaultPollRingDepth;
+                }
                 else
+                {
                     ret = poll_ring_depth;
+                }
             }
         }
     }
@@ -1072,7 +1126,9 @@ Tango::DevState DeviceImpl::dev_state()
 //
 
     if (run_att_conf_loop == true)
+    {
         att_conf_loop();
+    }
 
     if (device_state != Tango::FAULT && force_alarm_state == true)
     {
@@ -1109,7 +1165,9 @@ Tango::DevState DeviceImpl::dev_state()
                             ite = attr_list_2.erase(ite);
                         }
                         else
+                        {
                             ++ite;
+                        }
                     }
                     nb_wanted_attr = attr_list_2.size();
                 }
@@ -1120,9 +1178,13 @@ Tango::DevState DeviceImpl::dev_state()
                     {
                         Attribute &att = dev_attr->get_attr_by_ind(*ite);
                         if (att.is_polled() == true)
+                        {
                             ite = attr_list.erase(ite);
+                        }
                         else
+                        {
                             ++ite;
+                        }
                     }
                     nb_wanted_attr = attr_list.size();
                 }
@@ -1162,9 +1224,13 @@ Tango::DevState DeviceImpl::dev_state()
 
                     long idx;
                     if ((vers >= 3) && (state_from_read == true))
+                    {
                         idx = attr_list_2[i];
+                    }
                     else
+                    {
                         idx = attr_list[i];
+                    }
 
                     Attribute &att = dev_attr->get_attr_by_ind(idx);
                     att.save_alarm_quality();
@@ -1172,7 +1238,9 @@ Tango::DevState DeviceImpl::dev_state()
                     try
                     {
                         if (vers < 3)
+                        {
                             read_attr(att);
+                        }
                         else
                         {
 
@@ -1210,14 +1278,20 @@ Tango::DevState DeviceImpl::dev_state()
                         {
                             long idx;
                             if ((vers >= 3) && (state_from_read == true))
+                            {
                                 idx = attr_list_2[j];
+                            }
                             else
+                            {
                                 idx = attr_list[j];
+                            }
                             Tango::Attribute &tmp_att = dev_attr->get_attr_by_ind(idx);
                             if (att.get_wanted_date() == false)
                             {
                                 if (tmp_att.get_quality() != Tango::ATTR_INVALID)
+                                {
                                     tmp_att.delete_seq();
+                                }
                                 tmp_att.wanted_date(true);
                             }
                         }
@@ -1242,7 +1316,9 @@ Tango::DevState DeviceImpl::dev_state()
                 else
                 {
                     if (ext->alarm_state_kernel > ext->alarm_state_user)
+                    {
                         device_state = Tango::ON;
+                    }
                 }
 
 
@@ -1254,14 +1330,20 @@ Tango::DevState DeviceImpl::dev_state()
                 {
                     long idx;
                     if ((vers >= 3) && (state_from_read == true))
+                    {
                         idx = attr_list_2[i];
+                    }
                     else
+                    {
                         idx = attr_list[i];
+                    }
                     Tango::Attribute &att = dev_attr->get_attr_by_ind(idx);
                     if (att.get_wanted_date() == false)
                     {
                         if (att.get_quality() != Tango::ATTR_INVALID)
+                        {
                             att.delete_seq();
+                        }
                         att.wanted_date(true);
                     }
                 }
@@ -1269,7 +1351,9 @@ Tango::DevState DeviceImpl::dev_state()
             else
             {
                 if (ext->alarm_state_kernel > ext->alarm_state_user)
+                {
                     device_state = Tango::ON;
+                }
             }
 
 
@@ -1290,7 +1374,9 @@ Tango::DevState DeviceImpl::dev_state()
                     }
                 }
                 else
+                {
                     device_state = Tango::ON;
+                }
             }
         }
     }
@@ -1315,7 +1401,9 @@ Tango::ConstDevString DeviceImpl::dev_status()
     const char *returned_str;
 
     if (run_att_conf_loop == true)
+    {
         att_conf_loop();
+    }
 
     if (device_state != Tango::FAULT && force_alarm_state == true)
     {
@@ -1381,7 +1469,9 @@ Tango::ConstDevString DeviceImpl::dev_status()
                 returned_str = alarm_status.c_str();
             }
             else
+            {
                 returned_str = device_status.c_str();
+            }
         }
     }
 
@@ -1435,7 +1525,9 @@ CORBA::Any *DeviceImpl::command_inout(const char *in_cmd,
 //
 
         if (store_in_bb == true)
+        {
             blackbox_ptr->insert_cmd(in_cmd);
+        }
         store_in_bb = true;
 
 //
@@ -1491,9 +1583,13 @@ char *DeviceImpl::name()
     {
         CORBA::IMP_LIMIT lim;
         if (strcmp(e.errors[0].reason, API_CommandTimedOut) == 0)
+        {
             lim.minor(TG_IMP_MINOR_TO);
+        }
         else
+        {
             lim.minor(TG_IMP_MINOR_DEVFAILED);
+        }
         cout4 << "Leaving DeviceImpl::name throwing IMP_LIMIT" << endl;
         throw lim;
     }
@@ -1541,9 +1637,13 @@ char *DeviceImpl::adm_name()
     {
         CORBA::IMP_LIMIT lim;
         if (strcmp(e.errors[0].reason, API_CommandTimedOut) == 0)
+        {
             lim.minor(TG_IMP_MINOR_TO);
+        }
         else
+        {
             lim.minor(TG_IMP_MINOR_DEVFAILED);
+        }
         cout4 << "Leaving DeviceImpl::adm_name throwing IMP_LIMIT" << endl;
         throw lim;
     }
@@ -1593,9 +1693,13 @@ char *DeviceImpl::description()
     {
         CORBA::IMP_LIMIT lim;
         if (strcmp(e.errors[0].reason, API_CommandTimedOut) == 0)
+        {
             lim.minor(TG_IMP_MINOR_TO);
+        }
         else
+        {
             lim.minor(TG_IMP_MINOR_DEVFAILED);
+        }
         cout4 << "Leaving DeviceImpl::description throwing IMP_LIMIT" << endl;
         throw lim;
     }
@@ -1670,9 +1774,13 @@ Tango::DevState DeviceImpl::state()
 
         CORBA::IMP_LIMIT lim;
         if (strcmp(e.errors[0].reason, API_CommandTimedOut) == 0)
+        {
             lim.minor(TG_IMP_MINOR_TO);
+        }
         else
+        {
             lim.minor(TG_IMP_MINOR_DEVFAILED);
+        }
         cout4 << "Leaving DeviceImpl::state (attribute) throwing IMP_LIMIT" << endl;
         throw lim;
     }
@@ -1758,9 +1866,13 @@ char *DeviceImpl::status()
         }
 
         if (strcmp(e.errors[0].reason, API_CommandTimedOut) == 0)
+        {
             tmp = CORBA::string_dup("Not able to acquire device monitor");
+        }
         else
+        {
             tmp = CORBA::string_dup("Got exception	when trying to build device status");
+        }
     }
     catch (...)
     {
@@ -1855,14 +1967,22 @@ Tango::DevCmdInfoList *DeviceImpl::command_list_query()
             tmp.out_type = (long) ((device_class->get_command_list())[i]->get_out_type());
             string &str_in = (device_class->get_command_list())[i]->get_in_type_desc();
             if (str_in.size() != 0)
+            {
                 tmp.in_type_desc = CORBA::string_dup(str_in.c_str());
+            }
             else
+            {
                 tmp.in_type_desc = CORBA::string_dup(NotSet);
+            }
             string &str_out = (device_class->get_command_list())[i]->get_out_type_desc();
             if (str_out.size() != 0)
+            {
                 tmp.out_type_desc = CORBA::string_dup(str_out.c_str());
+            }
             else
+            {
                 tmp.out_type_desc = CORBA::string_dup(NotSet);
+            }
 
             (*back)[i] = tmp;
         }
@@ -1939,14 +2059,22 @@ Tango::DevCmdInfo *DeviceImpl::command_query(const char *command)
             back->out_type = (long) ((device_class->get_command_list())[i]->get_out_type());
             string &str_in = (device_class->get_command_list())[i]->get_in_type_desc();
             if (str_in.size() != 0)
+            {
                 back->in_type_desc = CORBA::string_dup(str_in.c_str());
+            }
             else
+            {
                 back->in_type_desc = CORBA::string_dup(NotSet);
+            }
             string &str_out = (device_class->get_command_list())[i]->get_out_type_desc();
             if (str_out.size() != 0)
+            {
                 back->out_type_desc = CORBA::string_dup(str_out.c_str());
+            }
             else
+            {
                 back->out_type_desc = CORBA::string_dup(NotSet);
+            }
             break;
         }
     }
@@ -2168,9 +2296,13 @@ Tango::AttributeConfigList *DeviceImpl::get_attribute_config(const Tango::DevVar
         {
             all_attr = true;
             if (vers < 3)
+            {
                 nb_attr = nb_dev_attr;
+            }
             else
+            {
                 nb_attr = nb_dev_attr - 2;
+            }
         }
         else if (in_name == AllAttr_3)
         {
@@ -2316,7 +2448,9 @@ void DeviceImpl::set_attribute_config(const Tango::AttributeConfigList &new_conf
             vector<Attribute::AttPropDb> v_db;
             attr.set_properties(new_conf[i], device_name, false, v_db);
             if (Tango::Util::_UseDb == true)
+            {
                 attr.upd_database(v_db);
+            }
 
 //
 // In case the attribute quality factor was set to ALARM, reset it to VALID
@@ -2325,21 +2459,31 @@ void DeviceImpl::set_attribute_config(const Tango::AttributeConfigList &new_conf
             if ((attr.get_quality() == Tango::ATTR_ALARM) &&
                 (old_alarm == true) &&
                 (attr.is_alarmed().any() == false))
+            {
                 attr.set_quality(Tango::ATTR_VALID);
+            }
 
 //
 // Send the event
 //
 
             if (attr.use_notifd_event() == true)
+            {
                 event_supplier_nd = tg->get_notifd_event_supplier();
+            }
             else
+            {
                 event_supplier_nd = NULL;
+            }
 
             if (attr.use_zmq_event() == true)
+            {
                 event_supplier_zmq = tg->get_zmq_event_supplier();
+            }
             else
+            {
                 event_supplier_zmq = NULL;
+            }
 
             if ((event_supplier_nd != NULL) || (event_supplier_zmq != NULL))
             {
@@ -2355,9 +2499,13 @@ void DeviceImpl::set_attribute_config(const Tango::AttributeConfigList &new_conf
                     attr.get_properties(attr_conf_2);
                     ad.attr_conf_2 = &attr_conf_2;
                     if (event_supplier_nd != NULL)
+                    {
                         event_supplier_nd->push_att_conf_events(this, ad, (Tango::DevFailed *) NULL, tmp_name);
+                    }
                     if (event_supplier_zmq != NULL)
+                    {
                         event_supplier_zmq->push_att_conf_events(this, ad, (Tango::DevFailed *) NULL, tmp_name);
+                    }
                 }
                 else if (vers <= 4)
                 {
@@ -2365,9 +2513,13 @@ void DeviceImpl::set_attribute_config(const Tango::AttributeConfigList &new_conf
                     attr.get_properties(attr_conf_3);
                     ad.attr_conf_3 = &attr_conf_3;
                     if (event_supplier_nd != NULL)
+                    {
                         event_supplier_nd->push_att_conf_events(this, ad, (Tango::DevFailed *) NULL, tmp_name);
+                    }
                     if (event_supplier_zmq != NULL)
+                    {
                         event_supplier_zmq->push_att_conf_events(this, ad, (Tango::DevFailed *) NULL, tmp_name);
+                    }
                 }
                 else
                 {
@@ -2375,9 +2527,13 @@ void DeviceImpl::set_attribute_config(const Tango::AttributeConfigList &new_conf
                     attr.get_properties(attr_conf_5);
                     ad.attr_conf_5 = &attr_conf_5;
                     if (event_supplier_nd != NULL)
+                    {
                         event_supplier_nd->push_att_conf_events(this, ad, (Tango::DevFailed *) NULL, tmp_name);
+                    }
                     if (event_supplier_zmq != NULL)
+                    {
                         event_supplier_zmq->push_att_conf_events(this, ad, (Tango::DevFailed *) NULL, tmp_name);
+                    }
                 }
             }
         }
@@ -2397,7 +2553,9 @@ void DeviceImpl::set_attribute_config(const Tango::AttributeConfigList &new_conf
             if (att.is_alarmed().any() == true)
             {
                 if (att.get_writable() != Tango::WRITE)
+                {
                     dev_attr->get_alarm_list().push_back(j);
+                }
             }
         }
 
@@ -2409,9 +2567,13 @@ void DeviceImpl::set_attribute_config(const Tango::AttributeConfigList &new_conf
 
         o << e.errors[0].reason;
         if (i != 0)
+        {
             o << "\nAll previous attribute(s) have been successfully updated";
+        }
         if (i != (nb_attr - 1))
+        {
             o << "\nAll remaining attribute(s) have not been updated";
+        }
         o << ends;
 
         string s = o.str();
@@ -2432,7 +2594,9 @@ void DeviceImpl::set_attribute_config(const Tango::AttributeConfigList &new_conf
         if (attr.is_alarmed().any() == true)
         {
             if (w_type != Tango::WRITE)
+            {
                 dev_attr->get_alarm_list().push_back(i);
+            }
         }
     }
 
@@ -2487,7 +2651,9 @@ Tango::AttributeValueList *DeviceImpl::read_attributes(const Tango::DevVarString
 //
 
         if (store_in_bb == true)
+        {
             blackbox_ptr->insert_attr(names);
+        }
         store_in_bb = true;
 
 //
@@ -2507,7 +2673,9 @@ Tango::AttributeValueList *DeviceImpl::read_attributes(const Tango::DevVarString
                                     (const char *) "DeviceImpl::read_attributes");
         }
         if (vers >= 3)
+        {
             nb_dev_attr = nb_dev_attr - 2;
+        }
 
 //
 // Build a sequence with the names of the attribute to be read.
@@ -2525,7 +2693,9 @@ Tango::AttributeValueList *DeviceImpl::read_attributes(const Tango::DevVarString
             {
                 real_names.length(nb_dev_attr);
                 for (i = 0; i < nb_dev_attr; i++)
+                {
                     real_names[i] = dev_attr->get_attr_by_ind(i).get_name().c_str();
+                }
             }
             else
             {
@@ -2618,7 +2788,9 @@ Tango::AttributeValueList *DeviceImpl::read_attributes(const Tango::DevVarString
 //
 
         if (nb_wanted_attr != 0)
+        {
             read_attr_hardware(wanted_attr);
+        }
 
 //
 // Set attr value (for readable attribute)
@@ -2629,7 +2801,9 @@ Tango::AttributeValueList *DeviceImpl::read_attributes(const Tango::DevVarString
         for (i = 0; i < nb_wanted_attr; i++)
         {
             if (vers < 3)
+            {
                 read_attr(dev_attr->get_attr_by_ind(wanted_attr[i]));
+            }
             else
             {
                 Attribute &att = dev_attr->get_attr_by_ind(wanted_attr[i]);
@@ -2670,7 +2844,9 @@ Tango::AttributeValueList *DeviceImpl::read_attributes(const Tango::DevVarString
             Tango::AttrWriteType w_type = dev_attr->get_attr_by_ind(wanted_w_attr[i]).get_writable();
             if ((w_type == Tango::READ_WITH_WRITE) ||
                 (w_type == Tango::WRITE))
+            {
                 dev_attr->get_attr_by_ind(wanted_w_attr[i]).set_rvalue();
+            }
         }
 
 //
@@ -2751,10 +2927,14 @@ Tango::AttributeValueList *DeviceImpl::read_attributes(const Tango::DevVarString
                     {
                         if ((w_type == Tango::READ_WRITE) ||
                             (w_type == Tango::READ_WITH_WRITE))
+                        {
                             dev_attr->add_write_value(att);
+                        }
 
                         if ((att.is_alarmed().any() == true) && (qual != Tango::ATTR_INVALID))
+                        {
                             att.check_alarm();
+                        }
                     }
 
                     CORBA::Any &a = (*back)[i].value;
@@ -2861,7 +3041,9 @@ Tango::AttributeValueList *DeviceImpl::read_attributes(const Tango::DevVarString
             }
 
             if (att.get_when().tv_sec == 0)
+            {
                 att.set_time();
+            }
 
             (*back)[i].time = att.get_when();
             (*back)[i].quality = att.get_quality();
@@ -2999,7 +3181,9 @@ void DeviceImpl::write_attributes(const Tango::AttributeValueList &values)
             catch (Tango::DevFailed &)
             {
                 for (long j = 0; j < i; j++)
+                {
                     dev_attr->get_w_attr_by_ind(updated_attr[j]).rollback();
+                }
 
                 throw;
             }
@@ -3043,9 +3227,13 @@ void DeviceImpl::write_attributes(const Tango::AttributeValueList &values)
                 attr_vect[att.get_attr_idx()]->write(this, att);
                 att.copy_data(values[i].value);
                 if (att.is_memorized() == true)
+                {
                     att_in_db.push_back(i);
+                }
                 if (att.is_alarmed().test(Attribute::rds) == true)
+                {
                     att.set_written_date();
+                }
             }
 
             if ((Tango::Util::_UseDb == true) && (att_in_db.empty() == false))
@@ -3173,7 +3361,9 @@ void DeviceImpl::add_attribute(Tango::Attr *new_attr)
             }
 
             if (th_running == false)
+            {
                 devintr_shared.interface.get_interface(this);
+            }
         }
     }
 
@@ -3238,7 +3428,9 @@ void DeviceImpl::add_attribute(Tango::Attr *new_attr)
         dev_attr->add_fwd_attribute(device_name, device_class, i, new_attr);
     }
     else
+    {
         dev_attr->add_attribute(device_name, device_class, i);
+    }
 
 //
 // Eventually start or update device interface change event thread
@@ -3253,14 +3445,18 @@ void DeviceImpl::add_attribute(Tango::Attr *new_attr)
     long per = new_attr->get_polling_period();
     Tango::Util *tg = Tango::Util::instance();
     if (tg->is_svr_starting() == false && per != 0)
+    {
         poll_attribute(attr_name, per);
+    }
 
 //
 // Free memory if needed
 //
 
     if (need_free == true)
+    {
         delete new_attr;
+    }
 
 }
 
@@ -3331,7 +3527,9 @@ void DeviceImpl::remove_attribute(Tango::Attr *rem_attr, bool free_it, bool clea
             }
 
             if (th_running == false)
+            {
                 devintr_shared.interface.get_interface(this);
+            }
         }
     }
 
@@ -3391,7 +3589,9 @@ void DeviceImpl::remove_attribute(Tango::Attr *rem_attr, bool free_it, bool clea
         else
         {
             if (tg->is_device_restarting(get_name()) == false)
+            {
                 adm_dev->rem_obj_polling(&send, clean_db);
+            }
         }
     }
 
@@ -3410,7 +3610,9 @@ void DeviceImpl::remove_attribute(Tango::Attr *rem_attr, bool free_it, bool clea
         {
             tg->get_all_dyn_attr_names().push_back(attr_name);
             if (tg->get_dyn_att_dev_name().size() == 0)
+            {
                 tg->get_dyn_att_dev_name() = device_name;
+            }
 
         }
     }
@@ -3439,7 +3641,9 @@ void DeviceImpl::remove_attribute(Tango::Attr *rem_attr, bool free_it, bool clea
                 Attribute &att = dev_list[i]->get_device_attr()->get_attr_by_name(attr_name.c_str());
                 vector<Tango::Attr *> &attr_list = device_class->get_class_attr()->get_attr_list();
                 if (attr_list[att.get_attr_idx()]->get_cl_name() != rem_attr->get_cl_name())
+                {
                     nb_except++;
+                }
             }
             catch (Tango::DevFailed &)
             {
@@ -3464,7 +3668,9 @@ void DeviceImpl::remove_attribute(Tango::Attr *rem_attr, bool free_it, bool clea
 //
 
     if ((free_it == true) && (update_idx == true))
+    {
         delete rem_attr;
+    }
 
 //
 // Eventually start or update device interface change event thread
@@ -3614,7 +3820,9 @@ void DeviceImpl::add_command(Tango::Command *new_cmd, bool device_level)
             }
 
             if (th_running == false)
+            {
                 devintr_shared.interface.get_interface(this);
+            }
         }
     }
 
@@ -3713,7 +3921,9 @@ void DeviceImpl::remove_command(Tango::Command *rem_cmd, bool free_it, bool clea
             }
 
             if (th_running == false)
+            {
                 devintr_shared.interface.get_interface(this);
+            }
         }
     }
 
@@ -3772,7 +3982,9 @@ void DeviceImpl::remove_command(Tango::Command *rem_cmd, bool free_it, bool clea
         else
         {
             if (tg->is_device_restarting(get_name()) == false)
+            {
                 adm_dev->rem_obj_polling(&send, clean_db);
+            }
         }
     }
 
@@ -3781,16 +3993,22 @@ void DeviceImpl::remove_command(Tango::Command *rem_cmd, bool free_it, bool clea
 //
 
     if (device_cmd == false)
+    {
         device_class->remove_command(cmd_name_low);
+    }
     else
+    {
         remove_local_command(cmd_name_low);
+    }
 
 //
 // Delete Command object if wanted
 //
 
     if (free_it == true)
+    {
         delete rem_cmd;
+    }
 
 //
 // Eventually start or update device interface change event thread
@@ -4345,7 +4563,9 @@ void DeviceImpl::init_attr_poll_period()
                 ss << poll_list[i + 1];
                 ss >> per;
                 if (ss)
+                {
                     att.set_polling_period(per);
+                }
             }
             catch (Tango::DevFailed &)
             {}
@@ -4375,9 +4595,13 @@ void DeviceImpl::push_att_conf_event(Attribute *attr)
     Tango::Util *tg = Tango::Util::instance();
 
     if (attr->use_notifd_event() == true)
+    {
         event_supplier_nd = tg->get_notifd_event_supplier();
+    }
     if (attr->use_zmq_event() == true)
+    {
         event_supplier_zmq = tg->get_zmq_event_supplier();
+    }
 
     if ((event_supplier_nd != NULL) || (event_supplier_zmq != NULL))
     {
@@ -4391,9 +4615,13 @@ void DeviceImpl::push_att_conf_event(Attribute *attr)
             attr->get_properties(attr_conf_2);
             ad.attr_conf_2 = &attr_conf_2;
             if (event_supplier_nd != NULL)
+            {
                 event_supplier_nd->push_att_conf_events(this, ad, (Tango::DevFailed *) NULL, attr->get_name());
+            }
             if (event_supplier_zmq != NULL)
+            {
                 event_supplier_zmq->push_att_conf_events(this, ad, (Tango::DevFailed *) NULL, attr->get_name());
+            }
         }
         else if (vers <= 4)
         {
@@ -4401,9 +4629,13 @@ void DeviceImpl::push_att_conf_event(Attribute *attr)
             attr->get_properties(attr_conf_3);
             ad.attr_conf_3 = &attr_conf_3;
             if (event_supplier_nd != NULL)
+            {
                 event_supplier_nd->push_att_conf_events(this, ad, (Tango::DevFailed *) NULL, attr->get_name());
+            }
             if (event_supplier_zmq != NULL)
+            {
                 event_supplier_zmq->push_att_conf_events(this, ad, (Tango::DevFailed *) NULL, attr->get_name());
+            }
         }
         else
         {
@@ -4411,9 +4643,13 @@ void DeviceImpl::push_att_conf_event(Attribute *attr)
             attr->get_properties(attr_conf_5);
             ad.attr_conf_5 = &attr_conf_5;
             if (event_supplier_nd != NULL)
+            {
                 event_supplier_nd->push_att_conf_events(this, ad, (Tango::DevFailed *) NULL, attr->get_name());
+            }
             if (event_supplier_zmq != NULL)
+            {
                 event_supplier_zmq->push_att_conf_events(this, ad, (Tango::DevFailed *) NULL, attr->get_name());
+            }
         }
     }
 }
@@ -4493,7 +4729,9 @@ void DeviceImpl::lock(client_addr *cl, int validity)
 //
 
     if (get_with_fwd_att() == true)
+    {
         lock_root_devices(validity, true);
+    }
 }
 
 //+------------------------------------------------------------------------------------------------------------------
@@ -4595,9 +4833,13 @@ Tango::DevLong DeviceImpl::unlock(bool forced)
     }
 
     if (lock_ctr > 0)
+    {
         lock_ctr--;
+    }
     if ((lock_ctr <= 0) || (forced == true))
+    {
         basic_unlock(forced);
+    }
 
     return lock_ctr;
 }
@@ -4620,9 +4862,13 @@ void DeviceImpl::basic_unlock(bool forced)
 {
     device_locked = false;
     if (forced == true)
+    {
         old_locker_client = locker_client;
+    }
     else
+    {
         delete locker_client;
+    }
     locker_client = NULL;
     lock_ctr = 0;
 
@@ -4631,7 +4877,9 @@ void DeviceImpl::basic_unlock(bool forced)
 //
 
     if (get_with_fwd_att() == true)
+    {
         lock_root_devices(0, false);
+    }
 }
 
 //+------------------------------------------------------------------------------------------------------------------
@@ -4649,9 +4897,13 @@ bool DeviceImpl::valid_lock()
 {
     time_t now = time(NULL);
     if (now > (locking_date + lock_validity))
+    {
         return false;
+    }
     else
+    {
         return true;
+    }
 }
 
 //+-----------------------------------------------------------------------------------------------------------------
@@ -4711,7 +4963,9 @@ Tango::DevVarLongStringArray *DeviceImpl::lock_status()
             {
                 dvlsa->svalue[2] = CORBA::string_dup("Not defined");
                 for (long loop = 2; loop < 6; loop++)
+                {
                     dvlsa->lvalue[loop] = 0;
+                }
             }
         }
         else
@@ -4721,7 +4975,9 @@ Tango::DevVarLongStringArray *DeviceImpl::lock_status()
             dvlsa->svalue[1] = CORBA::string_dup("Not defined");
             dvlsa->svalue[2] = CORBA::string_dup("Not defined");
             for (long loop = 0; loop < 6; loop++)
+            {
                 dvlsa->lvalue[loop] = 0;
+            }
         }
     }
     else
@@ -4730,7 +4986,9 @@ Tango::DevVarLongStringArray *DeviceImpl::lock_status()
         dvlsa->svalue[1] = CORBA::string_dup("Not defined");
         dvlsa->svalue[2] = CORBA::string_dup("Not defined");
         for (long loop = 0; loop < 6; loop++)
+        {
             dvlsa->lvalue[loop] = 0;
+        }
     }
 
     dvlsa->svalue[0] = CORBA::string_dup(lock_stat.c_str());
@@ -4805,7 +5063,9 @@ void DeviceImpl::check_lock(const char *meth, const char *cmd)
                     }
                 }
                 else
+                {
                     throw_locked_exception(meth);
+                }
             }
 
             if (*cl != *(locker_client))
@@ -4824,7 +5084,9 @@ void DeviceImpl::check_lock(const char *meth, const char *cmd)
                     }
                 }
                 else
+                {
                     throw_locked_exception(meth);
+                }
             }
         }
         else
@@ -4999,9 +5261,13 @@ void DeviceImpl::data_into_net_object(Attribute &att, AttributeIdlData &aid,
                     DevVarEncodedArray &the_seq = (*aid.data_5)[index].value.encoded_att_value();
 
                     if ((w_type == Tango::READ) || (w_type == Tango::WRITE))
+                    {
                         the_seq.length(1);
+                    }
                     else
+                    {
                         the_seq.length(2);
+                    }
 
                     the_seq[0].encoded_format = CORBA::string_dup((*ptr)[0].encoded_format);
 
@@ -5013,9 +5279,11 @@ void DeviceImpl::data_into_net_object(Attribute &att, AttributeIdlData &aid,
                         (*ptr)[0].encoded_data.replace(0, 0, NULL, false);
                     }
                     else
+                    {
                         the_seq[0].encoded_data.replace((*ptr)[0].encoded_data.length(),
                                                         (*ptr)[0].encoded_data.length(),
                                                         (*ptr)[0].encoded_data.get_buffer());
+                    }
 
                     if ((w_type == Tango::READ_WRITE) || (w_type == Tango::READ_WITH_WRITE))
                     {
@@ -5031,9 +5299,13 @@ void DeviceImpl::data_into_net_object(Attribute &att, AttributeIdlData &aid,
                     DevVarEncodedArray &the_seq = (*aid.data_4)[index].value.encoded_att_value();
 
                     if ((w_type == Tango::READ) || (w_type == Tango::WRITE))
+                    {
                         the_seq.length(1);
+                    }
                     else
+                    {
                         the_seq.length(2);
+                    }
 
                     the_seq[0].encoded_format = CORBA::string_dup((*ptr)[0].encoded_format);
 
@@ -5045,9 +5317,11 @@ void DeviceImpl::data_into_net_object(Attribute &att, AttributeIdlData &aid,
                         (*ptr)[0].encoded_data.replace(0, 0, NULL, false);
                     }
                     else
+                    {
                         the_seq[0].encoded_data.replace((*ptr)[0].encoded_data.length(),
                                                         (*ptr)[0].encoded_data.length(),
                                                         (*ptr)[0].encoded_data.get_buffer());
+                    }
 
                     if ((w_type == Tango::READ_WRITE) || (w_type == Tango::READ_WITH_WRITE))
                     {
@@ -5058,7 +5332,9 @@ void DeviceImpl::data_into_net_object(Attribute &att, AttributeIdlData &aid,
                     }
                 }
                 if (del_seq == true)
+                {
                     delete ptr;
+                }
             }
             break;
         }
@@ -5391,14 +5667,20 @@ void DeviceImpl::att_conf_loop()
         {
             force_alarm_state = true;
             if (att_list[i]->is_startup_exception() == true)
+            {
                 wrong_conf_att_list.push_back(att_list[i]->get_name());
+            }
             else
+            {
                 mem_att_list.push_back(att_list[i]->get_name());
+            }
         }
     }
 
     if (force_alarm_state == false && fwd_att_wrong_conf.empty() == false)
+    {
         force_alarm_state = true;
+    }
 
     run_att_conf_loop = false;
 }
@@ -5417,7 +5699,9 @@ void DeviceImpl::check_att_conf()
     dev_attr->check_idl_release(this);
 
     if (run_att_conf_loop == true)
+    {
         att_conf_loop();
+    }
 }
 
 //----------------------------------------------------------------------------------------------------------------------
@@ -5451,14 +5735,20 @@ void DeviceImpl::build_att_list_in_status_mess(size_t nb_att, AttErrorType att_t
         {
             alarm_status = alarm_status + "\nForwarded attribute " + fwd_att_wrong_conf[i].att_name;
             if (fwd_att_wrong_conf[i].fae != FWD_ROOT_DEV_NOT_STARTED)
+            {
                 alarm_status = alarm_status + " is not correctly configured! ";
+            }
             else
+            {
                 alarm_status = alarm_status + " not reachable! ";
+            }
 
             alarm_status = alarm_status + "Root attribute name = ";
             alarm_status = alarm_status + fwd_att_wrong_conf[i].full_root_att_name;
             if (fwd_att_wrong_conf[i].fae != FWD_ROOT_DEV_NOT_STARTED)
+            {
                 alarm_status = alarm_status + "\nYou can update it using the Jive tool";
+            }
             alarm_status = alarm_status + "\nError: ";
             switch (fwd_att_wrong_conf[i].fae)
             {
@@ -5524,23 +5814,35 @@ void DeviceImpl::build_att_list_in_status_mess(size_t nb_att, AttErrorType att_t
 //
 
         if (nb_att > 1)
+        {
             alarm_status = alarm_status + "s";
+        }
         alarm_status = alarm_status + " ";
         for (size_t i = 0; i < nb_att; ++i)
         {
             if (att_type == Tango::DeviceImpl::CONF)
+            {
                 alarm_status = alarm_status + att_wrong_db_conf[i];
+            }
             else
+            {
                 alarm_status = alarm_status + att_mem_failed[i];
+            }
 
             if ((nb_att > 1) && (i <= nb_att - 2))
+            {
                 alarm_status = alarm_status + ", ";
+            }
         }
 
         if (nb_att == 1)
+        {
             alarm_status = alarm_status + " has ";
+        }
         else
+        {
             alarm_status = alarm_status + " have ";
+        }
     }
 }
 
@@ -5694,7 +5996,9 @@ void DeviceImpl::lock_root_devices(int validity, bool lock_action)
             string &dev_name = fwd_att->get_fwd_dev_name();
             ite = find(root_devs.begin(), root_devs.end(), dev_name);
             if (ite == root_devs.end())
+            {
                 root_devs.push_back(dev_name);
+            }
         }
     }
 
@@ -5708,9 +6012,13 @@ void DeviceImpl::lock_root_devices(int validity, bool lock_action)
         DeviceProxy *dp = rar.get_root_att_dp(root_devs[loop]);
 
         if (lock_action == true)
+        {
             dp->lock(validity);
+        }
         else
+        {
             dp->unlock();
+        }
     }
 }
 
@@ -5733,7 +6041,9 @@ Command &DeviceImpl::get_local_cmd_by_name(const string &cmd_name)
                   [&](Command *cmd) -> bool
                   {
                       if (cmd_name.size() != cmd->get_lower_name().size())
+                      {
                           return false;
+                      }
                       string tmp_name(cmd_name);
                       transform(tmp_name.begin(), tmp_name.end(), tmp_name.begin(), ::tolower);
                       return cmd->get_lower_name() == tmp_name;
@@ -5774,7 +6084,9 @@ void DeviceImpl::remove_local_command(const string &cmd_name)
                   [&](Command *cmd) -> bool
                   {
                       if (cmd_name.size() != cmd->get_lower_name().size())
+                      {
                           return false;
+                      }
                       return cmd->get_lower_name() == cmd_name;
                   });
 #else
@@ -5850,7 +6162,9 @@ void DeviceImpl::set_event_param(vector<EventPar> &eve)
         if (eve[loop].attr_id == -1)
         {
             if (eve[loop].dev_intr_change == true)
+            {
                 set_event_intr_change_subscription(time(NULL));
+            }
             break;
         }
     }
@@ -5956,7 +6270,9 @@ void DeviceImpl::end_pipe_config()
         if (tg->_UseDb == true)
         {
             for (size_t i = 0; i < nb_pipe; i++)
+            {
                 db_list.push_back(DbDatum(pipe_list[i]->get_name()));
+            }
 
 //
 // On some small and old computers, this request could take time if at the same time some other processes also access
@@ -5966,14 +6282,20 @@ void DeviceImpl::end_pipe_config()
 
             int old_db_timeout = 0;
             if (Util::_FileDb == false)
+            {
                 old_db_timeout = tg->get_database()->get_timeout_millis();
+            }
             try
             {
                 if (old_db_timeout != 0)
+                {
                     tg->get_database()->set_timeout_millis(6000);
+                }
                 tg->get_database()->get_device_pipe_property(device_name, db_list, tg->get_db_cache());
                 if (old_db_timeout != 0)
+                {
                     tg->get_database()->set_timeout_millis(old_db_timeout);
+                }
             }
             catch (Tango::DevFailed &)
             {
@@ -6017,7 +6339,9 @@ void DeviceImpl::end_pipe_config()
                         dev_prop.push_back(PipeProperty(db_list[ind].name, tmp));
                     }
                     else
+                    {
                         dev_prop.push_back(PipeProperty(db_list[ind].name, db_list[ind].value_string[0]));
+                    }
                     ind++;
                 }
 
@@ -6069,9 +6393,13 @@ void DeviceImpl::set_pipe_prop(vector<PipeProperty> &dev_prop, Pipe *pi_ptr, Pip
     bool found = false;
     string req_p_name;
     if (ppt == LABEL)
+    {
         req_p_name = "label";
+    }
     else
+    {
         req_p_name = "description";
+    }
 
     vector<PipeProperty>::iterator dev_ite;
     for (dev_ite = dev_prop.begin(); dev_ite != dev_prop.end(); ++dev_ite)
@@ -6089,9 +6417,13 @@ void DeviceImpl::set_pipe_prop(vector<PipeProperty> &dev_prop, Pipe *pi_ptr, Pip
     if (found == true)
     {
         if (ppt == LABEL)
+        {
             pi_ptr->set_label(dev_ite->get_value());
+        }
         else
+        {
             pi_ptr->set_desc(dev_ite->get_value());
+        }
     }
     else
     {
@@ -6103,9 +6435,13 @@ void DeviceImpl::set_pipe_prop(vector<PipeProperty> &dev_prop, Pipe *pi_ptr, Pip
 
         bool still_default;
         if (ppt == LABEL)
+        {
             still_default = pi_ptr->is_label_lib_default();
+        }
         else
+        {
             still_default = pi_ptr->is_desc_lib_default();
+        }
 
         if (still_default == true)
         {
@@ -6130,9 +6466,13 @@ void DeviceImpl::set_pipe_prop(vector<PipeProperty> &dev_prop, Pipe *pi_ptr, Pip
                 if (found == true)
                 {
                     if (ppt == LABEL)
+                    {
                         pi_ptr->set_label(class_ite->get_value());
+                    }
                     else
+                    {
                         pi_ptr->set_desc(class_ite->get_value());
+                    }
                 }
             }
             catch (Tango::DevFailed &)

--- a/cppapi/server/device.cpp
+++ b/cppapi/server/device.cpp
@@ -974,7 +974,7 @@ long DeviceImpl::get_cmd_poll_ring_depth(string &cmd_name)
             {
                 TangoSys_MemStream s;
                 s << cmd_poll_ring_depth[k + 1];
-                if (!(s >> ret))
+                if (not(s >> ret))
                 {
                     TangoSys_OMemStream o;
                     o << "System property cmd_poll_ring_depth for device " << device_name << " has wrong syntax"

--- a/cppapi/server/device.cpp
+++ b/cppapi/server/device.cpp
@@ -74,147 +74,150 @@ extern omni_thread::key_t key;
 //
 //--------------------------------------------------------------------------
 
-DeviceImpl::DeviceImpl(DeviceClass *cl_ptr,const char *d_name,
-		       const char *de,Tango::DevState st,const char *sta)
-:device_name(d_name),desc(de),device_status(sta),
- device_state(st),device_class(cl_ptr),ext(new DeviceImplExt),
+DeviceImpl::DeviceImpl(DeviceClass *cl_ptr, const char *d_name,
+                       const char *de, Tango::DevState st, const char *sta)
+    : device_name(d_name), desc(de), device_status(sta),
+      device_state(st), device_class(cl_ptr), ext(new DeviceImplExt),
 #ifdef TANGO_HAS_LOG4TANGO
- logger(NULL),saved_log_level(log4tango::Level::WARN),rft(Tango::kDefaultRollingThreshold),poll_old_factor(0),idl_version(1),
+      logger(NULL), saved_log_level(log4tango::Level::WARN), rft(Tango::kDefaultRollingThreshold), poll_old_factor(0),
+      idl_version(1),
 #endif
- exported(false),polled(false),poll_ring_depth(0),only_one(d_name),
- store_in_bb(true),poll_mon("cache"),att_conf_mon("att_config"),
- state_from_read(false),py_device(false),device_locked(false),
- locker_client(NULL),old_locker_client(NULL),lock_ctr(0),
- min_poll_period(0),run_att_conf_loop(true),force_alarm_state(false),with_fwd_att(false),
- event_intr_change_subscription(0),intr_change_ev(false),devintr_thread(Tango_nullptr)
+      exported(false), polled(false), poll_ring_depth(0), only_one(d_name),
+      store_in_bb(true), poll_mon("cache"), att_conf_mon("att_config"),
+      state_from_read(false), py_device(false), device_locked(false),
+      locker_client(NULL), old_locker_client(NULL), lock_ctr(0),
+      min_poll_period(0), run_att_conf_loop(true), force_alarm_state(false), with_fwd_att(false),
+      event_intr_change_subscription(0), intr_change_ev(false), devintr_thread(Tango_nullptr)
 {
     real_ctor();
 }
 
-DeviceImpl::DeviceImpl(DeviceClass *cl_ptr,string &d_name,string &de,
-		       Tango::DevState st,string &sta)
-:device_name(d_name),desc(de),device_status(sta),
- device_state(st),device_class(cl_ptr),ext(new DeviceImplExt),
+DeviceImpl::DeviceImpl(DeviceClass *cl_ptr, string &d_name, string &de,
+                       Tango::DevState st, string &sta)
+    : device_name(d_name), desc(de), device_status(sta),
+      device_state(st), device_class(cl_ptr), ext(new DeviceImplExt),
 #ifdef TANGO_HAS_LOG4TANGO
- logger(NULL),saved_log_level(log4tango::Level::WARN),rft(Tango::kDefaultRollingThreshold),poll_old_factor(0),idl_version(1),
+      logger(NULL), saved_log_level(log4tango::Level::WARN), rft(Tango::kDefaultRollingThreshold), poll_old_factor(0),
+      idl_version(1),
 #endif
- exported(false),polled(false),poll_ring_depth(0),only_one(d_name.c_str()),
- store_in_bb(true),poll_mon("cache"),att_conf_mon("att_config"),
- state_from_read(false),py_device(false),device_locked(false),
- locker_client(NULL),old_locker_client(NULL),lock_ctr(0),
- min_poll_period(0),run_att_conf_loop(true),force_alarm_state(false),with_fwd_att(false),
- event_intr_change_subscription(0),intr_change_ev(false),devintr_thread(Tango_nullptr)
+      exported(false), polled(false), poll_ring_depth(0), only_one(d_name.c_str()),
+      store_in_bb(true), poll_mon("cache"), att_conf_mon("att_config"),
+      state_from_read(false), py_device(false), device_locked(false),
+      locker_client(NULL), old_locker_client(NULL), lock_ctr(0),
+      min_poll_period(0), run_att_conf_loop(true), force_alarm_state(false), with_fwd_att(false),
+      event_intr_change_subscription(0), intr_change_ev(false), devintr_thread(Tango_nullptr)
 {
     real_ctor();
 }
 
-DeviceImpl::DeviceImpl(DeviceClass *cl_ptr,string &d_name)
-:device_name(d_name),device_class(cl_ptr),ext(new DeviceImplExt),
+DeviceImpl::DeviceImpl(DeviceClass *cl_ptr, string &d_name)
+    : device_name(d_name), device_class(cl_ptr), ext(new DeviceImplExt),
 #ifdef TANGO_HAS_LOG4TANGO
- logger(NULL),saved_log_level(log4tango::Level::WARN),rft(Tango::kDefaultRollingThreshold),poll_old_factor(0),idl_version(1),
+      logger(NULL), saved_log_level(log4tango::Level::WARN), rft(Tango::kDefaultRollingThreshold), poll_old_factor(0),
+      idl_version(1),
 #endif
- exported(false),polled(false),poll_ring_depth(0),only_one(d_name.c_str()),
- store_in_bb(true),poll_mon("cache"),att_conf_mon("att_config"),
- state_from_read(false),py_device(false),device_locked(false),
- locker_client(NULL),old_locker_client(NULL),lock_ctr(0),
- min_poll_period(0),run_att_conf_loop(true),force_alarm_state(false),with_fwd_att(false),
- event_intr_change_subscription(0),intr_change_ev(false),devintr_thread(Tango_nullptr)
+      exported(false), polled(false), poll_ring_depth(0), only_one(d_name.c_str()),
+      store_in_bb(true), poll_mon("cache"), att_conf_mon("att_config"),
+      state_from_read(false), py_device(false), device_locked(false),
+      locker_client(NULL), old_locker_client(NULL), lock_ctr(0),
+      min_poll_period(0), run_att_conf_loop(true), force_alarm_state(false), with_fwd_att(false),
+      event_intr_change_subscription(0), intr_change_ev(false), devintr_thread(Tango_nullptr)
 {
-	desc = "A Tango device";
-	device_state = Tango::UNKNOWN;
-	device_status = StatusNotSet;
+    desc = "A Tango device";
+    device_state = Tango::UNKNOWN;
+    device_status = StatusNotSet;
 
     real_ctor();
 }
 
-DeviceImpl::DeviceImpl(DeviceClass *cl_ptr,string &d_name,string &description)
-:device_name(d_name),device_class(cl_ptr),ext(new DeviceImplExt),
+DeviceImpl::DeviceImpl(DeviceClass *cl_ptr, string &d_name, string &description)
+    : device_name(d_name), device_class(cl_ptr), ext(new DeviceImplExt),
 #ifdef TANGO_HAS_LOG4TANGO
- logger(NULL),saved_log_level(log4tango::Level::WARN),rft(Tango::kDefaultRollingThreshold),poll_old_factor(0),idl_version(1),
+      logger(NULL), saved_log_level(log4tango::Level::WARN), rft(Tango::kDefaultRollingThreshold), poll_old_factor(0),
+      idl_version(1),
 #endif
- exported(false),polled(false),poll_ring_depth(0),only_one(d_name.c_str()),
- store_in_bb(true),poll_mon("cache"),att_conf_mon("att_config"),
- state_from_read(false),py_device(false),device_locked(false),
- locker_client(NULL),old_locker_client(NULL),lock_ctr(0),
- min_poll_period(0),run_att_conf_loop(true),force_alarm_state(false),with_fwd_att(false),
- event_intr_change_subscription(0),intr_change_ev(false),devintr_thread(Tango_nullptr)
+      exported(false), polled(false), poll_ring_depth(0), only_one(d_name.c_str()),
+      store_in_bb(true), poll_mon("cache"), att_conf_mon("att_config"),
+      state_from_read(false), py_device(false), device_locked(false),
+      locker_client(NULL), old_locker_client(NULL), lock_ctr(0),
+      min_poll_period(0), run_att_conf_loop(true), force_alarm_state(false), with_fwd_att(false),
+      event_intr_change_subscription(0), intr_change_ev(false), devintr_thread(Tango_nullptr)
 {
-	desc = description;
-	device_state = Tango::UNKNOWN;
-	device_status = StatusNotSet;
+    desc = description;
+    device_state = Tango::UNKNOWN;
+    device_status = StatusNotSet;
 
-	real_ctor();
+    real_ctor();
 }
-
 
 void DeviceImpl::real_ctor()
 {
     version = DevVersion;
-	blackbox_depth = 0;
+    blackbox_depth = 0;
 
-	device_prev_state = device_state;
+    device_prev_state = device_state;
 
 //
 // Init lower case device name
 //
 
-	device_name_lower = device_name;
-	transform(device_name_lower.begin(),device_name_lower.end(),
-		  device_name_lower.begin(),::tolower);
+    device_name_lower = device_name;
+    transform(device_name_lower.begin(), device_name_lower.end(),
+              device_name_lower.begin(), ::tolower);
 
 //
 //  Write the device name into the per thread data for sub device diagnostics
 //
 
     Tango::Util *tg = Tango::Util::instance();
-	tg->get_sub_dev_diag().set_associated_device(device_name_lower);
+    tg->get_sub_dev_diag().set_associated_device(device_name_lower);
 
 //
 // Create the DbDevice object
 //
 
-	try
-	{
-		db_dev = new DbDevice(device_name,Tango::Util::instance()->get_database());
-	}
-	catch (Tango::DevFailed &)
-	{
-		throw;
-	}
+    try
+    {
+        db_dev = new DbDevice(device_name, Tango::Util::instance()->get_database());
+    }
+    catch (Tango::DevFailed &)
+    {
+        throw;
+    }
 
-	get_dev_system_resource();
+    get_dev_system_resource();
 
-	black_box_create();
+    black_box_create();
 
-	idl_version = 1;
-	devintr_shared.th_running = false;
+    idl_version = 1;
+    devintr_shared.th_running = false;
 
 //
 // Create the multi attribute object
 //
 
-	dev_attr = new MultiAttribute(device_name,device_class,this);
+    dev_attr = new MultiAttribute(device_name, device_class, this);
 
 //
 // Create device pipe and finish the pipe config init since we now have device name
 //
 
-    device_class->create_device_pipe(device_class,this);
+    device_class->create_device_pipe(device_class, this);
     end_pipe_config();
 
 //
 // Build adm device name
 //
 
-	adm_device_name = "dserver/";
-	adm_device_name = adm_device_name + Util::instance()->get_ds_name();
+    adm_device_name = "dserver/";
+    adm_device_name = adm_device_name + Util::instance()->get_ds_name();
 
 //
 // Init logging
 //
 
 #ifdef TANGO_HAS_LOG4TANGO
-	init_logger();
+    init_logger();
 #endif
 
 }
@@ -232,69 +235,69 @@ void DeviceImpl::real_ctor()
 
 void DeviceImpl::stop_polling(bool with_db_upd)
 {
-	Tango::Util *tg = Tango::Util::instance();
+    Tango::Util *tg = Tango::Util::instance();
 
 //
 // If the vector of polling info is empty, no need to do anything (polling
 // already stopped for all devices)
 //
 
-	vector<PollingThreadInfo *> &v_th_info = tg->get_polling_threads_info();
-	if (v_th_info.empty() == true)
-		return;
+    vector<PollingThreadInfo *> &v_th_info = tg->get_polling_threads_info();
+    if (v_th_info.empty() == true)
+        return;
 
 //
 // Find out which thread is in charge of the device.
 //
 
-	PollingThreadInfo *th_info;
+    PollingThreadInfo *th_info;
 
-	int poll_th_id = tg->get_polling_thread_id_by_name(device_name.c_str());
-	if (poll_th_id == 0)
-	{
-		TangoSys_OMemStream o;
-		o << "Can't find a polling thread for device " << device_name << ends;
-		Except::throw_exception((const char *)API_PollingThreadNotFound,o.str(),
-						(const char *)"DeviImpl::stop_polling");
-	}
+    int poll_th_id = tg->get_polling_thread_id_by_name(device_name.c_str());
+    if (poll_th_id == 0)
+    {
+        TangoSys_OMemStream o;
+        o << "Can't find a polling thread for device " << device_name << ends;
+        Except::throw_exception((const char *) API_PollingThreadNotFound, o.str(),
+                                (const char *) "DeviImpl::stop_polling");
+    }
 
-	th_info = tg->get_polling_thread_info_by_id(poll_th_id);
+    th_info = tg->get_polling_thread_info_by_id(poll_th_id);
 
-	TangoMonitor &mon = th_info->poll_mon;
-	PollThCmd &shared_cmd = th_info->shared_data;
+    TangoMonitor &mon = th_info->poll_mon;
+    PollThCmd &shared_cmd = th_info->shared_data;
 
-	{
-		omni_mutex_lock sync(mon);
-		if (shared_cmd.cmd_pending == true)
-		{
-			mon.wait();
-		}
-		shared_cmd.cmd_pending = true;
-		shared_cmd.cmd_code = POLL_REM_DEV;
-		shared_cmd.dev = this;
+    {
+        omni_mutex_lock sync(mon);
+        if (shared_cmd.cmd_pending == true)
+        {
+            mon.wait();
+        }
+        shared_cmd.cmd_pending = true;
+        shared_cmd.cmd_code = POLL_REM_DEV;
+        shared_cmd.dev = this;
 
-		mon.signal();
+        mon.signal();
 
 //
 // Wait for thread to execute command
 //
 
-		while (shared_cmd.cmd_pending == true)
-		{
-			int interupted = mon.wait(DEFAULT_TIMEOUT);
+        while (shared_cmd.cmd_pending == true)
+        {
+            int interupted = mon.wait(DEFAULT_TIMEOUT);
 
-			if ((shared_cmd.cmd_pending == true) && (interupted == false))
-			{
-				cout4 << "TIME OUT" << endl;
-				Except::throw_exception((const char *)API_CommandTimedOut,
-							(const char *)"Polling thread blocked !!",
-							(const char *)"DeviceImpl::stop_polling");
+            if ((shared_cmd.cmd_pending == true) && (interupted == false))
+            {
+                cout4 << "TIME OUT" << endl;
+                Except::throw_exception((const char *) API_CommandTimedOut,
+                                        (const char *) "Polling thread blocked !!",
+                                        (const char *) "DeviceImpl::stop_polling");
 
-			}
-		}
-	}
+            }
+        }
+    }
 
-	is_polled(false);
+    is_polled(false);
 
 //
 // Update the pool conf first locally.
@@ -303,74 +306,74 @@ void DeviceImpl::stop_polling(bool with_db_upd)
 // Then in Db if possible
 //
 
-	bool kill_thread = false;
-	int ind;
+    bool kill_thread = false;
+    int ind;
 
-	if ((ind = tg->get_dev_entry_in_pool_conf(device_name_lower)) ==  -1)
-	{
-		TangoSys_OMemStream o;
-		o << "Can't find entry for device " << device_name << " in polling threads pool configuration !"<< ends;
-		Except::throw_exception((const char *)API_PolledDeviceNotInPoolConf,o.str(),
-								(const char *)"DeviceImpl::stop_polling");
-	}
+    if ((ind = tg->get_dev_entry_in_pool_conf(device_name_lower)) == -1)
+    {
+        TangoSys_OMemStream o;
+        o << "Can't find entry for device " << device_name << " in polling threads pool configuration !" << ends;
+        Except::throw_exception((const char *) API_PolledDeviceNotInPoolConf, o.str(),
+                                (const char *) "DeviceImpl::stop_polling");
+    }
 
-	vector<string> &pool_conf = tg->get_poll_pool_conf();
-	string &conf_entry = pool_conf[ind];
-	string::size_type pos;
-	if ((pos = conf_entry.find(',')) != string::npos)
-	{
-		pos = conf_entry.find(device_name_lower);
-		if ((pos + device_name_lower.size()) != conf_entry.size())
-			conf_entry.erase(pos,device_name_lower.size() + 1);
-		else
-			conf_entry.erase(pos - 1);
-	}
-	else
-	{
-		vector<string>::iterator iter = pool_conf.begin() + ind;
-		pool_conf.erase(iter);
-		kill_thread = true;
-	}
+    vector<string> &pool_conf = tg->get_poll_pool_conf();
+    string &conf_entry = pool_conf[ind];
+    string::size_type pos;
+    if ((pos = conf_entry.find(',')) != string::npos)
+    {
+        pos = conf_entry.find(device_name_lower);
+        if ((pos + device_name_lower.size()) != conf_entry.size())
+            conf_entry.erase(pos, device_name_lower.size() + 1);
+        else
+            conf_entry.erase(pos - 1);
+    }
+    else
+    {
+        vector<string>::iterator iter = pool_conf.begin() + ind;
+        pool_conf.erase(iter);
+        kill_thread = true;
+    }
 
-	tg->remove_dev_from_polling_map(device_name_lower);
+    tg->remove_dev_from_polling_map(device_name_lower);
 
 //
 // Kill the thread if needed and join
 //
 
-	if (kill_thread == true)
-	{
-		TangoMonitor &mon = th_info->poll_mon;
-		PollThCmd &shared_cmd = th_info->shared_data;
+    if (kill_thread == true)
+    {
+        TangoMonitor &mon = th_info->poll_mon;
+        PollThCmd &shared_cmd = th_info->shared_data;
 
-		{
-			omni_mutex_lock sync(mon);
+        {
+            omni_mutex_lock sync(mon);
 
-			shared_cmd.cmd_pending = true;
-			shared_cmd.cmd_code = POLL_EXIT;
+            shared_cmd.cmd_pending = true;
+            shared_cmd.cmd_code = POLL_EXIT;
 
-			mon.signal();
-		}
+            mon.signal();
+        }
 
-		void *dummy_ptr;
-		cout4 << "POLLING: Joining with one polling thread" << endl;
-		th_info->poll_th->join(&dummy_ptr);
+        void *dummy_ptr;
+        cout4 << "POLLING: Joining with one polling thread" << endl;
+        th_info->poll_th->join(&dummy_ptr);
 
-		tg->remove_polling_thread_info_by_id(poll_th_id);
-	}
+        tg->remove_polling_thread_info_by_id(poll_th_id);
+    }
 
 //
 // Update db
 //
 
-	if ((with_db_upd == true) && (Tango::Util::_UseDb == true))
-	{
-		DbData send_data;
-		send_data.push_back(DbDatum("polling_threads_pool_conf"));
-		send_data[0] << tg->get_poll_pool_conf();
+    if ((with_db_upd == true) && (Tango::Util::_UseDb == true))
+    {
+        DbData send_data;
+        send_data.push_back(DbDatum("polling_threads_pool_conf"));
+        send_data[0] << tg->get_poll_pool_conf();
 
-		tg->get_dserver_device()->get_db_device()->put_property(send_data);
-	}
+        tg->get_dserver_device()->get_db_device()->put_property(send_data);
+    }
 }
 
 
@@ -385,55 +388,55 @@ void DeviceImpl::stop_polling(bool with_db_upd)
 
 DeviceImpl::~DeviceImpl()
 {
-	cout4 << "Entering DeviceImpl destructor for device " << device_name << endl;
+    cout4 << "Entering DeviceImpl destructor for device " << device_name << endl;
 
 //
 // Call user delete_device method
 //
 
-	delete_device();
+    delete_device();
 
 //
 // Delete the black box
 //
 
-	delete blackbox_ptr;
+    delete blackbox_ptr;
 
 //
 // Delete the DbDevice object
 //
 
-	delete db_dev;
+    delete db_dev;
 
 //
 // Unregister the signal from signal handler
 //
 
-	DServerSignal::instance()->unregister_dev_signal(this);
+    DServerSignal::instance()->unregister_dev_signal(this);
 
 //
 // Delete the multi attribute object
 //
 
-	delete dev_attr;
+    delete dev_attr;
 
 //
 // Clean up previously executed in extension destructor
 // Deletes memory for ring buffer used for polling
 //
 
-	for (unsigned long i = 0;i < poll_obj_list.size();i++)
-	{
-		delete (poll_obj_list[i]);
-	}
+    for (unsigned long i = 0; i < poll_obj_list.size(); i++)
+    {
+        delete (poll_obj_list[i]);
+    }
 
 #ifdef TANGO_HAS_LOG4TANGO
-	if (logger && logger != Logging::get_core_logger())
-	{
-		logger->remove_all_appenders();
-		delete logger;
-		logger = 0;
-	}
+    if (logger && logger != Logging::get_core_logger())
+    {
+        logger->remove_all_appenders();
+        delete logger;
+        logger = 0;
+    }
 #endif
 
     delete locker_client;
@@ -444,7 +447,7 @@ DeviceImpl::~DeviceImpl()
 //
 
 #ifndef HAS_UNIQUE_PTR
-	delete ext;
+    delete ext;
 #endif
 
 //
@@ -452,11 +455,11 @@ DeviceImpl::~DeviceImpl()
 //
 
     vector<DeviceImpl *> &dev_vect = get_device_class()->get_device_list();
-    vector<DeviceImpl *>::iterator ite = find(dev_vect.begin(),dev_vect.end(),this);
+    vector<DeviceImpl *>::iterator ite = find(dev_vect.begin(), dev_vect.end(), this);
     if (ite != dev_vect.end())
         *ite = NULL;
 
-	cout4 << "Leaving DeviceImpl destructor for device " << device_name << endl;
+    cout4 << "Leaving DeviceImpl destructor for device " << device_name << endl;
 }
 
 //+-------------------------------------------------------------------------
@@ -477,17 +480,17 @@ void DeviceImpl::black_box_create()
 // default depth
 //
 
-	try
-	{
-		if (blackbox_depth == 0)
-			blackbox_ptr = new BlackBox();
-		else
-			blackbox_ptr = new BlackBox(blackbox_depth);
-	}
-	catch (bad_alloc &)
-	{
-		throw;
-	}
+    try
+    {
+        if (blackbox_depth == 0)
+            blackbox_ptr = new BlackBox();
+        else
+            blackbox_ptr = new BlackBox(blackbox_depth);
+    }
+    catch (bad_alloc &)
+    {
+        throw;
+    }
 }
 
 //+----------------------------------------------------------------------------
@@ -517,159 +520,159 @@ void DeviceImpl::get_dev_system_resource()
 // description
 //
 
-	Tango::Util *tg = Tango::Util::instance();
-	if (tg->_UseDb == true)
-	{
-		DbData db_data;
+    Tango::Util *tg = Tango::Util::instance();
+    if (tg->_UseDb == true)
+    {
+        DbData db_data;
 
-		db_data.push_back(DbDatum("blackbox_depth"));
-		db_data.push_back(DbDatum("description"));
-		db_data.push_back(DbDatum("poll_ring_depth"));
-		db_data.push_back(DbDatum("polled_cmd"));
-		db_data.push_back(DbDatum("polled_attr"));
-		db_data.push_back(DbDatum("non_auto_polled_cmd"));
-		db_data.push_back(DbDatum("non_auto_polled_attr"));
-		db_data.push_back(DbDatum("poll_old_factor"));
-		db_data.push_back(DbDatum("cmd_poll_ring_depth"));
-		db_data.push_back(DbDatum("attr_poll_ring_depth"));
-		db_data.push_back(DbDatum("min_poll_period"));
-		db_data.push_back(DbDatum("cmd_min_poll_period"));
-		db_data.push_back(DbDatum("attr_min_poll_period"));
+        db_data.push_back(DbDatum("blackbox_depth"));
+        db_data.push_back(DbDatum("description"));
+        db_data.push_back(DbDatum("poll_ring_depth"));
+        db_data.push_back(DbDatum("polled_cmd"));
+        db_data.push_back(DbDatum("polled_attr"));
+        db_data.push_back(DbDatum("non_auto_polled_cmd"));
+        db_data.push_back(DbDatum("non_auto_polled_attr"));
+        db_data.push_back(DbDatum("poll_old_factor"));
+        db_data.push_back(DbDatum("cmd_poll_ring_depth"));
+        db_data.push_back(DbDatum("attr_poll_ring_depth"));
+        db_data.push_back(DbDatum("min_poll_period"));
+        db_data.push_back(DbDatum("cmd_min_poll_period"));
+        db_data.push_back(DbDatum("attr_min_poll_period"));
 
-		try
-		{
-			db_dev->get_property(db_data);
-		}
-		catch (Tango::DevFailed &)
-		{
-			TangoSys_OMemStream o;
-			o << "Database error while trying to retrieve device prperties for device " << device_name.c_str() << ends;
+        try
+        {
+            db_dev->get_property(db_data);
+        }
+        catch (Tango::DevFailed &)
+        {
+            TangoSys_OMemStream o;
+            o << "Database error while trying to retrieve device prperties for device " << device_name.c_str() << ends;
 
-			Except::throw_exception((const char *)API_DatabaseAccess,
-					o.str(),
-					(const char *)"DeviceImpl::get_dev_system_resource");
-		}
+            Except::throw_exception((const char *) API_DatabaseAccess,
+                                    o.str(),
+                                    (const char *) "DeviceImpl::get_dev_system_resource");
+        }
 
-		if (db_data[0].is_empty() == false)
-			db_data[0] >> blackbox_depth;
-		if (db_data[1].is_empty() == false)
-			db_data[1] >> desc;
-		if (db_data[2].is_empty() == false)
-		{
-			long tmp_depth;
-			db_data[2] >> tmp_depth;
-			set_poll_ring_depth(tmp_depth);
-		}
-		if (db_data[3].is_empty() == false)
-			db_data[3] >> get_polled_cmd();
-		if (db_data[4].is_empty() == false)
-			db_data[4] >> get_polled_attr();
-		if (db_data[5].is_empty() == false)
-			db_data[5] >> get_non_auto_polled_cmd();
-		if (db_data[6].is_empty() == false)
-			db_data[6] >> get_non_auto_polled_attr();
-		if (db_data[7].is_empty() == false)
-		{
-			long tmp_poll;
-			db_data[7] >> tmp_poll;
-			set_poll_old_factor(tmp_poll);
-		}
-		else
-			set_poll_old_factor(DEFAULT_POLL_OLD_FACTOR);
-		if (db_data[8].is_empty() == false)
-		{
-			db_data[8] >> cmd_poll_ring_depth;
-			unsigned long nb_prop = cmd_poll_ring_depth.size();
-			if ((nb_prop % 2) == 1)
-			{
-				cmd_poll_ring_depth.clear();
-				TangoSys_OMemStream o;
-				o << "System property cmd_poll_ring_depth for device " << device_name << " has wrong syntax" << ends;
-				Except::throw_exception((const char *)API_BadConfigurationProperty,
-				        		o.str(),
-				        		(const char *)"DeviceImpl::get_dev_system_resource()");
-			}
-			for (unsigned int i = 0;i < nb_prop;i = i + 2)
-				transform(cmd_poll_ring_depth[i].begin(),
-					  cmd_poll_ring_depth[i].end(),
-					  cmd_poll_ring_depth[i].begin(),
-					  ::tolower);
-		}
-		if (db_data[9].is_empty() == false)
-		{
-			db_data[9] >> attr_poll_ring_depth;
-			unsigned long nb_prop = attr_poll_ring_depth.size();
-			if ((attr_poll_ring_depth.size() % 2) == 1)
-			{
-				attr_poll_ring_depth.clear();
-				TangoSys_OMemStream o;
-				o << "System property attr_poll_ring_depth for device " << device_name << " has wrong syntax" << ends;
-				Except::throw_exception((const char *)API_BadConfigurationProperty,
-				        		o.str(),
-				        		(const char *)"DeviceImpl::get_dev_system_resource()");
-			}
-			for (unsigned int i = 0;i < nb_prop;i = i + 2)
-				transform(attr_poll_ring_depth[i].begin(),
-					  attr_poll_ring_depth[i].end(),
-					  attr_poll_ring_depth[i].begin(),
-					  ::tolower);
-		}
+        if (db_data[0].is_empty() == false)
+            db_data[0] >> blackbox_depth;
+        if (db_data[1].is_empty() == false)
+            db_data[1] >> desc;
+        if (db_data[2].is_empty() == false)
+        {
+            long tmp_depth;
+            db_data[2] >> tmp_depth;
+            set_poll_ring_depth(tmp_depth);
+        }
+        if (db_data[3].is_empty() == false)
+            db_data[3] >> get_polled_cmd();
+        if (db_data[4].is_empty() == false)
+            db_data[4] >> get_polled_attr();
+        if (db_data[5].is_empty() == false)
+            db_data[5] >> get_non_auto_polled_cmd();
+        if (db_data[6].is_empty() == false)
+            db_data[6] >> get_non_auto_polled_attr();
+        if (db_data[7].is_empty() == false)
+        {
+            long tmp_poll;
+            db_data[7] >> tmp_poll;
+            set_poll_old_factor(tmp_poll);
+        }
+        else
+            set_poll_old_factor(DEFAULT_POLL_OLD_FACTOR);
+        if (db_data[8].is_empty() == false)
+        {
+            db_data[8] >> cmd_poll_ring_depth;
+            unsigned long nb_prop = cmd_poll_ring_depth.size();
+            if ((nb_prop % 2) == 1)
+            {
+                cmd_poll_ring_depth.clear();
+                TangoSys_OMemStream o;
+                o << "System property cmd_poll_ring_depth for device " << device_name << " has wrong syntax" << ends;
+                Except::throw_exception((const char *) API_BadConfigurationProperty,
+                                        o.str(),
+                                        (const char *) "DeviceImpl::get_dev_system_resource()");
+            }
+            for (unsigned int i = 0; i < nb_prop; i = i + 2)
+                transform(cmd_poll_ring_depth[i].begin(),
+                          cmd_poll_ring_depth[i].end(),
+                          cmd_poll_ring_depth[i].begin(),
+                          ::tolower);
+        }
+        if (db_data[9].is_empty() == false)
+        {
+            db_data[9] >> attr_poll_ring_depth;
+            unsigned long nb_prop = attr_poll_ring_depth.size();
+            if ((attr_poll_ring_depth.size() % 2) == 1)
+            {
+                attr_poll_ring_depth.clear();
+                TangoSys_OMemStream o;
+                o << "System property attr_poll_ring_depth for device " << device_name << " has wrong syntax" << ends;
+                Except::throw_exception((const char *) API_BadConfigurationProperty,
+                                        o.str(),
+                                        (const char *) "DeviceImpl::get_dev_system_resource()");
+            }
+            for (unsigned int i = 0; i < nb_prop; i = i + 2)
+                transform(attr_poll_ring_depth[i].begin(),
+                          attr_poll_ring_depth[i].end(),
+                          attr_poll_ring_depth[i].begin(),
+                          ::tolower);
+        }
 
 //
 // The min. period related properties
 //
 
-		if (db_data[10].is_empty() == false)
-			db_data[10] >> min_poll_period;
+        if (db_data[10].is_empty() == false)
+            db_data[10] >> min_poll_period;
 
-		if (db_data[11].is_empty() == false)
-		{
-			db_data[11] >> cmd_min_poll_period;
-			unsigned long nb_prop = cmd_min_poll_period.size();
-			if ((cmd_min_poll_period.size() % 2) == 1)
-			{
-				cmd_min_poll_period.clear();
-				TangoSys_OMemStream o;
-				o << "System property cmd_min_poll_period for device " << device_name << " has wrong syntax" << ends;
-				Except::throw_exception((const char *)API_BadConfigurationProperty,
-				        		o.str(),
-				        		(const char *)"DeviceImpl::get_dev_system_resource()");
-			}
-			for (unsigned int i = 0;i < nb_prop;i = i + 2)
-				transform(cmd_min_poll_period[i].begin(),
-					  cmd_min_poll_period[i].end(),
-					  cmd_min_poll_period[i].begin(),
-					  ::tolower);
-		}
+        if (db_data[11].is_empty() == false)
+        {
+            db_data[11] >> cmd_min_poll_period;
+            unsigned long nb_prop = cmd_min_poll_period.size();
+            if ((cmd_min_poll_period.size() % 2) == 1)
+            {
+                cmd_min_poll_period.clear();
+                TangoSys_OMemStream o;
+                o << "System property cmd_min_poll_period for device " << device_name << " has wrong syntax" << ends;
+                Except::throw_exception((const char *) API_BadConfigurationProperty,
+                                        o.str(),
+                                        (const char *) "DeviceImpl::get_dev_system_resource()");
+            }
+            for (unsigned int i = 0; i < nb_prop; i = i + 2)
+                transform(cmd_min_poll_period[i].begin(),
+                          cmd_min_poll_period[i].end(),
+                          cmd_min_poll_period[i].begin(),
+                          ::tolower);
+        }
 
-		if (db_data[12].is_empty() == false)
-		{
-			db_data[12] >> attr_min_poll_period;
-			unsigned long nb_prop = attr_min_poll_period.size();
-			if ((attr_min_poll_period.size() % 2) == 1)
-			{
-				attr_min_poll_period.clear();
-				TangoSys_OMemStream o;
-				o << "System property attr_min_poll_period for device " << device_name << " has wrong syntax" << ends;
-				Except::throw_exception((const char *)API_BadConfigurationProperty,
-				        		o.str(),
-				        		(const char *)"DeviceImpl::get_dev_system_resource()");
-			}
-			for (unsigned int i = 0;i < nb_prop;i = i + 2)
-				transform(attr_min_poll_period[i].begin(),
-					  attr_min_poll_period[i].end(),
-					  attr_min_poll_period[i].begin(),
-					  ::tolower);
-		}
+        if (db_data[12].is_empty() == false)
+        {
+            db_data[12] >> attr_min_poll_period;
+            unsigned long nb_prop = attr_min_poll_period.size();
+            if ((attr_min_poll_period.size() % 2) == 1)
+            {
+                attr_min_poll_period.clear();
+                TangoSys_OMemStream o;
+                o << "System property attr_min_poll_period for device " << device_name << " has wrong syntax" << ends;
+                Except::throw_exception((const char *) API_BadConfigurationProperty,
+                                        o.str(),
+                                        (const char *) "DeviceImpl::get_dev_system_resource()");
+            }
+            for (unsigned int i = 0; i < nb_prop; i = i + 2)
+                transform(attr_min_poll_period[i].begin(),
+                          attr_min_poll_period[i].end(),
+                          attr_min_poll_period[i].begin(),
+                          ::tolower);
+        }
 
 //
 // Since Tango V5 (IDL V3), State and Status are now polled as attributes
 // Change properties if necessary
 //
 
-		if ((get_polled_cmd()).size() != 0)
-			poll_lists_2_v5();
-	}
+        if ((get_polled_cmd()).size() != 0)
+            poll_lists_2_v5();
+    }
 }
 
 //+-------------------------------------------------------------------------
@@ -684,7 +687,7 @@ void DeviceImpl::get_dev_system_resource()
 
 PortableServer::POA_ptr DeviceImpl::_default_POA()
 {
-	return Util::instance()->get_poa();
+    return Util::instance()->get_poa();
 }
 
 //+-------------------------------------------------------------------------
@@ -700,16 +703,16 @@ PortableServer::POA_ptr DeviceImpl::_default_POA()
 //--------------------------------------------------------------------------
 
 #ifndef  _TG_WINDOWS_
-void DeviceImpl::register_signal(long signo,bool hand)
+void DeviceImpl::register_signal(long signo, bool hand)
 {
-	cout4 << "DeviceImpl::register_signal() arrived for signal " << signo << endl;
+    cout4 << "DeviceImpl::register_signal() arrived for signal " << signo << endl;
 
-	DServerSignal::instance()->register_dev_signal(signo,hand,this);
+    DServerSignal::instance()->register_dev_signal(signo, hand, this);
 
-	cout4 << "Leaving DeviceImpl::register_signal method()" << endl;
+    cout4 << "Leaving DeviceImpl::register_signal method()" << endl;
 }
 #else
-void DeviceImpl::register_signal(long signo)
+                                                                                                                        void DeviceImpl::register_signal(long signo)
 {
 	cout4 << "DeviceImpl::register_signal() arrived for signal " << signo << endl;
 
@@ -731,11 +734,11 @@ void DeviceImpl::register_signal(long signo)
 
 void DeviceImpl::unregister_signal(long signo)
 {
-	cout4 << "DeviceImpl::unregister_signal() arrived for signal " << signo << endl;
+    cout4 << "DeviceImpl::unregister_signal() arrived for signal " << signo << endl;
 
-	DServerSignal::instance()->unregister_dev_signal(signo,this);
+    DServerSignal::instance()->unregister_dev_signal(signo, this);
 
-	cout4 << "Leaving DeviceImpl::unregister_signal method()" << endl;
+    cout4 << "Leaving DeviceImpl::unregister_signal method()" << endl;
 }
 
 //+-------------------------------------------------------------------------
@@ -753,9 +756,9 @@ void DeviceImpl::unregister_signal(long signo)
 
 void DeviceImpl::signal_handler(long signo)
 {
-	cout4 << "DeviceImpl::signal_handler() arrived for signal " << signo << endl;
+    cout4 << "DeviceImpl::signal_handler() arrived for signal " << signo << endl;
 
-	cout4 << "Leaving DeviceImpl::signal_handler method()" << endl;
+    cout4 << "Leaving DeviceImpl::signal_handler method()" << endl;
 }
 
 
@@ -774,27 +777,27 @@ void DeviceImpl::signal_handler(long signo)
 
 void DeviceImpl::check_command_exists(const string &cmd_name)
 {
-	vector<Command *> &cmd_list = device_class->get_command_list();
-	unsigned long i;
-	for (i = 0;i < cmd_list.size();i++)
-	{
-		if (cmd_list[i]->get_lower_name() == cmd_name)
-		{
-			if (cmd_list[i]->get_in_type() != Tango::DEV_VOID)
-			{
-				TangoSys_OMemStream o;
-				o << "Command " << cmd_name << " cannot be polled because it needs input value" << ends;
-				Except::throw_exception((const char *)API_IncompatibleCmdArgumentType,
-							o.str(),(const char *)"DeviceImpl::check_command_exists");
-			}
-			return;
-		}
-	}
+    vector<Command *> &cmd_list = device_class->get_command_list();
+    unsigned long i;
+    for (i = 0; i < cmd_list.size(); i++)
+    {
+        if (cmd_list[i]->get_lower_name() == cmd_name)
+        {
+            if (cmd_list[i]->get_in_type() != Tango::DEV_VOID)
+            {
+                TangoSys_OMemStream o;
+                o << "Command " << cmd_name << " cannot be polled because it needs input value" << ends;
+                Except::throw_exception((const char *) API_IncompatibleCmdArgumentType,
+                                        o.str(), (const char *) "DeviceImpl::check_command_exists");
+            }
+            return;
+        }
+    }
 
-	TangoSys_OMemStream o;
-	o << "Command " << cmd_name << " not found" << ends;
-	Except::throw_exception((const char *)API_CommandNotFound,o.str(),
-				(const char *)"DeviceImpl::check_command_exists");
+    TangoSys_OMemStream o;
+    o << "Command " << cmd_name << " not found" << ends;
+    Except::throw_exception((const char *) API_CommandNotFound, o.str(),
+                            (const char *) "DeviceImpl::check_command_exists");
 }
 
 //+-------------------------------------------------------------------------
@@ -811,20 +814,20 @@ void DeviceImpl::check_command_exists(const string &cmd_name)
 
 Command *DeviceImpl::get_command(const string &cmd_name)
 {
-	vector<Command *> cmd_list = device_class->get_command_list();
-	unsigned long i;
-	for (i = 0;i < cmd_list.size();i++)
-	{
-		if (cmd_list[i]->get_lower_name() == cmd_name)
-		{
-			return cmd_list[i];
-		}
-	}
+    vector<Command *> cmd_list = device_class->get_command_list();
+    unsigned long i;
+    for (i = 0; i < cmd_list.size(); i++)
+    {
+        if (cmd_list[i]->get_lower_name() == cmd_name)
+        {
+            return cmd_list[i];
+        }
+    }
 
-	TangoSys_OMemStream o;
-	o << "Command " << cmd_name << " not found" << ends;
-	Except::throw_exception((const char *)API_CommandNotFound,o.str(),
-				(const char *)"DeviceImpl::get_command");
+    TangoSys_OMemStream o;
+    o << "Command " << cmd_name << " not found" << ends;
+    Except::throw_exception((const char *) API_CommandNotFound, o.str(),
+                            (const char *) "DeviceImpl::get_command");
 
 //
 // This piece of code is added for VC++ compiler. As they advice, I have try to
@@ -832,7 +835,7 @@ Command *DeviceImpl::get_command(const string &cmd_name)
 // that it does not work !
 //
 
-	return NULL;
+    return NULL;
 }
 
 //+-------------------------------------------------------------------------
@@ -849,29 +852,29 @@ Command *DeviceImpl::get_command(const string &cmd_name)
 //--------------------------------------------------------------------------
 
 vector<PollObj *>::iterator DeviceImpl::get_polled_obj_by_type_name(
-					Tango::PollObjType obj_type,
-					const string &obj_name)
+    Tango::PollObjType obj_type,
+    const string &obj_name)
 {
-	vector<PollObj *> &po_list = get_poll_obj_list();
-	vector<PollObj *>::iterator ite;
-	for (ite = po_list.begin();ite < po_list.end();++ite)
-	{
-		omni_mutex_lock sync(**ite);
-		{
-			if ((*ite)->get_type_i() == obj_type)
-			{
-				if ((*ite)->get_name_i() == obj_name)
-				{
-					return ite;
-				}
-			}
-		}
-	}
+    vector<PollObj *> &po_list = get_poll_obj_list();
+    vector<PollObj *>::iterator ite;
+    for (ite = po_list.begin(); ite < po_list.end(); ++ite)
+    {
+        omni_mutex_lock sync(**ite);
+        {
+            if ((*ite)->get_type_i() == obj_type)
+            {
+                if ((*ite)->get_name_i() == obj_name)
+                {
+                    return ite;
+                }
+            }
+        }
+    }
 
-	TangoSys_OMemStream o;
-	o << obj_name << " not found in list of polled object" << ends;
-	Except::throw_exception((const char *)API_PollObjNotFound,o.str(),
-				(const char *)"DeviceImpl::get_polled_obj_by_type_name");
+    TangoSys_OMemStream o;
+    o << obj_name << " not found in list of polled object" << ends;
+    Except::throw_exception((const char *) API_PollObjNotFound, o.str(),
+                            (const char *) "DeviceImpl::get_polled_obj_by_type_name");
 
 //
 // Only to make compiler quiet. Should never pass here
@@ -879,7 +882,7 @@ vector<PollObj *>::iterator DeviceImpl::get_polled_obj_by_type_name(
 
 // exclude the return value for VC8+
 #if !defined(_TG_WINDOWS_) || (defined(_MSC_VER) && _MSC_VER < 1400)
-	return (vector<PollObj *>::iterator)NULL;
+    return (vector<PollObj *>::iterator) NULL;
 #endif
 }
 
@@ -904,56 +907,57 @@ vector<PollObj *>::iterator DeviceImpl::get_polled_obj_by_type_name(
 
 long DeviceImpl::get_cmd_poll_ring_depth(string &cmd_name)
 {
-	long ret;
+    long ret;
 
-	if (cmd_poll_ring_depth.size() == 0)
-	{
+    if (cmd_poll_ring_depth.size() == 0)
+    {
 //
 // No specific depth defined
 //
-		if (poll_ring_depth == 0)
-			ret = DefaultPollRingDepth;
-		else
-			ret = poll_ring_depth;
-	}
-	else
-	{
-		unsigned long k;
+        if (poll_ring_depth == 0)
+            ret = DefaultPollRingDepth;
+        else
+            ret = poll_ring_depth;
+    }
+    else
+    {
+        unsigned long k;
 //
 // Try to find command in list of specific polling buffer depth
 //
 
-		for (k = 0; k < cmd_poll_ring_depth.size();k = k + 2)
-		{
-			if (cmd_poll_ring_depth[k] == cmd_name)
-			{
-				TangoSys_MemStream s;
-				s << cmd_poll_ring_depth[k + 1];
-				if (!(s >> ret))
-				{
-					TangoSys_OMemStream o;
-					o << "System property cmd_poll_ring_depth for device " << device_name << " has wrong syntax" << ends;
-					Except::throw_exception((const char *)API_BadConfigurationProperty,
-				        			o.str(),
-				        			(const char *)"DeviceImpl::get_poll_ring_depth()");
-				}
-				break;
-			}
-		}
-		if (k >= cmd_poll_ring_depth.size())
-		{
+        for (k = 0; k < cmd_poll_ring_depth.size(); k = k + 2)
+        {
+            if (cmd_poll_ring_depth[k] == cmd_name)
+            {
+                TangoSys_MemStream s;
+                s << cmd_poll_ring_depth[k + 1];
+                if (!(s >> ret))
+                {
+                    TangoSys_OMemStream o;
+                    o << "System property cmd_poll_ring_depth for device " << device_name << " has wrong syntax"
+                      << ends;
+                    Except::throw_exception((const char *) API_BadConfigurationProperty,
+                                            o.str(),
+                                            (const char *) "DeviceImpl::get_poll_ring_depth()");
+                }
+                break;
+            }
+        }
+        if (k >= cmd_poll_ring_depth.size())
+        {
 //
 // Not found
 //
 
-			if (poll_ring_depth == 0)
-				ret = DefaultPollRingDepth;
-			else
-				ret = poll_ring_depth;
-		}
-	}
+            if (poll_ring_depth == 0)
+                ret = DefaultPollRingDepth;
+            else
+                ret = poll_ring_depth;
+        }
+    }
 
-	return ret;
+    return ret;
 }
 
 //+-----------------------------------------------------------------------------------------------------------------
@@ -977,72 +981,73 @@ long DeviceImpl::get_cmd_poll_ring_depth(string &cmd_name)
 
 long DeviceImpl::get_attr_poll_ring_depth(string &attr_name)
 {
-	long ret;
+    long ret;
 
-	if (attr_poll_ring_depth.size() == 0)
-	{
-		if ((attr_name == "state") || (attr_name == "status"))
-		{
-			ret = get_cmd_poll_ring_depth(attr_name);
-		}
-		else
-		{
+    if (attr_poll_ring_depth.size() == 0)
+    {
+        if ((attr_name == "state") || (attr_name == "status"))
+        {
+            ret = get_cmd_poll_ring_depth(attr_name);
+        }
+        else
+        {
 
 //
 // No specific depth defined
 //
 
-			if (poll_ring_depth == 0)
-				ret = DefaultPollRingDepth;
-			else
-				ret = poll_ring_depth;
-		}
-	}
-	else
-	{
-		unsigned long k;
+            if (poll_ring_depth == 0)
+                ret = DefaultPollRingDepth;
+            else
+                ret = poll_ring_depth;
+        }
+    }
+    else
+    {
+        unsigned long k;
 //
 // Try to find command in list of specific polling buffer depth
 //
 
-		for (k = 0; k < attr_poll_ring_depth.size();k = k + 2)
-		{
-			if (attr_poll_ring_depth[k] == attr_name)
-			{
-				TangoSys_MemStream s;
-				s << attr_poll_ring_depth[k + 1];
-				if (!(s >> ret))
-				{
-					TangoSys_OMemStream o;
-					o << "System property attr_poll_ring_depth for device " << device_name << " has wrong syntax" << ends;
-					Except::throw_exception((const char *)API_BadConfigurationProperty,
-				        			o.str(),
-				        			(const char *)"DeviceImpl::get_poll_ring_depth()");
-				}
-				break;
-			}
-		}
-		if (k >= attr_poll_ring_depth.size())
-		{
-			if ((attr_name == "state") || (attr_name == "status"))
-			{
-				ret = get_cmd_poll_ring_depth(attr_name);
-			}
-			else
-			{
+        for (k = 0; k < attr_poll_ring_depth.size(); k = k + 2)
+        {
+            if (attr_poll_ring_depth[k] == attr_name)
+            {
+                TangoSys_MemStream s;
+                s << attr_poll_ring_depth[k + 1];
+                if (!(s >> ret))
+                {
+                    TangoSys_OMemStream o;
+                    o << "System property attr_poll_ring_depth for device " << device_name << " has wrong syntax"
+                      << ends;
+                    Except::throw_exception((const char *) API_BadConfigurationProperty,
+                                            o.str(),
+                                            (const char *) "DeviceImpl::get_poll_ring_depth()");
+                }
+                break;
+            }
+        }
+        if (k >= attr_poll_ring_depth.size())
+        {
+            if ((attr_name == "state") || (attr_name == "status"))
+            {
+                ret = get_cmd_poll_ring_depth(attr_name);
+            }
+            else
+            {
 //
 // Not found
 //
 
-				if (poll_ring_depth == 0)
-					ret = DefaultPollRingDepth;
-				else
-					ret = poll_ring_depth;
-			}
-		}
-	}
+                if (poll_ring_depth == 0)
+                    ret = DefaultPollRingDepth;
+                else
+                    ret = poll_ring_depth;
+            }
+        }
+    }
 
-	return ret;
+    return ret;
 }
 
 //--------------------------------------------------------------------------------------------------------------------
@@ -1059,7 +1064,7 @@ long DeviceImpl::get_attr_poll_ring_depth(string &attr_name)
 
 Tango::DevState DeviceImpl::dev_state()
 {
-	NoSyncModelTangoMonitor mon(this);
+    NoSyncModelTangoMonitor mon(this);
 
 //
 // If we need to run att. conf loop, do it.
@@ -1145,10 +1150,10 @@ Tango::DevState DeviceImpl::dev_state()
 // Set attr value
 //
 
-                long i,j;
+                long i, j;
                 vector<Tango::Attr *> &attr_vect = device_class->get_class_attr()->get_attr_list();
 
-                for (i = 0;i < nb_wanted_attr;i++)
+                for (i = 0; i < nb_wanted_attr; i++)
                 {
 
 //
@@ -1178,12 +1183,12 @@ Tango::DevState DeviceImpl::dev_state()
                             att.wanted_date(false);
                             att.set_value_flag(false);
 
-                            if (attr_vect[att.get_attr_idx()]->is_allowed(this,Tango::READ_REQ) == false)
+                            if (attr_vect[att.get_attr_idx()]->is_allowed(this, Tango::READ_REQ) == false)
                             {
                                 att.wanted_date(true);
                                 continue;
                             }
-                            attr_vect[att.get_attr_idx()]->read(this,att);
+                            attr_vect[att.get_attr_idx()]->read(this, att);
                             Tango::AttrQuality qua = att.get_quality();
                             if ((qua != Tango::ATTR_INVALID) && (att.get_value_flag() == false))
                             {
@@ -1194,14 +1199,14 @@ Tango::DevState DeviceImpl::dev_state()
                                 o << " has not been updated";
                                 o << "Hint: Did the server follow Tango V5 attribute reading framework ?" << ends;
 
-                                Except::throw_exception((const char *)API_AttrValueNotSet,o.str(),
-                                            (const char *)"DeviceImpl::dev_state");
+                                Except::throw_exception((const char *) API_AttrValueNotSet, o.str(),
+                                                        (const char *) "DeviceImpl::dev_state");
                             }
                         }
                     }
                     catch (Tango::DevFailed &)
                     {
-                        for (j = 0;j < i;j++)
+                        for (j = 0; j < i; j++)
                         {
                             long idx;
                             if ((vers >= 3) && (state_from_read == true))
@@ -1217,7 +1222,7 @@ Tango::DevState DeviceImpl::dev_state()
                             }
                         }
                         att.wanted_date(true);
- //                       throw;
+                        //                       throw;
                     }
                 }
 
@@ -1245,7 +1250,7 @@ Tango::DevState DeviceImpl::dev_state()
 // Free the sequence created to store the attribute value
 //
 
-                for (long i = 0;i < nb_wanted_attr;i++)
+                for (long i = 0; i < nb_wanted_attr; i++)
                 {
                     long idx;
                     if ((vers >= 3) && (state_from_read == true))
@@ -1290,7 +1295,7 @@ Tango::DevState DeviceImpl::dev_state()
         }
     }
 
-	return device_state;
+    return device_state;
 }
 
 //----------------------------------------------------------------------------------------------------------------------
@@ -1306,8 +1311,8 @@ Tango::DevState DeviceImpl::dev_state()
 
 Tango::ConstDevString DeviceImpl::dev_status()
 {
-	NoSyncModelTangoMonitor mon(this);
-	const char *returned_str;
+    NoSyncModelTangoMonitor mon(this);
+    const char *returned_str;
 
     if (run_att_conf_loop == true)
         att_conf_loop();
@@ -1322,12 +1327,12 @@ Tango::ConstDevString DeviceImpl::dev_status()
 
         size_t nb_wrong_att = att_wrong_db_conf.size();
         if (nb_wrong_att != 0)
-		{
-			alarm_status = alarm_status + "\nAttribute";
-			build_att_list_in_status_mess(nb_wrong_att,DeviceImpl::CONF);
-			alarm_status = alarm_status + "wrong configuration";
-			alarm_status = alarm_status + "\nTry accessing the faulty attribute(s) to get more information";
-		}
+        {
+            alarm_status = alarm_status + "\nAttribute";
+            build_att_list_in_status_mess(nb_wrong_att, DeviceImpl::CONF);
+            alarm_status = alarm_status + "wrong configuration";
+            alarm_status = alarm_status + "\nTry accessing the faulty attribute(s) to get more information";
+        }
 
 //
 // Add message for memorized attributes which failed during device startup
@@ -1335,11 +1340,11 @@ Tango::ConstDevString DeviceImpl::dev_status()
 
         nb_wrong_att = att_mem_failed.size();
         if (nb_wrong_att != 0)
-		{
-			alarm_status = alarm_status + "\nMemorized attribute";
-			build_att_list_in_status_mess(nb_wrong_att,DeviceImpl::MEM);
-			alarm_status = alarm_status + "failed during device startup sequence";
-		}
+        {
+            alarm_status = alarm_status + "\nMemorized attribute";
+            build_att_list_in_status_mess(nb_wrong_att, DeviceImpl::MEM);
+            alarm_status = alarm_status + "failed during device startup sequence";
+        }
 
 //
 // Add message for forwarded attributes wrongly configured
@@ -1347,9 +1352,9 @@ Tango::ConstDevString DeviceImpl::dev_status()
 
         nb_wrong_att = fwd_att_wrong_conf.size();
         if (nb_wrong_att != 0)
-		{
-			build_att_list_in_status_mess(nb_wrong_att,DeviceImpl::FWD);
-		}
+        {
+            build_att_list_in_status_mess(nb_wrong_att, DeviceImpl::FWD);
+        }
 
         returned_str = alarm_status.c_str();
     }
@@ -1380,7 +1385,7 @@ Tango::ConstDevString DeviceImpl::dev_status()
         }
     }
 
-	return returned_str;
+    return returned_str;
 }
 
 //+-------------------------------------------------------------------------
@@ -1398,14 +1403,14 @@ Tango::ConstDevString DeviceImpl::dev_status()
 //--------------------------------------------------------------------------
 
 CORBA::Any *DeviceImpl::command_inout(const char *in_cmd,
-				     const CORBA::Any &in_any)
+                                      const CORBA::Any &in_any)
 {
-	AutoTangoMonitor sync(this);
+    AutoTangoMonitor sync(this);
 
-	string command(in_cmd);
-	CORBA::Any *out_any;
+    string command(in_cmd);
+    CORBA::Any *out_any;
 
-	cout4 << "DeviceImpl::command_inout(): command received : " << command << endl;
+    cout4 << "DeviceImpl::command_inout(): command received : " << command << endl;
 
 //
 //  Write the device name into the per thread data for
@@ -1414,48 +1419,48 @@ CORBA::Any *DeviceImpl::command_inout(const char *in_cmd,
 //  During device access inside the same server,
 //  the thread stays the same!
 //
-	SubDevDiag &sub = (Tango::Util::instance())->get_sub_dev_diag();
-	string last_associated_device = sub.get_associated_device();
-	sub.set_associated_device(get_name());
+    SubDevDiag &sub = (Tango::Util::instance())->get_sub_dev_diag();
+    string last_associated_device = sub.get_associated_device();
+    sub.set_associated_device(get_name());
 
 //
 // Catch all exceptions to set back the associated device after execution
 //
 
-	try
-	{
+    try
+    {
 
 //
 // Record operation request in black box
 //
 
-		if (store_in_bb == true)
-			blackbox_ptr->insert_cmd(in_cmd);
-		store_in_bb = true;
+        if (store_in_bb == true)
+            blackbox_ptr->insert_cmd(in_cmd);
+        store_in_bb = true;
 
 //
 // Execute command
 //
 
-		out_any = device_class->command_handler(this,command,in_any);
-	}
-	catch (...)
-	{
-		// set back the device attribution for the thread
-		// and rethrow the exception.
-		sub.set_associated_device(last_associated_device);
-		throw;
-	}
+        out_any = device_class->command_handler(this, command, in_any);
+    }
+    catch (...)
+    {
+        // set back the device attribution for the thread
+        // and rethrow the exception.
+        sub.set_associated_device(last_associated_device);
+        throw;
+    }
 
-	// set back the device attribution for the thread
-	sub.set_associated_device(last_associated_device);
+    // set back the device attribution for the thread
+    sub.set_associated_device(last_associated_device);
 
 //
 // Return value to the caller
 //
 
-	cout4 << "DeviceImpl::command_inout(): leaving method for command " << in_cmd << endl;
-	return(out_any);
+    cout4 << "DeviceImpl::command_inout(): leaving method for command " << in_cmd << endl;
+    return (out_any);
 }
 
 //+-------------------------------------------------------------------------
@@ -1472,40 +1477,40 @@ CORBA::Any *DeviceImpl::command_inout(const char *in_cmd,
 
 char *DeviceImpl::name()
 {
-	try
-	{
-		cout4 << "DeviceImpl::name arrived" << endl;
+    try
+    {
+        cout4 << "DeviceImpl::name arrived" << endl;
 
 //
 // Record attribute request in black box
 //
 
-		blackbox_ptr->insert_corba_attr(Attr_Name);
-	}
-	catch (Tango::DevFailed &e)
-	{
-		CORBA::IMP_LIMIT lim;
-		if (strcmp(e.errors[0].reason,API_CommandTimedOut) == 0)
-			lim.minor(TG_IMP_MINOR_TO);
-		else
-			lim.minor(TG_IMP_MINOR_DEVFAILED);
-		cout4 << "Leaving DeviceImpl::name throwing IMP_LIMIT" << endl;
-		throw lim;
-	}
-	catch (...)
-	{
-		CORBA::IMP_LIMIT lim;
-		lim.minor(TG_IMP_MINOR_NON_DEVFAILED);
-		cout4 << "Leaving DeviceImpl::name throwing IMP_LIMIT" << endl;
-		throw lim;
-	}
+        blackbox_ptr->insert_corba_attr(Attr_Name);
+    }
+    catch (Tango::DevFailed &e)
+    {
+        CORBA::IMP_LIMIT lim;
+        if (strcmp(e.errors[0].reason, API_CommandTimedOut) == 0)
+            lim.minor(TG_IMP_MINOR_TO);
+        else
+            lim.minor(TG_IMP_MINOR_DEVFAILED);
+        cout4 << "Leaving DeviceImpl::name throwing IMP_LIMIT" << endl;
+        throw lim;
+    }
+    catch (...)
+    {
+        CORBA::IMP_LIMIT lim;
+        lim.minor(TG_IMP_MINOR_NON_DEVFAILED);
+        cout4 << "Leaving DeviceImpl::name throwing IMP_LIMIT" << endl;
+        throw lim;
+    }
 
 //
 // Return data to caller
 //
 
-	cout4 << "Leaving DeviceImpl::name" << endl;
-	return CORBA::string_dup(device_name.c_str());
+    cout4 << "Leaving DeviceImpl::name" << endl;
+    return CORBA::string_dup(device_name.c_str());
 }
 
 //+-------------------------------------------------------------------------
@@ -1522,40 +1527,40 @@ char *DeviceImpl::name()
 
 char *DeviceImpl::adm_name()
 {
-	try
-	{
-		cout4 << "DeviceImpl::adm_name arrived" << endl;
+    try
+    {
+        cout4 << "DeviceImpl::adm_name arrived" << endl;
 
 //
 // Record attribute request in black box
 //
 
-		blackbox_ptr->insert_corba_attr(Attr_AdmName);
-	}
-	catch (Tango::DevFailed &e)
-	{
-		CORBA::IMP_LIMIT lim;
-		if (strcmp(e.errors[0].reason,API_CommandTimedOut) == 0)
-			lim.minor(TG_IMP_MINOR_TO);
-		else
-			lim.minor(TG_IMP_MINOR_DEVFAILED);
-		cout4 << "Leaving DeviceImpl::adm_name throwing IMP_LIMIT" << endl;
-		throw lim;
-	}
-	catch (...)
-	{
-		CORBA::IMP_LIMIT lim;
-		lim.minor(TG_IMP_MINOR_NON_DEVFAILED);
-		cout4 << "Leaving DeviceImpl::adm_name throwing IMP_LIMIT" << endl;
-		throw lim;
-	}
+        blackbox_ptr->insert_corba_attr(Attr_AdmName);
+    }
+    catch (Tango::DevFailed &e)
+    {
+        CORBA::IMP_LIMIT lim;
+        if (strcmp(e.errors[0].reason, API_CommandTimedOut) == 0)
+            lim.minor(TG_IMP_MINOR_TO);
+        else
+            lim.minor(TG_IMP_MINOR_DEVFAILED);
+        cout4 << "Leaving DeviceImpl::adm_name throwing IMP_LIMIT" << endl;
+        throw lim;
+    }
+    catch (...)
+    {
+        CORBA::IMP_LIMIT lim;
+        lim.minor(TG_IMP_MINOR_NON_DEVFAILED);
+        cout4 << "Leaving DeviceImpl::adm_name throwing IMP_LIMIT" << endl;
+        throw lim;
+    }
 
 //
 // Return data to caller
 //
 
-	cout4 << "Leaving DeviceImpl::adm_name" << endl;
-	return CORBA::string_dup(adm_device_name.c_str());
+    cout4 << "Leaving DeviceImpl::adm_name" << endl;
+    return CORBA::string_dup(adm_device_name.c_str());
 }
 
 
@@ -1574,40 +1579,40 @@ char *DeviceImpl::adm_name()
 
 char *DeviceImpl::description()
 {
-	try
-	{
-		cout4 << "DeviceImpl::description arrived" << endl;
+    try
+    {
+        cout4 << "DeviceImpl::description arrived" << endl;
 
 //
 // Record attribute request in black box
 //
 
-		blackbox_ptr->insert_corba_attr(Attr_Description);
-	}
-	catch (Tango::DevFailed &e)
-	{
-		CORBA::IMP_LIMIT lim;
-		if (strcmp(e.errors[0].reason,API_CommandTimedOut) == 0)
-			lim.minor(TG_IMP_MINOR_TO);
-		else
-			lim.minor(TG_IMP_MINOR_DEVFAILED);
-		cout4 << "Leaving DeviceImpl::description throwing IMP_LIMIT" << endl;
-		throw lim;
-	}
-	catch (...)
-	{
-		CORBA::IMP_LIMIT lim;
-		lim.minor(TG_IMP_MINOR_NON_DEVFAILED);
-		cout4 << "Leaving DeviceImpl::description throwing IMP_LIMIT" << endl;
-		throw lim;
-	}
+        blackbox_ptr->insert_corba_attr(Attr_Description);
+    }
+    catch (Tango::DevFailed &e)
+    {
+        CORBA::IMP_LIMIT lim;
+        if (strcmp(e.errors[0].reason, API_CommandTimedOut) == 0)
+            lim.minor(TG_IMP_MINOR_TO);
+        else
+            lim.minor(TG_IMP_MINOR_DEVFAILED);
+        cout4 << "Leaving DeviceImpl::description throwing IMP_LIMIT" << endl;
+        throw lim;
+    }
+    catch (...)
+    {
+        CORBA::IMP_LIMIT lim;
+        lim.minor(TG_IMP_MINOR_NON_DEVFAILED);
+        cout4 << "Leaving DeviceImpl::description throwing IMP_LIMIT" << endl;
+        throw lim;
+    }
 
 //
 // Return data to caller
 //
 
-	cout4 << "Leaving DeviceImpl::description" << endl;
-	return CORBA::string_dup(desc.c_str());
+    cout4 << "Leaving DeviceImpl::description" << endl;
+    return CORBA::string_dup(desc.c_str());
 }
 
 //+-------------------------------------------------------------------------
@@ -1621,13 +1626,13 @@ char *DeviceImpl::description()
 
 Tango::DevState DeviceImpl::state()
 {
-	Tango::DevState tmp;
-	string last_associated_device;
+    Tango::DevState tmp;
+    string last_associated_device;
 
-	try
-	{
-		AutoTangoMonitor sync(this);
-		cout4 << "DeviceImpl::state (attribute) arrived" << endl;
+    try
+    {
+        AutoTangoMonitor sync(this);
+        cout4 << "DeviceImpl::state (attribute) arrived" << endl;
 
 //
 //  Write the device name into the per thread data for
@@ -1637,62 +1642,62 @@ Tango::DevState DeviceImpl::state()
 //  the thread stays the same!
 //
 
-		SubDevDiag &sub = (Tango::Util::instance())->get_sub_dev_diag();
-		last_associated_device = sub.get_associated_device();
-		sub.set_associated_device(get_name());
+        SubDevDiag &sub = (Tango::Util::instance())->get_sub_dev_diag();
+        last_associated_device = sub.get_associated_device();
+        sub.set_associated_device(get_name());
 
 //
 // Record attribute request in black box
 //
 
-		blackbox_ptr->insert_corba_attr(Attr_State);
+        blackbox_ptr->insert_corba_attr(Attr_State);
 
-		always_executed_hook();
+        always_executed_hook();
 
 //
 // Return data to caller. If the state_cmd throw an exception, catch it and do
 // not re-throw it because we are in a CORBA attribute implementation
 
         tmp = dev_state();
-	}
-	catch (Tango::DevFailed &e)
-	{
-		if (last_associated_device.size() > 0)
-		{
-			// set back the device attribution for the thread
-			(Tango::Util::instance())->get_sub_dev_diag().set_associated_device(last_associated_device);
-		}
+    }
+    catch (Tango::DevFailed &e)
+    {
+        if (last_associated_device.size() > 0)
+        {
+            // set back the device attribution for the thread
+            (Tango::Util::instance())->get_sub_dev_diag().set_associated_device(last_associated_device);
+        }
 
-		CORBA::IMP_LIMIT lim;
-		if (strcmp(e.errors[0].reason,API_CommandTimedOut) == 0)
-			lim.minor(TG_IMP_MINOR_TO);
-		else
-			lim.minor(TG_IMP_MINOR_DEVFAILED);
-		cout4 << "Leaving DeviceImpl::state (attribute) throwing IMP_LIMIT" << endl;
-		throw lim;
-	}
-	catch (...)
-	{
-		if (last_associated_device.size() > 0)
-		{
-			// set back the device attribution for the thread
-			(Tango::Util::instance())->get_sub_dev_diag().set_associated_device(last_associated_device);
-		}
+        CORBA::IMP_LIMIT lim;
+        if (strcmp(e.errors[0].reason, API_CommandTimedOut) == 0)
+            lim.minor(TG_IMP_MINOR_TO);
+        else
+            lim.minor(TG_IMP_MINOR_DEVFAILED);
+        cout4 << "Leaving DeviceImpl::state (attribute) throwing IMP_LIMIT" << endl;
+        throw lim;
+    }
+    catch (...)
+    {
+        if (last_associated_device.size() > 0)
+        {
+            // set back the device attribution for the thread
+            (Tango::Util::instance())->get_sub_dev_diag().set_associated_device(last_associated_device);
+        }
 
-		CORBA::IMP_LIMIT lim;
-		lim.minor(TG_IMP_MINOR_NON_DEVFAILED);
-		cout4 << "Leaving DeviceImpl::state (attribute) throwing IMP_LIMIT" << endl;
-		throw lim;
-	}
+        CORBA::IMP_LIMIT lim;
+        lim.minor(TG_IMP_MINOR_NON_DEVFAILED);
+        cout4 << "Leaving DeviceImpl::state (attribute) throwing IMP_LIMIT" << endl;
+        throw lim;
+    }
 
-	if (last_associated_device.size() > 0)
-	{
-		// set back the device attribution for the thread
-		(Tango::Util::instance())->get_sub_dev_diag().set_associated_device(last_associated_device);
-	}
+    if (last_associated_device.size() > 0)
+    {
+        // set back the device attribution for the thread
+        (Tango::Util::instance())->get_sub_dev_diag().set_associated_device(last_associated_device);
+    }
 
-	cout4 << "Leaving DeviceImpl::state (attribute)" << endl;
-	return tmp;
+    cout4 << "Leaving DeviceImpl::state (attribute)" << endl;
+    return tmp;
 }
 
 //+-------------------------------------------------------------------------
@@ -1710,13 +1715,13 @@ Tango::DevState DeviceImpl::state()
 
 char *DeviceImpl::status()
 {
-	char *tmp;
-	string last_associated_device;
+    char *tmp;
+    string last_associated_device;
 
-	try
-	{
-		AutoTangoMonitor sync(this);
-		cout4 << "DeviceImpl::status (attibute) arrived" << endl;
+    try
+    {
+        AutoTangoMonitor sync(this);
+        cout4 << "DeviceImpl::status (attibute) arrived" << endl;
 
 //
 //  Write the device name into the per thread data for
@@ -1726,58 +1731,58 @@ char *DeviceImpl::status()
 //  the thread stays the same!
 //
 
-		SubDevDiag &sub = (Tango::Util::instance())->get_sub_dev_diag();
-		last_associated_device = sub.get_associated_device();
-		sub.set_associated_device(get_name());
+        SubDevDiag &sub = (Tango::Util::instance())->get_sub_dev_diag();
+        last_associated_device = sub.get_associated_device();
+        sub.set_associated_device(get_name());
 
 //
 // Record attribute request in black box
 //
 
-		blackbox_ptr->insert_corba_attr(Attr_Status);
+        blackbox_ptr->insert_corba_attr(Attr_Status);
 
 //
 // Return data to caller. If the status_cmd method throw exception, catch it
 // and forget it because we are in a CORBA attribute implementation
 //
 
-		always_executed_hook();
-		tmp = CORBA::string_dup(dev_status());
-	}
-	catch (Tango::DevFailed &e)
-	{
-		if (last_associated_device.size() > 0)
-		{
-			// set back the device attribution for the thread
-			(Tango::Util::instance())->get_sub_dev_diag().set_associated_device(last_associated_device);
-		}
+        always_executed_hook();
+        tmp = CORBA::string_dup(dev_status());
+    }
+    catch (Tango::DevFailed &e)
+    {
+        if (last_associated_device.size() > 0)
+        {
+            // set back the device attribution for the thread
+            (Tango::Util::instance())->get_sub_dev_diag().set_associated_device(last_associated_device);
+        }
 
-		if (strcmp(e.errors[0].reason,API_CommandTimedOut) == 0)
-			tmp = CORBA::string_dup("Not able to acquire device monitor");
-		else
-			tmp = CORBA::string_dup("Got exception	when trying to build device status");
-	}
-	catch (...)
-	{
-		if (last_associated_device.size() > 0)
-		{
-			// set back the device attribution for the thread
-			(Tango::Util::instance())->get_sub_dev_diag().set_associated_device(last_associated_device);
-		}
+        if (strcmp(e.errors[0].reason, API_CommandTimedOut) == 0)
+            tmp = CORBA::string_dup("Not able to acquire device monitor");
+        else
+            tmp = CORBA::string_dup("Got exception	when trying to build device status");
+    }
+    catch (...)
+    {
+        if (last_associated_device.size() > 0)
+        {
+            // set back the device attribution for the thread
+            (Tango::Util::instance())->get_sub_dev_diag().set_associated_device(last_associated_device);
+        }
 
-		CORBA::IMP_LIMIT lim;
-		lim.minor(TG_IMP_MINOR_NON_DEVFAILED);
-		throw lim;
-	}
+        CORBA::IMP_LIMIT lim;
+        lim.minor(TG_IMP_MINOR_NON_DEVFAILED);
+        throw lim;
+    }
 
-	if (last_associated_device.size() > 0)
-	{
-		// set back the device attribution for the thread
-		(Tango::Util::instance())->get_sub_dev_diag().set_associated_device(last_associated_device);
-	}
+    if (last_associated_device.size() > 0)
+    {
+        // set back the device attribution for the thread
+        (Tango::Util::instance())->get_sub_dev_diag().set_associated_device(last_associated_device);
+    }
 
-	cout4 << "Leaving DeviceImpl::status (attribute)" << endl;
-	return tmp;
+    cout4 << "Leaving DeviceImpl::status (attribute)" << endl;
+    return tmp;
 }
 
 //+-------------------------------------------------------------------------
@@ -1792,20 +1797,20 @@ char *DeviceImpl::status()
 //--------------------------------------------------------------------------
 
 
-Tango::DevVarStringArray* DeviceImpl::black_box(CORBA::Long n)
+Tango::DevVarStringArray *DeviceImpl::black_box(CORBA::Long n)
 {
-	cout4 << "DeviceImpl::black_box arrived" << endl;
+    cout4 << "DeviceImpl::black_box arrived" << endl;
 
-	Tango::DevVarStringArray *ret = blackbox_ptr->read((long)n);
+    Tango::DevVarStringArray *ret = blackbox_ptr->read((long) n);
 
 //
 // Record operation request in black box
 //
 
-	blackbox_ptr->insert_op(Op_BlackBox);
+    blackbox_ptr->insert_op(Op_BlackBox);
 
-	cout4 << "Leaving DeviceImpl::black_box" << endl;
-	return ret;
+    cout4 << "Leaving DeviceImpl::black_box" << endl;
+    return ret;
 }
 
 
@@ -1820,67 +1825,67 @@ Tango::DevVarStringArray* DeviceImpl::black_box(CORBA::Long n)
 //--------------------------------------------------------------------------
 
 
-Tango::DevCmdInfoList* DeviceImpl::command_list_query()
+Tango::DevCmdInfoList *DeviceImpl::command_list_query()
 {
-	cout4 << "DeviceImpl::command_list_query arrived" << endl;
+    cout4 << "DeviceImpl::command_list_query arrived" << endl;
 
 //
 // Retrieve number of command and allocate memory to send back info
 //
 
-	long nb_cmd = device_class->get_command_list().size();
-	cout4 << nb_cmd << " command(s) for device" << endl;
-	Tango::DevCmdInfoList *back = NULL;
+    long nb_cmd = device_class->get_command_list().size();
+    cout4 << nb_cmd << " command(s) for device" << endl;
+    Tango::DevCmdInfoList *back = NULL;
 
-	try
-	{
-		back = new Tango::DevCmdInfoList(nb_cmd);
-		back->length(nb_cmd);
+    try
+    {
+        back = new Tango::DevCmdInfoList(nb_cmd);
+        back->length(nb_cmd);
 
 //
 // Populate the vector
 //
 
-		for (long i = 0;i < nb_cmd;i++)
-		{
-			Tango::DevCmdInfo tmp;
-			tmp.cmd_name = CORBA::string_dup(((device_class->get_command_list())[i]->get_name()).c_str());
-			tmp.cmd_tag = (long)((device_class->get_command_list())[i]->get_disp_level());
-			tmp.in_type = (long)((device_class->get_command_list())[i]->get_in_type());
-			tmp.out_type = (long)((device_class->get_command_list())[i]->get_out_type());
-			string &str_in = (device_class->get_command_list())[i]->get_in_type_desc();
-			if (str_in.size() != 0)
-				tmp.in_type_desc = CORBA::string_dup(str_in.c_str());
-			else
-				tmp.in_type_desc = CORBA::string_dup(NotSet);
-			string &str_out = (device_class->get_command_list())[i]->get_out_type_desc();
-			if (str_out.size() != 0)
-				tmp.out_type_desc = CORBA::string_dup(str_out.c_str());
-			else
-				tmp.out_type_desc = CORBA::string_dup(NotSet);
+        for (long i = 0; i < nb_cmd; i++)
+        {
+            Tango::DevCmdInfo tmp;
+            tmp.cmd_name = CORBA::string_dup(((device_class->get_command_list())[i]->get_name()).c_str());
+            tmp.cmd_tag = (long) ((device_class->get_command_list())[i]->get_disp_level());
+            tmp.in_type = (long) ((device_class->get_command_list())[i]->get_in_type());
+            tmp.out_type = (long) ((device_class->get_command_list())[i]->get_out_type());
+            string &str_in = (device_class->get_command_list())[i]->get_in_type_desc();
+            if (str_in.size() != 0)
+                tmp.in_type_desc = CORBA::string_dup(str_in.c_str());
+            else
+                tmp.in_type_desc = CORBA::string_dup(NotSet);
+            string &str_out = (device_class->get_command_list())[i]->get_out_type_desc();
+            if (str_out.size() != 0)
+                tmp.out_type_desc = CORBA::string_dup(str_out.c_str());
+            else
+                tmp.out_type_desc = CORBA::string_dup(NotSet);
 
-			(*back)[i] = tmp;
-		}
-	}
-	catch (bad_alloc &)
-	{
-	Except::throw_exception((const char *)API_MemoryAllocation,
-				      (const char *)"Can't allocate memory in server",
-				      (const char *)"DeviceImpl::command_list_query");
-	}
+            (*back)[i] = tmp;
+        }
+    }
+    catch (bad_alloc &)
+    {
+        Except::throw_exception((const char *) API_MemoryAllocation,
+                                (const char *) "Can't allocate memory in server",
+                                (const char *) "DeviceImpl::command_list_query");
+    }
 
 //
 // Record operation request in black box
 //
 
-	blackbox_ptr->insert_op(Op_Command_list);
+    blackbox_ptr->insert_op(Op_Command_list);
 
 //
 // Return to caller
 //
 
-	cout4 << "Leaving DeviceImpl::command_list_query" << endl;
-	return back;
+    cout4 << "Leaving DeviceImpl::command_list_query" << endl;
+    return back;
 }
 
 
@@ -1897,84 +1902,84 @@ Tango::DevCmdInfoList* DeviceImpl::command_list_query()
 
 Tango::DevCmdInfo *DeviceImpl::command_query(const char *command)
 {
-	cout4 << "DeviceImpl::command_query arrived" << endl;
+    cout4 << "DeviceImpl::command_query arrived" << endl;
 
-	Tango::DevCmdInfo *back = NULL;
-	string cmd(command);
-	transform(cmd.begin(),cmd.end(),cmd.begin(),::tolower);
+    Tango::DevCmdInfo *back = NULL;
+    string cmd(command);
+    transform(cmd.begin(), cmd.end(), cmd.begin(), ::tolower);
 
 //
 // Allocate memory for the stucture sent back to caller. The ORB will free it
 //
 
-	try
-	{
-		back = new Tango::DevCmdInfo();
-	}
-	catch (bad_alloc &)
-	{
-		Except::throw_exception((const char *)API_MemoryAllocation,
-					(const char *)"Can't allocate memory in server",
-					(const char *)"DeviceImpl::command_query");
-	}
+    try
+    {
+        back = new Tango::DevCmdInfo();
+    }
+    catch (bad_alloc &)
+    {
+        Except::throw_exception((const char *) API_MemoryAllocation,
+                                (const char *) "Can't allocate memory in server",
+                                (const char *) "DeviceImpl::command_query");
+    }
 
 //
 // Try to retrieve the command in the command list
 //
 
-	long i;
-	long nb_cmd = device_class->get_command_list().size();
-	for (i = 0;i < nb_cmd;i++)
-	{
-		if (device_class->get_command_list()[i]->get_lower_name() == cmd)
-		{
-			back->cmd_name = CORBA::string_dup(((device_class->get_command_list())[i]->get_name()).c_str());
-			back->cmd_tag = (long)((device_class->get_command_list())[i]->get_disp_level());
-			back->in_type = (long)((device_class->get_command_list())[i]->get_in_type());
-			back->out_type = (long)((device_class->get_command_list())[i]->get_out_type());
-			string &str_in = (device_class->get_command_list())[i]->get_in_type_desc();
-			if (str_in.size() != 0)
-				back->in_type_desc = CORBA::string_dup(str_in.c_str());
-			else
-				back->in_type_desc = CORBA::string_dup(NotSet);
-			string &str_out = (device_class->get_command_list())[i]->get_out_type_desc();
-			if (str_out.size() != 0)
-				back->out_type_desc = CORBA::string_dup(str_out.c_str());
-			else
-				back->out_type_desc = CORBA::string_dup(NotSet);
-			break;
-		}
-	}
+    long i;
+    long nb_cmd = device_class->get_command_list().size();
+    for (i = 0; i < nb_cmd; i++)
+    {
+        if (device_class->get_command_list()[i]->get_lower_name() == cmd)
+        {
+            back->cmd_name = CORBA::string_dup(((device_class->get_command_list())[i]->get_name()).c_str());
+            back->cmd_tag = (long) ((device_class->get_command_list())[i]->get_disp_level());
+            back->in_type = (long) ((device_class->get_command_list())[i]->get_in_type());
+            back->out_type = (long) ((device_class->get_command_list())[i]->get_out_type());
+            string &str_in = (device_class->get_command_list())[i]->get_in_type_desc();
+            if (str_in.size() != 0)
+                back->in_type_desc = CORBA::string_dup(str_in.c_str());
+            else
+                back->in_type_desc = CORBA::string_dup(NotSet);
+            string &str_out = (device_class->get_command_list())[i]->get_out_type_desc();
+            if (str_out.size() != 0)
+                back->out_type_desc = CORBA::string_dup(str_out.c_str());
+            else
+                back->out_type_desc = CORBA::string_dup(NotSet);
+            break;
+        }
+    }
 
-	if (i == nb_cmd)
-	{
-		delete back;
-		cout3 << "DeviceImpl::command_query(): command " << command << " not found" << endl;
+    if (i == nb_cmd)
+    {
+        delete back;
+        cout3 << "DeviceImpl::command_query(): command " << command << " not found" << endl;
 
 //
 // throw an exception to client
 //
 
-		TangoSys_OMemStream o;
+        TangoSys_OMemStream o;
 
-		o << "Command " << command << " not found" << ends;
-		Except::throw_exception((const char *)API_CommandNotFound,
-				      o.str(),
-				      (const char *)"DeviceImpl::command_query");
-	}
+        o << "Command " << command << " not found" << ends;
+        Except::throw_exception((const char *) API_CommandNotFound,
+                                o.str(),
+                                (const char *) "DeviceImpl::command_query");
+    }
 
 //
 // Record operation request in black box
 //
 
-	blackbox_ptr->insert_op(Op_Command);
+    blackbox_ptr->insert_op(Op_Command);
 
 //
 // Return to caller
 //
 
-	cout4 << "Leaving DeviceImpl::command_query" << endl;
-	return back;
+    cout4 << "Leaving DeviceImpl::command_query" << endl;
+    return back;
 }
 
 
@@ -1989,101 +1994,101 @@ Tango::DevCmdInfo *DeviceImpl::command_query(const char *command)
 
 Tango::DevInfo *DeviceImpl::info()
 {
-	cout4 << "DeviceImpl::info arrived" << endl;
+    cout4 << "DeviceImpl::info arrived" << endl;
 
-	Tango::DevInfo *back = NULL;
+    Tango::DevInfo *back = NULL;
 
 //
 // Allocate memory for the stucture sent back to caller. The ORB will free it
 //
 
-	try
-	{
-		back = new Tango::DevInfo();
-	}
-	catch (bad_alloc &)
-	{
-		Except::throw_exception((const char *)API_MemoryAllocation,
-				      (const char *)"Can't allocate memory in server",
-				      (const char *)"DeviceImpl::info");
-	}
+    try
+    {
+        back = new Tango::DevInfo();
+    }
+    catch (bad_alloc &)
+    {
+        Except::throw_exception((const char *) API_MemoryAllocation,
+                                (const char *) "Can't allocate memory in server",
+                                (const char *) "DeviceImpl::info");
+    }
 
 //
 // Retrieve server host
 //
 
-	Tango::Util *tango_ptr = Tango::Util::instance();
-	back->server_host = CORBA::string_dup(tango_ptr->get_host_name().c_str());
+    Tango::Util *tango_ptr = Tango::Util::instance();
+    back->server_host = CORBA::string_dup(tango_ptr->get_host_name().c_str());
 
 //
 // Fill-in remaining structure fields
 //
 
-	back->dev_class = CORBA::string_dup(device_class->get_name().c_str());
-	back->server_id = CORBA::string_dup(tango_ptr->get_ds_name().c_str());
-	back->server_version = DevVersion;
+    back->dev_class = CORBA::string_dup(device_class->get_name().c_str());
+    back->server_id = CORBA::string_dup(tango_ptr->get_ds_name().c_str());
+    back->server_version = DevVersion;
 
 //
 // Build the complete info sent in the doc_url string
 //
 
-	string doc_url("Doc URL = ");
-	doc_url = doc_url + device_class->get_doc_url();
+    string doc_url("Doc URL = ");
+    doc_url = doc_url + device_class->get_doc_url();
 
 //
 // Add TAG if it exist
 //
 
-	string &svn_tag = device_class->get_svn_tag();
-	if (svn_tag.size() != 0)
-	{
-	    doc_url = doc_url + "\nSVN Tag = ";
-	    doc_url = doc_url + svn_tag;
-	}
-	else
-	{
+    string &svn_tag = device_class->get_svn_tag();
+    if (svn_tag.size() != 0)
+    {
+        doc_url = doc_url + "\nSVN Tag = ";
+        doc_url = doc_url + svn_tag;
+    }
+    else
+    {
         string &cvs_tag = device_class->get_cvs_tag();
         if (cvs_tag.size() != 0)
         {
             doc_url = doc_url + "\nCVS Tag = ";
             doc_url = doc_url + cvs_tag;
         }
-	}
+    }
 
 //
 // Add SCM location if defined
 //
 
-	string &svn_location = device_class->get_svn_location();
-	if (svn_location.size() != 0)
-	{
-	    doc_url = doc_url + "\nSVN Location = ";
-	    doc_url = doc_url + svn_location;
-	}
-	else
-	{
+    string &svn_location = device_class->get_svn_location();
+    if (svn_location.size() != 0)
+    {
+        doc_url = doc_url + "\nSVN Location = ";
+        doc_url = doc_url + svn_location;
+    }
+    else
+    {
         string &cvs_location = device_class->get_cvs_location();
         if (cvs_location.size() != 0)
         {
             doc_url = doc_url + "\nCVS Location = ";
             doc_url = doc_url + cvs_location;
         }
-	}
+    }
 
-	back->doc_url = CORBA::string_dup(doc_url.c_str());
+    back->doc_url = CORBA::string_dup(doc_url.c_str());
 
 //
 // Record operation request in black box
 //
 
-	blackbox_ptr->insert_op(Op_Info);
+    blackbox_ptr->insert_op(Op_Info);
 
 //
 // Return to caller
 //
 
-	cout4 << "Leaving DeviceImpl::info" << endl;
-	return back;
+    cout4 << "Leaving DeviceImpl::info" << endl;
+    return back;
 }
 
 //+-------------------------------------------------------------------------
@@ -2097,19 +2102,19 @@ Tango::DevInfo *DeviceImpl::info()
 
 void DeviceImpl::ping()
 {
-	cout4 << "DeviceImpl::ping arrived" << endl;
+    cout4 << "DeviceImpl::ping arrived" << endl;
 
 //
 // Record operation request in black box
 //
 
-	blackbox_ptr->insert_op(Op_Ping);
+    blackbox_ptr->insert_op(Op_Ping);
 
 //
 // Return to caller
 //
 
-	cout4 << "Leaving DeviceImpl::ping" << endl;
+    cout4 << "Leaving DeviceImpl::ping" << endl;
 }
 
 //+-------------------------------------------------------------------------
@@ -2125,29 +2130,29 @@ void DeviceImpl::ping()
 //
 //--------------------------------------------------------------------------
 
-Tango::AttributeConfigList *DeviceImpl::get_attribute_config(const Tango::DevVarStringArray& names)
+Tango::AttributeConfigList *DeviceImpl::get_attribute_config(const Tango::DevVarStringArray &names)
 {
-	cout4 << "DeviceImpl::get_attribute_config arrived" << endl;
+    cout4 << "DeviceImpl::get_attribute_config arrived" << endl;
 
-	TangoMonitor &mon = get_att_conf_monitor();
-	AutoTangoMonitor sync(&mon);
+    TangoMonitor &mon = get_att_conf_monitor();
+    AutoTangoMonitor sync(&mon);
 
-	long nb_attr = names.length();
-	Tango::AttributeConfigList *back = NULL;
-	bool all_attr = false;
+    long nb_attr = names.length();
+    Tango::AttributeConfigList *back = NULL;
+    bool all_attr = false;
 
 //
 // Record operation request in black box
 //
 
-	blackbox_ptr->insert_op(Op_Get_Attr_Config);
+    blackbox_ptr->insert_op(Op_Get_Attr_Config);
 
 //
 // Get attribute number and device version
 //
 
-	long nb_dev_attr = dev_attr->get_attr_nb();
-	long vers = get_dev_idl_version();
+    long nb_dev_attr = dev_attr->get_attr_nb();
+    long vers = get_dev_idl_version();
 
 //
 // Check if the caller want to get config for all attribute
@@ -2156,73 +2161,73 @@ Tango::AttributeConfigList *DeviceImpl::get_attribute_config(const Tango::DevVar
 // attribute), decrement attribute number
 //
 
-	string in_name(names[0]);
-	if (nb_attr == 1)
-	{
-		if (in_name == AllAttr)
-		{
-			all_attr = true;
-			if (vers < 3)
-				nb_attr = nb_dev_attr;
-			else
-				nb_attr = nb_dev_attr - 2;
-		}
-		else if (in_name == AllAttr_3)
-		{
-			all_attr = true;
-			nb_attr = nb_dev_attr;
-		}
-	}
+    string in_name(names[0]);
+    if (nb_attr == 1)
+    {
+        if (in_name == AllAttr)
+        {
+            all_attr = true;
+            if (vers < 3)
+                nb_attr = nb_dev_attr;
+            else
+                nb_attr = nb_dev_attr - 2;
+        }
+        else if (in_name == AllAttr_3)
+        {
+            all_attr = true;
+            nb_attr = nb_dev_attr;
+        }
+    }
 
 //
 // Allocate memory for the AttributeConfig structures
 //
 
-	try
-	{
-		back = new Tango::AttributeConfigList(nb_attr);
-		back->length(nb_attr);
-	}
-	catch (bad_alloc &)
-	{
-		Except::throw_exception((const char *)API_MemoryAllocation,
-				        (const char *)"Can't allocate memory in server",
-				        (const char *)"DeviceImpl::get_attribute_config");
-	}
+    try
+    {
+        back = new Tango::AttributeConfigList(nb_attr);
+        back->length(nb_attr);
+    }
+    catch (bad_alloc &)
+    {
+        Except::throw_exception((const char *) API_MemoryAllocation,
+                                (const char *) "Can't allocate memory in server",
+                                (const char *) "DeviceImpl::get_attribute_config");
+    }
 
 //
 // Fill in these structures
 //
 
-	for (long i = 0;i < nb_attr;i++)
-	{
-		try
-		{
-			if (all_attr == true)
-			{
-				Attribute &attr = dev_attr->get_attr_by_ind(i);
-				attr.get_properties((*back)[i]);
-			}
-			else
-			{
-				Attribute &attr = dev_attr->get_attr_by_name(names[i]);
-				attr.get_properties((*back)[i]);
-			}
-		}
-		catch (Tango::DevFailed &e)
-		{
-			delete back;
-			throw;
-		}
-	}
+    for (long i = 0; i < nb_attr; i++)
+    {
+        try
+        {
+            if (all_attr == true)
+            {
+                Attribute &attr = dev_attr->get_attr_by_ind(i);
+                attr.get_properties((*back)[i]);
+            }
+            else
+            {
+                Attribute &attr = dev_attr->get_attr_by_name(names[i]);
+                attr.get_properties((*back)[i]);
+            }
+        }
+        catch (Tango::DevFailed &e)
+        {
+            delete back;
+            throw;
+        }
+    }
 
 //
 // Return to caller
 //
 
-	cout4 << "Leaving DeviceImpl::get_attribute_config" << endl;
+    cout4 << "Leaving DeviceImpl::get_attribute_config" << endl;
 
-	return back;
+    return back;
 }
 
 //+-------------------------------------------------------------------------
@@ -2238,10 +2243,10 @@ Tango::AttributeConfigList *DeviceImpl::get_attribute_config(const Tango::DevVar
 //
 //--------------------------------------------------------------------------
 
-void DeviceImpl::set_attribute_config(const Tango::AttributeConfigList& new_conf)
+void DeviceImpl::set_attribute_config(const Tango::AttributeConfigList &new_conf)
 {
-	AutoTangoMonitor sync(this,true);
-	cout4 << "DeviceImpl::set_attribute_config arrived" << endl;
+    AutoTangoMonitor sync(this, true);
+    cout4 << "DeviceImpl::set_attribute_config arrived" << endl;
 
 //
 // The attribute conf. is protected by two monitors. One protects access between
@@ -2249,78 +2254,78 @@ void DeviceImpl::set_attribute_config(const Tango::AttributeConfigList& new_conf
 // usage. This is the classical device monitor
 //
 
-	TangoMonitor &mon1 = get_att_conf_monitor();
-	AutoTangoMonitor sync1(&mon1);
+    TangoMonitor &mon1 = get_att_conf_monitor();
+    AutoTangoMonitor sync1(&mon1);
 
 //
 // Record operation request in black box
 //
 
-	blackbox_ptr->insert_op(Op_Set_Attr_Config);
+    blackbox_ptr->insert_op(Op_Set_Attr_Config);
 
 //
 // Check if device is locked
 //
 
-	check_lock("set_attribute_config");
+    check_lock("set_attribute_config");
 
 //
 // Return exception if the device does not have any attribute
 //
 
-	long nb_dev_attr = dev_attr->get_attr_nb();
-	if (nb_dev_attr == 0)
-	{
-		Except::throw_exception((const char *)API_AttrNotFound,
-				        (const char *)"The device does not have any attribute",
-				        (const char *)"DeviceImpl::set_attribute_config");
-	}
+    long nb_dev_attr = dev_attr->get_attr_nb();
+    if (nb_dev_attr == 0)
+    {
+        Except::throw_exception((const char *) API_AttrNotFound,
+                                (const char *) "The device does not have any attribute",
+                                (const char *) "DeviceImpl::set_attribute_config");
+    }
 
 //
 // Get some event related data
 //
 
-	Tango::Util *tg = Tango::Util::instance();
+    Tango::Util *tg = Tango::Util::instance();
 
-	EventSupplier *event_supplier_nd = NULL;
-	EventSupplier *event_supplier_zmq = NULL;
+    EventSupplier *event_supplier_nd = NULL;
+    EventSupplier *event_supplier_zmq = NULL;
 
 //
 // Update attribute config first in database, then locally
 // Finally send attr conf. event
 //
 
-	long nb_attr = new_conf.length();
-	long i;
+    long nb_attr = new_conf.length();
+    long i;
 
-	try
-	{
-		for (i = 0;i < nb_attr;i++)
-		{
-			string tmp_name(new_conf[i].name);
-			transform(tmp_name.begin(),tmp_name.end(),tmp_name.begin(),::tolower);
-			if ((tmp_name == "state") || (tmp_name == "status"))
-			{
-				Except::throw_exception((const char *)API_AttrNotFound,
-				        		(const char *)"Cannot set config for attribute state or status",
-				        		(const char *)"DeviceImpl::set_attribute_config");
-			}
+    try
+    {
+        for (i = 0; i < nb_attr; i++)
+        {
+            string tmp_name(new_conf[i].name);
+            transform(tmp_name.begin(), tmp_name.end(), tmp_name.begin(), ::tolower);
+            if ((tmp_name == "state") || (tmp_name == "status"))
+            {
+                Except::throw_exception((const char *) API_AttrNotFound,
+                                        (const char *) "Cannot set config for attribute state or status",
+                                        (const char *) "DeviceImpl::set_attribute_config");
+            }
 
-			Attribute &attr = dev_attr->get_attr_by_name(new_conf[i].name);
-			bool old_alarm = attr.is_alarmed().any();
-			vector<Attribute::AttPropDb> v_db;
-			attr.set_properties(new_conf[i],device_name,false,v_db);
-			if (Tango::Util::_UseDb == true)
-				attr.upd_database(v_db);
+            Attribute &attr = dev_attr->get_attr_by_name(new_conf[i].name);
+            bool old_alarm = attr.is_alarmed().any();
+            vector<Attribute::AttPropDb> v_db;
+            attr.set_properties(new_conf[i], device_name, false, v_db);
+            if (Tango::Util::_UseDb == true)
+                attr.upd_database(v_db);
 
 //
 // In case the attribute quality factor was set to ALARM, reset it to VALID
 //
 
-			if ((attr.get_quality() == Tango::ATTR_ALARM) &&
-			    (old_alarm == true) &&
-			    (attr.is_alarmed().any() == false))
-				attr.set_quality(Tango::ATTR_VALID);
+            if ((attr.get_quality() == Tango::ATTR_ALARM) &&
+                (old_alarm == true) &&
+                (attr.is_alarmed().any() == false))
+                attr.set_quality(Tango::ATTR_VALID);
 
 //
 // Send the event
@@ -2336,106 +2341,106 @@ void DeviceImpl::set_attribute_config(const Tango::AttributeConfigList& new_conf
             else
                 event_supplier_zmq = NULL;
 
-			if ((event_supplier_nd != NULL) || (event_supplier_zmq != NULL))
-			{
-				string tmp_name(new_conf[i].name);
+            if ((event_supplier_nd != NULL) || (event_supplier_zmq != NULL))
+            {
+                string tmp_name(new_conf[i].name);
 
                 EventSupplier::SuppliedEventData ad;
-                ::memset(&ad,0,sizeof(ad));
+                ::memset(&ad, 0, sizeof(ad));
 
-				long vers = get_dev_idl_version();
-				if (vers <= 2)
-				{
-					Tango::AttributeConfig_2 attr_conf_2;
-					attr.get_properties(attr_conf_2);
-					ad.attr_conf_2 = &attr_conf_2;
-					if (event_supplier_nd != NULL)
-                        event_supplier_nd->push_att_conf_events(this,ad,(Tango::DevFailed *)NULL,tmp_name);
+                long vers = get_dev_idl_version();
+                if (vers <= 2)
+                {
+                    Tango::AttributeConfig_2 attr_conf_2;
+                    attr.get_properties(attr_conf_2);
+                    ad.attr_conf_2 = &attr_conf_2;
+                    if (event_supplier_nd != NULL)
+                        event_supplier_nd->push_att_conf_events(this, ad, (Tango::DevFailed *) NULL, tmp_name);
                     if (event_supplier_zmq != NULL)
-                        event_supplier_zmq->push_att_conf_events(this,ad,(Tango::DevFailed *)NULL,tmp_name);
-				}
-				else if (vers <= 4)
-				{
-					Tango::AttributeConfig_3 attr_conf_3;
-					attr.get_properties(attr_conf_3);
-					ad.attr_conf_3 = &attr_conf_3;
-					if (event_supplier_nd != NULL)
-                        event_supplier_nd->push_att_conf_events(this,ad,(Tango::DevFailed *)NULL,tmp_name);
-					if (event_supplier_zmq != NULL)
-                        event_supplier_zmq->push_att_conf_events(this,ad,(Tango::DevFailed *)NULL,tmp_name);
-				}
-				else
-				{
-					Tango::AttributeConfig_5 attr_conf_5;
-					attr.get_properties(attr_conf_5);
-					ad.attr_conf_5 = &attr_conf_5;
-					if (event_supplier_nd != NULL)
-                        event_supplier_nd->push_att_conf_events(this,ad,(Tango::DevFailed *)NULL,tmp_name);
-					if (event_supplier_zmq != NULL)
-                        event_supplier_zmq->push_att_conf_events(this,ad,(Tango::DevFailed *)NULL,tmp_name);
-				}
-			}
-		}
+                        event_supplier_zmq->push_att_conf_events(this, ad, (Tango::DevFailed *) NULL, tmp_name);
+                }
+                else if (vers <= 4)
+                {
+                    Tango::AttributeConfig_3 attr_conf_3;
+                    attr.get_properties(attr_conf_3);
+                    ad.attr_conf_3 = &attr_conf_3;
+                    if (event_supplier_nd != NULL)
+                        event_supplier_nd->push_att_conf_events(this, ad, (Tango::DevFailed *) NULL, tmp_name);
+                    if (event_supplier_zmq != NULL)
+                        event_supplier_zmq->push_att_conf_events(this, ad, (Tango::DevFailed *) NULL, tmp_name);
+                }
+                else
+                {
+                    Tango::AttributeConfig_5 attr_conf_5;
+                    attr.get_properties(attr_conf_5);
+                    ad.attr_conf_5 = &attr_conf_5;
+                    if (event_supplier_nd != NULL)
+                        event_supplier_nd->push_att_conf_events(this, ad, (Tango::DevFailed *) NULL, tmp_name);
+                    if (event_supplier_zmq != NULL)
+                        event_supplier_zmq->push_att_conf_events(this, ad, (Tango::DevFailed *) NULL, tmp_name);
+                }
+            }
+        }
 
-	}
-	catch (Tango::DevFailed &e)
-	{
+    }
+    catch (Tango::DevFailed &e)
+    {
 
 //
 // Re build the list of "alarmable" attribute
 //
 
-		dev_attr->get_alarm_list().clear();
-		for (long j = 0;j < nb_dev_attr;j++)
-		{
-			Attribute &att = dev_attr->get_attr_by_ind(j);
-			if (att.is_alarmed().any() == true)
-			{
-				if (att.get_writable() != Tango::WRITE)
-					dev_attr->get_alarm_list().push_back(j);
-			}
-		}
+        dev_attr->get_alarm_list().clear();
+        for (long j = 0; j < nb_dev_attr; j++)
+        {
+            Attribute &att = dev_attr->get_attr_by_ind(j);
+            if (att.is_alarmed().any() == true)
+            {
+                if (att.get_writable() != Tango::WRITE)
+                    dev_attr->get_alarm_list().push_back(j);
+            }
+        }
 
 //
 // Change the exception reason flag
 //
 
-		TangoSys_OMemStream o;
+        TangoSys_OMemStream o;
 
-		o << e.errors[0].reason;
-		if (i != 0)
-			o << "\nAll previous attribute(s) have been successfully updated";
-		if (i != (nb_attr - 1))
-			o << "\nAll remaining attribute(s) have not been updated";
-		o << ends;
+        o << e.errors[0].reason;
+        if (i != 0)
+            o << "\nAll previous attribute(s) have been successfully updated";
+        if (i != (nb_attr - 1))
+            o << "\nAll remaining attribute(s) have not been updated";
+        o << ends;
 
-		string s = o.str();
-		e.errors[0].reason = CORBA::string_dup(s.c_str());
+        string s = o.str();
+        e.errors[0].reason = CORBA::string_dup(s.c_str());
 
-		throw;
-	}
+        throw;
+    }
 
 //
 // Re build the list of "alarmable" attribute
 //
 
-	dev_attr->get_alarm_list().clear();
-	for (i = 0;i < nb_dev_attr;i++)
-	{
-		Tango::Attribute &attr = dev_attr->get_attr_by_ind(i);
-		Tango::AttrWriteType w_type = attr.get_writable();
-		if (attr.is_alarmed().any() == true)
-		{
-			if (w_type != Tango::WRITE)
-				dev_attr->get_alarm_list().push_back(i);
-		}
-	}
+    dev_attr->get_alarm_list().clear();
+    for (i = 0; i < nb_dev_attr; i++)
+    {
+        Tango::Attribute &attr = dev_attr->get_attr_by_ind(i);
+        Tango::AttrWriteType w_type = attr.get_writable();
+        if (attr.is_alarmed().any() == true)
+        {
+            if (w_type != Tango::WRITE)
+                dev_attr->get_alarm_list().push_back(i);
+        }
+    }
 
 //
 // Return to caller
 //
 
-	cout4 << "Leaving DeviceImpl::set_attribute_config" << endl;
+    cout4 << "Leaving DeviceImpl::set_attribute_config" << endl;
 }
 
 
@@ -2453,13 +2458,13 @@ void DeviceImpl::set_attribute_config(const Tango::AttributeConfigList& new_conf
 //
 //--------------------------------------------------------------------------
 
-Tango::AttributeValueList *DeviceImpl::read_attributes(const Tango::DevVarStringArray& names)
+Tango::AttributeValueList *DeviceImpl::read_attributes(const Tango::DevVarStringArray &names)
 {
-	AutoTangoMonitor sync(this,true);
+    AutoTangoMonitor sync(this, true);
 
-	Tango::AttributeValueList *back = NULL;
+    Tango::AttributeValueList *back = NULL;
 
-	cout4 << "DeviceImpl::read_attributes arrived" << endl;
+    cout4 << "DeviceImpl::read_attributes arrived" << endl;
 
 //
 //  Write the device name into the per thread data for
@@ -2468,22 +2473,22 @@ Tango::AttributeValueList *DeviceImpl::read_attributes(const Tango::DevVarString
 //  During device access inside the same server,
 //  the thread stays the same!
 //
-	SubDevDiag &sub = (Tango::Util::instance())->get_sub_dev_diag();
-	string last_associated_device = sub.get_associated_device();
-	sub.set_associated_device(get_name());
+    SubDevDiag &sub = (Tango::Util::instance())->get_sub_dev_diag();
+    string last_associated_device = sub.get_associated_device();
+    sub.set_associated_device(get_name());
 
 // Catch all execeptions to set back the associated device after
 // execution
-	try
-	{
+    try
+    {
 
 //
 // Record operation request in black box
 //
 
-		if (store_in_bb == true)
-			blackbox_ptr->insert_attr(names);
-		store_in_bb = true;
+        if (store_in_bb == true)
+            blackbox_ptr->insert_attr(names);
+        store_in_bb = true;
 
 //
 // Return exception if the device does not have any attribute
@@ -2492,17 +2497,17 @@ Tango::AttributeValueList *DeviceImpl::read_attributes(const Tango::DevVarString
 // a "new" client
 //
 
-		long vers = get_dev_idl_version();
-		long nb_dev_attr = dev_attr->get_attr_nb();
+        long vers = get_dev_idl_version();
+        long nb_dev_attr = dev_attr->get_attr_nb();
 
-		if (nb_dev_attr == 0)
-		{
-			Except::throw_exception((const char *)API_AttrNotFound,
-						(const char *)"The device does not have any attribute",
-						(const char *)"DeviceImpl::read_attributes");
-		}
-		if (vers >= 3)
-			nb_dev_attr = nb_dev_attr - 2;
+        if (nb_dev_attr == 0)
+        {
+            Except::throw_exception((const char *) API_AttrNotFound,
+                                    (const char *) "The device does not have any attribute",
+                                    (const char *) "DeviceImpl::read_attributes");
+        }
+        if (vers >= 3)
+            nb_dev_attr = nb_dev_attr - 2;
 
 //
 // Build a sequence with the names of the attribute to be read.
@@ -2510,27 +2515,27 @@ Tango::AttributeValueList *DeviceImpl::read_attributes(const Tango::DevVarString
 // If all attributes are wanted, build this list
 //
 
-		long i;
-		Tango::DevVarStringArray real_names(nb_dev_attr);
-		long nb_names = names.length();
-		if (nb_names == 1)
-		{
-			string att_name(names[0]);
-			if (att_name == AllAttr)
-			{
-				real_names.length(nb_dev_attr);
-				for (i = 0;i < nb_dev_attr;i++)
-					real_names[i] = dev_attr->get_attr_by_ind(i).get_name().c_str();
-			}
-			else
-			{
-				real_names = names;
-			}
-		}
-		else
-		{
-			real_names = names;
-		}
+        long i;
+        Tango::DevVarStringArray real_names(nb_dev_attr);
+        long nb_names = names.length();
+        if (nb_names == 1)
+        {
+            string att_name(names[0]);
+            if (att_name == AllAttr)
+            {
+                real_names.length(nb_dev_attr);
+                for (i = 0; i < nb_dev_attr; i++)
+                    real_names[i] = dev_attr->get_attr_by_ind(i).get_name().c_str();
+            }
+            else
+            {
+                real_names = names;
+            }
+        }
+        else
+        {
+            real_names = names;
+        }
 
 
 //
@@ -2545,343 +2550,343 @@ Tango::AttributeValueList *DeviceImpl::read_attributes(const Tango::DevVarString
 //
 //
 
-		nb_names = real_names.length();
-		vector<long> wanted_attr;
-		vector<long> wanted_w_attr;
+        nb_names = real_names.length();
+        vector<long> wanted_attr;
+        vector<long> wanted_w_attr;
 
-		for (i = 0;i < nb_names;i++)
-		{
-			long j = dev_attr->get_attr_ind_by_name(real_names[i]);
-			if ((dev_attr->get_attr_by_ind(j).get_writable() == Tango::READ_WRITE) ||
-		    	(dev_attr->get_attr_by_ind(j).get_writable() == Tango::READ_WITH_WRITE))
-			{
-				wanted_w_attr.push_back(j);
-				wanted_attr.push_back(j);
-				Attribute &att = dev_attr->get_attr_by_ind(wanted_attr.back());
-				Tango::AttrDataFormat format_type = att.get_data_format();
-				if ((format_type == Tango::SPECTRUM) || (format_type == Tango::IMAGE))
-				{
-					TangoSys_OMemStream o;
-					o << "Client too old to get data for attribute " << real_names[i].in();
-					o << ".\nPlease, use a client linked with Tango V5";
-					o << " and a device inheriting from Device_3Impl" << ends;
-					Except::throw_exception((const char *)API_NotSupportedFeature,
-								o.str(),
-								(const char *)"DeviceImpl::read_attributes");
-				}
-				att.set_value_flag(false);
-				att.get_when().tv_sec = 0;
-			}
-			else
-			{
-				if (dev_attr->get_attr_by_ind(j).get_writable() == Tango::WRITE)
-				{
-					wanted_w_attr.push_back(j);
-					Attribute &att = dev_attr->get_attr_by_ind(wanted_w_attr.back());
-					Tango::AttrDataFormat format_type = att.get_data_format();
-					if ((format_type == Tango::SPECTRUM) || (format_type == Tango::IMAGE))
-					{
-						TangoSys_OMemStream o;
-						o << "Client too old to get data for attribute " << real_names[i].in();
-						o << ".\nPlease, use a client linked with Tango V5";
-						o << " and a device inheriting from Device_3Impl" << ends;
-						Except::throw_exception((const char *)API_NotSupportedFeature,
-								o.str(),
-								(const char *)"DeviceImpl::read_attributes");
-					}
-				}
-				else
-				{
-					wanted_attr.push_back(j);
-					Attribute &att = dev_attr->get_attr_by_ind(wanted_attr.back());
-					att.set_value_flag(false);
-					att.get_when().tv_sec = 0;
-				}
-			}
-		}
-		long nb_wanted_attr = wanted_attr.size();
-		long nb_wanted_w_attr = wanted_w_attr.size();
+        for (i = 0; i < nb_names; i++)
+        {
+            long j = dev_attr->get_attr_ind_by_name(real_names[i]);
+            if ((dev_attr->get_attr_by_ind(j).get_writable() == Tango::READ_WRITE) ||
+                (dev_attr->get_attr_by_ind(j).get_writable() == Tango::READ_WITH_WRITE))
+            {
+                wanted_w_attr.push_back(j);
+                wanted_attr.push_back(j);
+                Attribute &att = dev_attr->get_attr_by_ind(wanted_attr.back());
+                Tango::AttrDataFormat format_type = att.get_data_format();
+                if ((format_type == Tango::SPECTRUM) || (format_type == Tango::IMAGE))
+                {
+                    TangoSys_OMemStream o;
+                    o << "Client too old to get data for attribute " << real_names[i].in();
+                    o << ".\nPlease, use a client linked with Tango V5";
+                    o << " and a device inheriting from Device_3Impl" << ends;
+                    Except::throw_exception((const char *) API_NotSupportedFeature,
+                                            o.str(),
+                                            (const char *) "DeviceImpl::read_attributes");
+                }
+                att.set_value_flag(false);
+                att.get_when().tv_sec = 0;
+            }
+            else
+            {
+                if (dev_attr->get_attr_by_ind(j).get_writable() == Tango::WRITE)
+                {
+                    wanted_w_attr.push_back(j);
+                    Attribute &att = dev_attr->get_attr_by_ind(wanted_w_attr.back());
+                    Tango::AttrDataFormat format_type = att.get_data_format();
+                    if ((format_type == Tango::SPECTRUM) || (format_type == Tango::IMAGE))
+                    {
+                        TangoSys_OMemStream o;
+                        o << "Client too old to get data for attribute " << real_names[i].in();
+                        o << ".\nPlease, use a client linked with Tango V5";
+                        o << " and a device inheriting from Device_3Impl" << ends;
+                        Except::throw_exception((const char *) API_NotSupportedFeature,
+                                                o.str(),
+                                                (const char *) "DeviceImpl::read_attributes");
+                    }
+                }
+                else
+                {
+                    wanted_attr.push_back(j);
+                    Attribute &att = dev_attr->get_attr_by_ind(wanted_attr.back());
+                    att.set_value_flag(false);
+                    att.get_when().tv_sec = 0;
+                }
+            }
+        }
+        long nb_wanted_attr = wanted_attr.size();
+        long nb_wanted_w_attr = wanted_w_attr.size();
 
 //
 // Call the always_executed_hook
 //
 
-		always_executed_hook();
+        always_executed_hook();
 
 //
 // Read the hardware for readable attribute
 //
 
-		if (nb_wanted_attr != 0)
-			read_attr_hardware(wanted_attr);
+        if (nb_wanted_attr != 0)
+            read_attr_hardware(wanted_attr);
 
 //
 // Set attr value (for readable attribute)
 //
 
-		vector<Tango::Attr *> &attr_vect = device_class->get_class_attr()->get_attr_list();
+        vector<Tango::Attr *> &attr_vect = device_class->get_class_attr()->get_attr_list();
 
-		for (i = 0;i < nb_wanted_attr;i++)
-		{
-			if (vers < 3)
-				read_attr(dev_attr->get_attr_by_ind(wanted_attr[i]));
-			else
-			{
-				Attribute &att = dev_attr->get_attr_by_ind(wanted_attr[i]);
-				long idx = att.get_attr_idx();
-				if (idx == -1)
-				{
-					TangoSys_OMemStream o;
+        for (i = 0; i < nb_wanted_attr; i++)
+        {
+            if (vers < 3)
+                read_attr(dev_attr->get_attr_by_ind(wanted_attr[i]));
+            else
+            {
+                Attribute &att = dev_attr->get_attr_by_ind(wanted_attr[i]);
+                long idx = att.get_attr_idx();
+                if (idx == -1)
+                {
+                    TangoSys_OMemStream o;
 
-					o << "It is not possible to read state/status as attributes with your\n";
-					o << "Tango software release. Please, re-link with Tango V5." << ends;
+                    o << "It is not possible to read state/status as attributes with your\n";
+                    o << "Tango software release. Please, re-link with Tango V5." << ends;
 
-					Except::throw_exception((const char *)API_NotSupportedFeature,
-					        		o.str(),
-					        		(const char *)"Device_Impl::read_attributes");
-				}
+                    Except::throw_exception((const char *) API_NotSupportedFeature,
+                                            o.str(),
+                                            (const char *) "Device_Impl::read_attributes");
+                }
 
-				if (attr_vect[idx]->is_allowed(this,Tango::READ_REQ) == false)
-				{
-					TangoSys_OMemStream o;
+                if (attr_vect[idx]->is_allowed(this, Tango::READ_REQ) == false)
+                {
+                    TangoSys_OMemStream o;
 
-					o << "It is currently not allowed to read attribute ";
-					o << att.get_name() << ends;
+                    o << "It is currently not allowed to read attribute ";
+                    o << att.get_name() << ends;
 
-					Except::throw_exception((const char *)API_AttrNotAllowed,
-					        		o.str(),
-					        		(const char *)"Device_Impl::read_attributes");
-				}
-				attr_vect[idx]->read(this,att);
-			}
-		}
+                    Except::throw_exception((const char *) API_AttrNotAllowed,
+                                            o.str(),
+                                            (const char *) "Device_Impl::read_attributes");
+                }
+                attr_vect[idx]->read(this, att);
+            }
+        }
 
 //
 // Set attr value for writable attribute
 //
 
-		for (i = 0;i < nb_wanted_w_attr;i++)
-		{
-			Tango::AttrWriteType w_type = dev_attr->get_attr_by_ind(wanted_w_attr[i]).get_writable();
-			if ((w_type == Tango::READ_WITH_WRITE) ||
-		    	(w_type == Tango::WRITE))
-				dev_attr->get_attr_by_ind(wanted_w_attr[i]).set_rvalue();
-		}
+        for (i = 0; i < nb_wanted_w_attr; i++)
+        {
+            Tango::AttrWriteType w_type = dev_attr->get_attr_by_ind(wanted_w_attr[i]).get_writable();
+            if ((w_type == Tango::READ_WITH_WRITE) ||
+                (w_type == Tango::WRITE))
+                dev_attr->get_attr_by_ind(wanted_w_attr[i]).set_rvalue();
+        }
 
 //
 // Allocate memory for the AttributeValue structures
 //
 
-		try
-		{
-			back = new Tango::AttributeValueList(nb_names);
-			back->length(nb_names);
-		}
-		catch (bad_alloc &)
-		{
-			Except::throw_exception((const char *)API_MemoryAllocation,
-						(const char *)"Can't allocate memory in server",
-						(const char *)"DeviceImpl::read_attributes");
-		}
+        try
+        {
+            back = new Tango::AttributeValueList(nb_names);
+            back->length(nb_names);
+        }
+        catch (bad_alloc &)
+        {
+            Except::throw_exception((const char *) API_MemoryAllocation,
+                                    (const char *) "Can't allocate memory in server",
+                                    (const char *) "DeviceImpl::read_attributes");
+        }
 
 //
 // Build the sequence returned to caller for readable attributes and check
 // that all the wanted attributes set value has been updated
 //
 
-		for (i = 0;i < nb_names;i++)
-		{
-			Attribute &att = dev_attr->get_attr_by_name(real_names[i]);
-			Tango::AttrQuality qual = att.get_quality();
-			if (qual != Tango::ATTR_INVALID)
-			{
-				if (att.get_value_flag() == false)
-				{
-					TangoSys_OMemStream o;
-					delete back;
-					for (long j = 0;j < i;j++)
-					{
-						att = dev_attr->get_attr_by_name(real_names[j]);
-						att.delete_seq();
-					}
+        for (i = 0; i < nb_names; i++)
+        {
+            Attribute &att = dev_attr->get_attr_by_name(real_names[i]);
+            Tango::AttrQuality qual = att.get_quality();
+            if (qual != Tango::ATTR_INVALID)
+            {
+                if (att.get_value_flag() == false)
+                {
+                    TangoSys_OMemStream o;
+                    delete back;
+                    for (long j = 0; j < i; j++)
+                    {
+                        att = dev_attr->get_attr_by_name(real_names[j]);
+                        att.delete_seq();
+                    }
 
-					try
-					{
-						string att_name(real_names[i]);
-						transform(att_name.begin(),att_name.end(),att_name.begin(),::tolower);
+                    try
+                    {
+                        string att_name(real_names[i]);
+                        transform(att_name.begin(), att_name.end(), att_name.begin(), ::tolower);
 
-						vector<PollObj *>::iterator ite = get_polled_obj_by_type_name(Tango::POLL_ATTR,att_name);
-						long upd = (*ite)->get_upd();
-						if (upd == 0)
-						{
-							o << "Attribute ";
-							o << att.get_name();
-							o << " value is available only by CACHE.\n";
-							o << "Attribute values are set by external polling buffer filling" << ends;
-						}
-						else
-						{
-							o << "Read value for attribute ";
-							o << att.get_name();
-							o << " has not been updated" << ends;
-						}
-					}
-					catch (Tango::DevFailed &)
-					{
-						o << "Read value for attribute ";
-						o << att.get_name();
-						o << " has not been updated" << ends;
-					}
+                        vector<PollObj *>::iterator ite = get_polled_obj_by_type_name(Tango::POLL_ATTR, att_name);
+                        long upd = (*ite)->get_upd();
+                        if (upd == 0)
+                        {
+                            o << "Attribute ";
+                            o << att.get_name();
+                            o << " value is available only by CACHE.\n";
+                            o << "Attribute values are set by external polling buffer filling" << ends;
+                        }
+                        else
+                        {
+                            o << "Read value for attribute ";
+                            o << att.get_name();
+                            o << " has not been updated" << ends;
+                        }
+                    }
+                    catch (Tango::DevFailed &)
+                    {
+                        o << "Read value for attribute ";
+                        o << att.get_name();
+                        o << " has not been updated" << ends;
+                    }
 
-					Except::throw_exception((const char *)API_AttrValueNotSet,
-								 o.str(),
-								(const char *)"DeviceImpl::read_attributes");
-				}
-				else
-				{
-					Tango::AttrWriteType w_type = att.get_writable();
-					if ((w_type == Tango::READ) ||
-				    	(w_type == Tango::READ_WRITE) ||
-				    	(w_type == Tango::READ_WITH_WRITE))
-					{
-						if ((w_type == Tango::READ_WRITE) ||
-					    	(w_type == Tango::READ_WITH_WRITE))
-							dev_attr->add_write_value(att);
+                    Except::throw_exception((const char *) API_AttrValueNotSet,
+                                            o.str(),
+                                            (const char *) "DeviceImpl::read_attributes");
+                }
+                else
+                {
+                    Tango::AttrWriteType w_type = att.get_writable();
+                    if ((w_type == Tango::READ) ||
+                        (w_type == Tango::READ_WRITE) ||
+                        (w_type == Tango::READ_WITH_WRITE))
+                    {
+                        if ((w_type == Tango::READ_WRITE) ||
+                            (w_type == Tango::READ_WITH_WRITE))
+                            dev_attr->add_write_value(att);
 
-						if ((att.is_alarmed().any() == true) && (qual != Tango::ATTR_INVALID))
-							att.check_alarm();
-					}
+                        if ((att.is_alarmed().any() == true) && (qual != Tango::ATTR_INVALID))
+                            att.check_alarm();
+                    }
 
-					CORBA::Any &a = (*back)[i].value;
-					switch (att.get_data_type())
-					{
-					case Tango::DEV_SHORT :
-					case Tango::DEV_ENUM :
-					{
-						Tango::DevVarShortArray *ptr = att.get_short_value();
-						a <<= *ptr;
-						delete ptr;
-						break;
-					}
+                    CORBA::Any &a = (*back)[i].value;
+                    switch (att.get_data_type())
+                    {
+                        case Tango::DEV_SHORT :
+                        case Tango::DEV_ENUM :
+                        {
+                            Tango::DevVarShortArray *ptr = att.get_short_value();
+                            a <<= *ptr;
+                            delete ptr;
+                            break;
+                        }
 
-					case Tango::DEV_LONG :
-					{
-						Tango::DevVarLongArray *ptr = att.get_long_value();
-						a <<= *ptr;
-						delete ptr;
-						break;
-					}
+                        case Tango::DEV_LONG :
+                        {
+                            Tango::DevVarLongArray *ptr = att.get_long_value();
+                            a <<= *ptr;
+                            delete ptr;
+                            break;
+                        }
 
-					case Tango::DEV_LONG64 :
-					{
-						Tango::DevVarLong64Array *ptr = att.get_long64_value();
-						a <<= *ptr;
-						delete ptr;
-						break;
-					}
+                        case Tango::DEV_LONG64 :
+                        {
+                            Tango::DevVarLong64Array *ptr = att.get_long64_value();
+                            a <<= *ptr;
+                            delete ptr;
+                            break;
+                        }
 
-					case Tango::DEV_DOUBLE :
-					{
-						Tango::DevVarDoubleArray *ptr = att.get_double_value();
-						a <<= *ptr;
-						delete ptr;
-						break;
-					}
+                        case Tango::DEV_DOUBLE :
+                        {
+                            Tango::DevVarDoubleArray *ptr = att.get_double_value();
+                            a <<= *ptr;
+                            delete ptr;
+                            break;
+                        }
 
-					case Tango::DEV_STRING :
-					{
-						Tango::DevVarStringArray *ptr = att.get_string_value();
-						a <<= *ptr;
-						delete ptr;
-						break;
-					}
+                        case Tango::DEV_STRING :
+                        {
+                            Tango::DevVarStringArray *ptr = att.get_string_value();
+                            a <<= *ptr;
+                            delete ptr;
+                            break;
+                        }
 
-					case Tango::DEV_FLOAT :
-					{
-						Tango::DevVarFloatArray *ptr = att.get_float_value();
-						a <<= *ptr;
-						delete ptr;
-						break;
-					}
+                        case Tango::DEV_FLOAT :
+                        {
+                            Tango::DevVarFloatArray *ptr = att.get_float_value();
+                            a <<= *ptr;
+                            delete ptr;
+                            break;
+                        }
 
-					case Tango::DEV_BOOLEAN :
-					{
-						Tango::DevVarBooleanArray *ptr = att.get_boolean_value();
-						a <<= *ptr;
-						delete ptr;
-						break;
-					}
+                        case Tango::DEV_BOOLEAN :
+                        {
+                            Tango::DevVarBooleanArray *ptr = att.get_boolean_value();
+                            a <<= *ptr;
+                            delete ptr;
+                            break;
+                        }
 
-					case Tango::DEV_USHORT :
-					{
-						Tango::DevVarUShortArray *ptr = att.get_ushort_value();
-						a <<= *ptr;
-						delete ptr;
-						break;
-					}
+                        case Tango::DEV_USHORT :
+                        {
+                            Tango::DevVarUShortArray *ptr = att.get_ushort_value();
+                            a <<= *ptr;
+                            delete ptr;
+                            break;
+                        }
 
-					case Tango::DEV_UCHAR :
-					{
-						Tango::DevVarUCharArray *ptr = att.get_uchar_value();
-						a <<= *ptr;
-						delete ptr;
-						break;
-					}
+                        case Tango::DEV_UCHAR :
+                        {
+                            Tango::DevVarUCharArray *ptr = att.get_uchar_value();
+                            a <<= *ptr;
+                            delete ptr;
+                            break;
+                        }
 
-					case Tango::DEV_ULONG :
-					{
-						Tango::DevVarULongArray *ptr = att.get_ulong_value();
-						a <<= *ptr;
-						delete ptr;
-						break;
-					}
+                        case Tango::DEV_ULONG :
+                        {
+                            Tango::DevVarULongArray *ptr = att.get_ulong_value();
+                            a <<= *ptr;
+                            delete ptr;
+                            break;
+                        }
 
-					case Tango::DEV_ULONG64 :
-					{
-						Tango::DevVarULong64Array *ptr = att.get_ulong64_value();
-						a <<= *ptr;
-						delete ptr;
-						break;
-					}
+                        case Tango::DEV_ULONG64 :
+                        {
+                            Tango::DevVarULong64Array *ptr = att.get_ulong64_value();
+                            a <<= *ptr;
+                            delete ptr;
+                            break;
+                        }
 
-					case Tango::DEV_STATE :
-					{
-						Tango::DevVarStateArray *ptr = att.get_state_value();
-						a <<= *ptr;
-						delete ptr;
-						break;
-					}
-					}
-				}
-			}
+                        case Tango::DEV_STATE :
+                        {
+                            Tango::DevVarStateArray *ptr = att.get_state_value();
+                            a <<= *ptr;
+                            delete ptr;
+                            break;
+                        }
+                    }
+                }
+            }
 
-			if (att.get_when().tv_sec == 0)
-				att.set_time();
+            if (att.get_when().tv_sec == 0)
+                att.set_time();
 
-			(*back)[i].time = att.get_when();
-			(*back)[i].quality = att.get_quality();
-			(*back)[i].name = CORBA::string_dup(att.get_name().c_str());
-			(*back)[i].dim_x = att.get_x();
-			(*back)[i].dim_y = att.get_y();
-		}
-	}
-	catch (...)
-	{
-		// set back the device attribution for the thread
-		// and rethrow the exception.
-		sub.set_associated_device(last_associated_device);
-		throw;
-	}
+            (*back)[i].time = att.get_when();
+            (*back)[i].quality = att.get_quality();
+            (*back)[i].name = CORBA::string_dup(att.get_name().c_str());
+            (*back)[i].dim_x = att.get_x();
+            (*back)[i].dim_y = att.get_y();
+        }
+    }
+    catch (...)
+    {
+        // set back the device attribution for the thread
+        // and rethrow the exception.
+        sub.set_associated_device(last_associated_device);
+        throw;
+    }
 
-	// set back the device attribution for the thread
-	sub.set_associated_device(last_associated_device);
+    // set back the device attribution for the thread
+    sub.set_associated_device(last_associated_device);
 
 //
 // Return to caller
 //
 
-	cout4 << "Leaving DeviceImpl::read_attributes" << endl;
-	return back;
+    cout4 << "Leaving DeviceImpl::read_attributes" << endl;
+    return back;
 }
 
 //+-------------------------------------------------------------------------
@@ -2894,10 +2899,10 @@ Tango::AttributeValueList *DeviceImpl::read_attributes(const Tango::DevVarString
 //
 //--------------------------------------------------------------------------
 
-void DeviceImpl::write_attributes(const Tango::AttributeValueList& values)
+void DeviceImpl::write_attributes(const Tango::AttributeValueList &values)
 {
-	AutoTangoMonitor sync(this,true);
-	cout4 << "DeviceImpl::write_attributes arrived" << endl;
+    AutoTangoMonitor sync(this, true);
+    cout4 << "DeviceImpl::write_attributes arrived" << endl;
 
 
 //
@@ -2907,172 +2912,173 @@ void DeviceImpl::write_attributes(const Tango::AttributeValueList& values)
 //  During device access inside the same server,
 //  the thread stays the same!
 //
-	SubDevDiag &sub = (Tango::Util::instance())->get_sub_dev_diag();
-	string last_associated_device = sub.get_associated_device();
-	sub.set_associated_device(get_name());
+    SubDevDiag &sub = (Tango::Util::instance())->get_sub_dev_diag();
+    string last_associated_device = sub.get_associated_device();
+    sub.set_associated_device(get_name());
 
 // Catch all execeptions to set back the associated device after
 // execution
-	try
-	{
+    try
+    {
 
 //
 // Record operation request in black box
 //
 
-		blackbox_ptr->insert_attr(values);
+        blackbox_ptr->insert_attr(values);
 
 //
 // Check if the device is locked
 //
 
-		check_lock("write_attributes");
+        check_lock("write_attributes");
 
 //
 // Return exception if the device does not have any attribute
 //
 
-		long nb_dev_attr = dev_attr->get_attr_nb();
-		if (nb_dev_attr == 0)
-		{
-			Except::throw_exception((const char *)API_AttrNotFound,
-						(const char *)"The device does not have any attribute",
-						(const char *)"DeviceImpl::write_attributes");
-		}
+        long nb_dev_attr = dev_attr->get_attr_nb();
+        if (nb_dev_attr == 0)
+        {
+            Except::throw_exception((const char *) API_AttrNotFound,
+                                    (const char *) "The device does not have any attribute",
+                                    (const char *) "DeviceImpl::write_attributes");
+        }
 
 //
 // Retrieve index of wanted attributes in the device attribute list
 //
 
-		long nb_updated_attr = values.length();
-		vector<long> updated_attr;
+        long nb_updated_attr = values.length();
+        vector<long> updated_attr;
 
-		long i;
-		for (i = 0;i < nb_updated_attr;i++)
-		{
-			updated_attr.push_back(dev_attr->get_attr_ind_by_name(values[i].name));
-		}
+        long i;
+        for (i = 0; i < nb_updated_attr; i++)
+        {
+            updated_attr.push_back(dev_attr->get_attr_ind_by_name(values[i].name));
+        }
 
 //
 // Check that these attributes are writable
 //
 
-		for (i = 0;i < nb_updated_attr;i++)
-		{
-			if ((dev_attr->get_attr_by_ind(updated_attr[i]).get_writable() == Tango::READ) ||
-		    	(dev_attr->get_attr_by_ind(updated_attr[i]).get_writable() == Tango::READ_WITH_WRITE))
-			{
-				TangoSys_OMemStream o;
+        for (i = 0; i < nb_updated_attr; i++)
+        {
+            if ((dev_attr->get_attr_by_ind(updated_attr[i]).get_writable() == Tango::READ) ||
+                (dev_attr->get_attr_by_ind(updated_attr[i]).get_writable() == Tango::READ_WITH_WRITE))
+            {
+                TangoSys_OMemStream o;
 
-				o << "Attribute ";
-				o << dev_attr->get_attr_by_ind(updated_attr[i]).get_name();
-				o << " is not writable" << ends;
+                o << "Attribute ";
+                o << dev_attr->get_attr_by_ind(updated_attr[i]).get_name();
+                o << " is not writable" << ends;
 
-				Except::throw_exception((const char *)API_AttrNotWritable,
-							o.str(),
-							(const char *)"DeviceImpl::write_attributes");
-			}
-		}
+                Except::throw_exception((const char *) API_AttrNotWritable,
+                                        o.str(),
+                                        (const char *) "DeviceImpl::write_attributes");
+            }
+        }
 
 //
 // Call the always_executed_hook
 //
 
-		always_executed_hook();
+        always_executed_hook();
 
 //
 // Set attribute internal value
 //
 
-		for (i = 0;i < nb_updated_attr;i++)
-		{
-			try
-			{
-				dev_attr->get_w_attr_by_ind(updated_attr[i]).check_written_value(values[i].value,(unsigned long)1,(unsigned long)0);
-			}
-			catch (Tango::DevFailed &)
-			{
-				for (long j = 0;j < i;j++)
-					dev_attr->get_w_attr_by_ind(updated_attr[j]).rollback();
+        for (i = 0; i < nb_updated_attr; i++)
+        {
+            try
+            {
+                dev_attr->get_w_attr_by_ind(updated_attr[i])
+                    .check_written_value(values[i].value, (unsigned long) 1, (unsigned long) 0);
+            }
+            catch (Tango::DevFailed &)
+            {
+                for (long j = 0; j < i; j++)
+                    dev_attr->get_w_attr_by_ind(updated_attr[j]).rollback();
 
-				throw;
-			}
-		}
+                throw;
+            }
+        }
 
 //
 // Write the hardware
 //
 
-		long vers = get_dev_idl_version();
-		if (vers < 3)
-		{
-			write_attr_hardware(updated_attr);
-			for (i = 0;i < nb_updated_attr;i++)
-			{
-				WAttribute &att = dev_attr->get_w_attr_by_ind(updated_attr[i]);
-				att.copy_data(values[i].value);
-			}
-		}
-		else
-		{
-			vector<long> att_in_db;
+        long vers = get_dev_idl_version();
+        if (vers < 3)
+        {
+            write_attr_hardware(updated_attr);
+            for (i = 0; i < nb_updated_attr; i++)
+            {
+                WAttribute &att = dev_attr->get_w_attr_by_ind(updated_attr[i]);
+                att.copy_data(values[i].value);
+            }
+        }
+        else
+        {
+            vector<long> att_in_db;
 
-			for (i = 0;i < nb_updated_attr;i++)
-			{
-				WAttribute &att = dev_attr->get_w_attr_by_ind(updated_attr[i]);
-				vector<Tango::Attr *> &attr_vect = device_class->get_class_attr()->get_attr_list();
-				if (attr_vect[att.get_attr_idx()]->is_allowed(this,Tango::WRITE_REQ) == false)
-				{
-					TangoSys_OMemStream o;
+            for (i = 0; i < nb_updated_attr; i++)
+            {
+                WAttribute &att = dev_attr->get_w_attr_by_ind(updated_attr[i]);
+                vector<Tango::Attr *> &attr_vect = device_class->get_class_attr()->get_attr_list();
+                if (attr_vect[att.get_attr_idx()]->is_allowed(this, Tango::WRITE_REQ) == false)
+                {
+                    TangoSys_OMemStream o;
 
-					o << "It is currently not allowed to write attribute ";
-					o << att.get_name();
-					o << ". The device state is " << Tango::DevStateName[get_state()] << ends;
+                    o << "It is currently not allowed to write attribute ";
+                    o << att.get_name();
+                    o << ". The device state is " << Tango::DevStateName[get_state()] << ends;
 
 
-					Except::throw_exception((const char *)API_AttrNotAllowed,
-					        		o.str(),
-					        		(const char *)"Device_Impl::write_attributes");
-				}
-				attr_vect[att.get_attr_idx()]->write(this,att);
-				att.copy_data(values[i].value);
-				if (att.is_memorized() == true)
-					att_in_db.push_back(i);
-				if (att.is_alarmed().test(Attribute::rds) == true)
-					att.set_written_date();
-			}
+                    Except::throw_exception((const char *) API_AttrNotAllowed,
+                                            o.str(),
+                                            (const char *) "Device_Impl::write_attributes");
+                }
+                attr_vect[att.get_attr_idx()]->write(this, att);
+                att.copy_data(values[i].value);
+                if (att.is_memorized() == true)
+                    att_in_db.push_back(i);
+                if (att.is_alarmed().test(Attribute::rds) == true)
+                    att.set_written_date();
+            }
 
-			if ((Tango::Util::_UseDb == true) && (att_in_db.empty() == false))
-			{
-				try
-				{
-					 static_cast<Device_3Impl *>(this)->write_attributes_in_db(att_in_db,updated_attr);
-				}
-				catch (Tango::DevFailed &e)
-				{
-					Except::re_throw_exception(e,(const char *)API_AttrNotAllowed,
-					        	    	 (const char *)"Failed to store memorized attribute value in db",
-					        	    	 (const char *)"Device_Impl::write_attributes");
-				}
-			}
-		}
-	}
-	catch (...)
-	{
-		// set back the device attribution for the thread
-		// and rethrow the exception.
-		sub.set_associated_device(last_associated_device);
-		throw;
-	}
+            if ((Tango::Util::_UseDb == true) && (att_in_db.empty() == false))
+            {
+                try
+                {
+                    static_cast<Device_3Impl *>(this)->write_attributes_in_db(att_in_db, updated_attr);
+                }
+                catch (Tango::DevFailed &e)
+                {
+                    Except::re_throw_exception(e, (const char *) API_AttrNotAllowed,
+                                               (const char *) "Failed to store memorized attribute value in db",
+                                               (const char *) "Device_Impl::write_attributes");
+                }
+            }
+        }
+    }
+    catch (...)
+    {
+        // set back the device attribution for the thread
+        // and rethrow the exception.
+        sub.set_associated_device(last_associated_device);
+        throw;
+    }
 
-	// set back the device attribution for the thread
-	sub.set_associated_device(last_associated_device);
+    // set back the device attribution for the thread
+    sub.set_associated_device(last_associated_device);
 
 //
 // Return to caller.
 //
 
-	cout4 << "Leaving DeviceImpl::write_attributes" << endl;
+    cout4 << "Leaving DeviceImpl::write_attributes" << endl;
 }
 
 
@@ -3096,10 +3102,10 @@ void DeviceImpl::add_attribute(Tango::Attr *new_attr)
 // Take the device monitor in order to protect the attribute list
 //
 
-	AutoTangoMonitor sync(this,true);
+    AutoTangoMonitor sync(this, true);
 
-	vector<Tango::Attr *> &attr_list = device_class->get_class_attr()->get_attr_list();
-	long old_attr_nb = attr_list.size();
+    vector<Tango::Attr *> &attr_list = device_class->get_class_attr()->get_attr_list();
+    long old_attr_nb = attr_list.size();
 
 //
 // Check that this attribute is not already defined for this device. If it is already there, immediately returns.
@@ -3107,136 +3113,138 @@ void DeviceImpl::add_attribute(Tango::Attr *new_attr)
 // Therefore, all devices created after this attribute addition will also have this attribute.
 //
 
-	string &attr_name = new_attr->get_name();
-	bool already_there = true;
-	bool throw_ex = false;
-	try
-	{
-		Tango::Attribute &al_attr = dev_attr->get_attr_by_name(attr_name.c_str());
-		if ((al_attr.get_data_type() != new_attr->get_type()) ||
-		    (al_attr.get_data_format() != new_attr->get_format()) ||
-		    (al_attr.get_writable() != new_attr->get_writable()))
-		{
-			throw_ex = true;
-		}
-	}
-	catch (Tango::DevFailed &)
-	{
-		already_there = false;
-	}
+    string &attr_name = new_attr->get_name();
+    bool already_there = true;
+    bool throw_ex = false;
+    try
+    {
+        Tango::Attribute &al_attr = dev_attr->get_attr_by_name(attr_name.c_str());
+        if ((al_attr.get_data_type() != new_attr->get_type()) ||
+            (al_attr.get_data_format() != new_attr->get_format()) ||
+            (al_attr.get_writable() != new_attr->get_writable()))
+        {
+            throw_ex = true;
+        }
+    }
+    catch (Tango::DevFailed &)
+    {
+        already_there = false;
+    }
 
 //
 // Throw exception if the device already have an attribute with the same name but with a different definition
 //
 
-	if (throw_ex == true)
-	{
-		TangoSys_OMemStream o;
+    if (throw_ex == true)
+    {
+        TangoSys_OMemStream o;
 
-		o << "Device " << get_name() << " -> Attribute " << attr_name << " already exists for your device but with other definition";
-		o << "\n(data type, data format or data write type)" << ends;
+        o << "Device " << get_name() << " -> Attribute " << attr_name
+          << " already exists for your device but with other definition";
+        o << "\n(data type, data format or data write type)" << ends;
 
-		Except::throw_exception((const char *)API_AttrNotFound,
-				o.str(),
-				(const char *)"DeviceImpl::add_attribute");
-	}
+        Except::throw_exception((const char *) API_AttrNotFound,
+                                o.str(),
+                                (const char *) "DeviceImpl::add_attribute");
+    }
 
-	if (already_there == true)
-	{
-		delete new_attr;
-		return;
-	}
+    if (already_there == true)
+    {
+        delete new_attr;
+        return;
+    }
 
 //
 // If device is IDL 5 or more and if enabled, and if there is some client(s) listening on the device interface
 // change event, get device interface.
 //
 
-	ZmqEventSupplier *event_supplier_zmq = Util::instance()->get_zmq_event_supplier();
-	bool ev_client = event_supplier_zmq->any_dev_intr_client(this);
+    ZmqEventSupplier *event_supplier_zmq = Util::instance()->get_zmq_event_supplier();
+    bool ev_client = event_supplier_zmq->any_dev_intr_client(this);
 
-	if (idl_version >= MIN_IDL_DEV_INTR && is_intr_change_ev_enable() == true)
-	{
-		if (ev_client == true)
-		{
-			bool th_running;
-			{
-				omni_mutex_lock lo(devintr_mon);
-				th_running = devintr_shared.th_running;
-			}
+    if (idl_version >= MIN_IDL_DEV_INTR && is_intr_change_ev_enable() == true)
+    {
+        if (ev_client == true)
+        {
+            bool th_running;
+            {
+                omni_mutex_lock lo(devintr_mon);
+                th_running = devintr_shared.th_running;
+            }
 
-			if (th_running == false)
-				devintr_shared.interface.get_interface(this);
-		}
-	}
+            if (th_running == false)
+                devintr_shared.interface.get_interface(this);
+        }
+    }
 
 //
 // Add this attribute in the MultiClassAttribute attr_list vector if it does not already exist
 //
 
-	bool need_free = false;
-	long i;
+    bool need_free = false;
+    long i;
 
-	for (i = 0;i < old_attr_nb;i++)
-	{
-		if ((attr_list[i]->get_name() == attr_name) && (attr_list[i]->get_cl_name() == new_attr->get_cl_name()))
-		{
-			need_free = true;
-			break;
-		}
-	}
+    for (i = 0; i < old_attr_nb; i++)
+    {
+        if ((attr_list[i]->get_name() == attr_name) && (attr_list[i]->get_cl_name() == new_attr->get_cl_name()))
+        {
+            need_free = true;
+            break;
+        }
+    }
 
-	if (i == old_attr_nb)
-	{
-		attr_list.push_back(new_attr);
+    if (i == old_attr_nb)
+    {
+        attr_list.push_back(new_attr);
 
 //
 // Get all the properties defined for this attribute at class level
 //
 
-		device_class->get_class_attr()->init_class_attribute(
-						device_class->get_name(),
-						old_attr_nb);
-	}
-	else
-	{
+        device_class->get_class_attr()->init_class_attribute(
+            device_class->get_name(),
+            old_attr_nb);
+    }
+    else
+    {
 
 //
 // An attribute with the same name is already defined within the class. Check if the data type, data format and
 // write type are the same
 //
 
-		if ((attr_list[i]->get_type() != new_attr->get_type()) ||
-		    (attr_list[i]->get_format() != new_attr->get_format()) ||
-		    (attr_list[i]->get_writable() != new_attr->get_writable()))
-		{
-			TangoSys_OMemStream o;
+        if ((attr_list[i]->get_type() != new_attr->get_type()) ||
+            (attr_list[i]->get_format() != new_attr->get_format()) ||
+            (attr_list[i]->get_writable() != new_attr->get_writable()))
+        {
+            TangoSys_OMemStream o;
 
-			o << "Device " << get_name() << " -> Attribute " << attr_name << " already exists for your device class but with other definition";
-			o << "\n(data type, data format or data write type)" << ends;
+            o << "Device " << get_name() << " -> Attribute " << attr_name
+              << " already exists for your device class but with other definition";
+            o << "\n(data type, data format or data write type)" << ends;
 
-			Except::throw_exception((const char *)API_AttrNotFound,
-					o.str(),
-					(const char *)"DeviceImpl::add_attribute");
-		}
-	}
+            Except::throw_exception((const char *) API_AttrNotFound,
+                                    o.str(),
+                                    (const char *) "DeviceImpl::add_attribute");
+        }
+    }
 
 //
 // Add the attribute to the MultiAttribute object
 //
 
-	if (new_attr->is_fwd() == true)
-	{
-		dev_attr->add_fwd_attribute(device_name,device_class,i,new_attr);
-	}
-	else
-		dev_attr->add_attribute(device_name,device_class,i);
+    if (new_attr->is_fwd() == true)
+    {
+        dev_attr->add_fwd_attribute(device_name, device_class, i, new_attr);
+    }
+    else
+        dev_attr->add_attribute(device_name, device_class, i);
 
 //
 // Eventually start or update device interface change event thread
 //
 
-	push_dev_intr(ev_client);
+    push_dev_intr(ev_client);
 
 //
 // If attribute has to be polled (set by Pogo), start polling now
@@ -3245,14 +3253,14 @@ void DeviceImpl::add_attribute(Tango::Attr *new_attr)
     long per = new_attr->get_polling_period();
     Tango::Util *tg = Tango::Util::instance();
     if (tg->is_svr_starting() == false && per != 0)
-        poll_attribute(attr_name,per);
+        poll_attribute(attr_name, per);
 
 //
 // Free memory if needed
 //
 
-	if (need_free == true)
-		delete new_attr;
+    if (need_free == true)
+        delete new_attr;
 
 }
 
@@ -3273,99 +3281,99 @@ void DeviceImpl::add_attribute(Tango::Attr *new_attr)
 //
 //-------------------------------------------------------------------------------------------------------------------
 
-void DeviceImpl::remove_attribute(Tango::Attr *rem_attr, bool free_it,bool clean_db)
+void DeviceImpl::remove_attribute(Tango::Attr *rem_attr, bool free_it, bool clean_db)
 {
 
 //
 // Take the device monitor in order to protect the attribute list
 //
 
-	AutoTangoMonitor sync(this,true);
+    AutoTangoMonitor sync(this, true);
 
 //
 // Check that the class support this attribute
 //
 
-	string &attr_name = rem_attr->get_name();
+    string &attr_name = rem_attr->get_name();
 
-	try
-	{
-		dev_attr->get_attr_by_name(attr_name.c_str());
-	}
-	catch (Tango::DevFailed &)
-	{
-		TangoSys_OMemStream o;
+    try
+    {
+        dev_attr->get_attr_by_name(attr_name.c_str());
+    }
+    catch (Tango::DevFailed &)
+    {
+        TangoSys_OMemStream o;
 
-		o << "Attribute " << attr_name << " is not defined as attribute for your device.";
-		o << "\nCan't remove it" << ends;
+        o << "Attribute " << attr_name << " is not defined as attribute for your device.";
+        o << "\nCan't remove it" << ends;
 
-		Except::throw_exception((const char *)API_AttrNotFound,
-					o.str(),
-					(const char *)"DeviceImpl::remove_attribute");
-	}
+        Except::throw_exception((const char *) API_AttrNotFound,
+                                o.str(),
+                                (const char *) "DeviceImpl::remove_attribute");
+    }
 
 //
 // If device is IDL 5 or more and if enabled, and if there is some client(s) listening on the device interface
 // change event, get device interface.
 //
 
-	ZmqEventSupplier *event_supplier_zmq = Util::instance()->get_zmq_event_supplier();
-	bool ev_client = event_supplier_zmq->any_dev_intr_client(this);
+    ZmqEventSupplier *event_supplier_zmq = Util::instance()->get_zmq_event_supplier();
+    bool ev_client = event_supplier_zmq->any_dev_intr_client(this);
 
-	if (idl_version >= MIN_IDL_DEV_INTR && is_intr_change_ev_enable() == true)
-	{
-		if (ev_client == true)
-		{
-			bool th_running;
-			{
-				omni_mutex_lock lo(devintr_mon);
-				th_running = devintr_shared.th_running;
-			}
+    if (idl_version >= MIN_IDL_DEV_INTR && is_intr_change_ev_enable() == true)
+    {
+        if (ev_client == true)
+        {
+            bool th_running;
+            {
+                omni_mutex_lock lo(devintr_mon);
+                th_running = devintr_shared.th_running;
+            }
 
-			if (th_running == false)
-				devintr_shared.interface.get_interface(this);
-		}
-	}
+            if (th_running == false)
+                devintr_shared.interface.get_interface(this);
+        }
+    }
 
 //
 // stop any configured polling for this attribute first!
 //
 
-	vector<string> &poll_attr = get_polled_attr();
-	vector<string>::iterator ite_attr;
+    vector<string> &poll_attr = get_polled_attr();
+    vector<string>::iterator ite_attr;
 
-	string  attr_name_low(attr_name);
-	transform(attr_name_low.begin(),attr_name_low.end(),attr_name_low.begin(),::tolower);
+    string attr_name_low(attr_name);
+    transform(attr_name_low.begin(), attr_name_low.end(), attr_name_low.begin(), ::tolower);
 
 //
 // Try to find the attribute in the list of polled attributes
 //
 
-	Tango::Util *tg = Tango::Util::instance();
-	ite_attr = find(poll_attr.begin(),poll_attr.end(), attr_name_low);
-	if (ite_attr != poll_attr.end())
-	{
-		// stop the polling and clean-up the database
+    Tango::Util *tg = Tango::Util::instance();
+    ite_attr = find(poll_attr.begin(), poll_attr.end(), attr_name_low);
+    if (ite_attr != poll_attr.end())
+    {
+        // stop the polling and clean-up the database
 
-		DServer *adm_dev = tg->get_dserver_device();
+        DServer *adm_dev = tg->get_dserver_device();
 
-		DevVarStringArray send;
-		send.length(3);
+        DevVarStringArray send;
+        send.length(3);
 
-		send[0] = CORBA::string_dup(device_name.c_str());
-		send[1] = CORBA::string_dup("attribute");
-		send[2] = CORBA::string_dup(attr_name.c_str());
+        send[0] = CORBA::string_dup(device_name.c_str());
+        send[1] = CORBA::string_dup("attribute");
+        send[2] = CORBA::string_dup(attr_name.c_str());
 
-		if (tg->is_svr_shutting_down() == true)
-		{
+        if (tg->is_svr_shutting_down() == true)
+        {
 
 //
 // There is no need to stop the polling because we are in the server shutdown sequence and the polling is
 // already stopped.
 //
 
-			if (clean_db == true && Tango::Util::_UseDb == true)
-			{
+            if (clean_db == true && Tango::Util::_UseDb == true)
+            {
 
 //
 // Memorize the fact that the dynamic polling properties has to be removed from db.
@@ -3378,14 +3386,14 @@ void DeviceImpl::remove_attribute(Tango::Attr *rem_attr, bool free_it,bool clean
                     tg->get_full_polled_att_list() = poll_attr;
                     tg->get_dyn_att_dev_name() = device_name;
                 }
-			}
-		}
-		else
-		{
-			if (tg->is_device_restarting(get_name()) == false)
-				adm_dev->rem_obj_polling(&send, clean_db);
-		}
-	}
+            }
+        }
+        else
+        {
+            if (tg->is_device_restarting(get_name()) == false)
+                adm_dev->rem_obj_polling(&send, clean_db);
+        }
+    }
 
 //
 // Now remove all configured attribute properties from the database. Do it in one go if the Db server support this
@@ -3412,57 +3420,57 @@ void DeviceImpl::remove_attribute(Tango::Attr *rem_attr, bool free_it,bool clean
 // in this class with this attribute
 //
 
-	bool update_idx = false;
-	unsigned long nb_dev = device_class->get_device_list().size();
+    bool update_idx = false;
+    unsigned long nb_dev = device_class->get_device_list().size();
 
-	if (nb_dev <= 1)
-	{
-		device_class->get_class_attr()->remove_attr(attr_name,rem_attr->get_cl_name());
-		update_idx = true;
-	}
-	else
-	{
-		vector<Tango::DeviceImpl *> dev_list = device_class->get_device_list();
-		unsigned long nb_except = 0;
-		for (unsigned long i = 0;i < nb_dev;i++)
-		{
-			try
-			{
-				Attribute &att = dev_list[i]->get_device_attr()->get_attr_by_name(attr_name.c_str());
-				vector<Tango::Attr *> &attr_list = device_class->get_class_attr()->get_attr_list();
-				if (attr_list[att.get_attr_idx()]->get_cl_name() != rem_attr->get_cl_name())
-					nb_except++;
-			}
-			catch (Tango::DevFailed &)
-			{
-				nb_except++;
-			}
-		}
-		if (nb_except == (nb_dev - 1))
-		{
-			device_class->get_class_attr()->remove_attr(attr_name,rem_attr->get_cl_name());
-			update_idx = true;
-		}
-	}
+    if (nb_dev <= 1)
+    {
+        device_class->get_class_attr()->remove_attr(attr_name, rem_attr->get_cl_name());
+        update_idx = true;
+    }
+    else
+    {
+        vector<Tango::DeviceImpl *> dev_list = device_class->get_device_list();
+        unsigned long nb_except = 0;
+        for (unsigned long i = 0; i < nb_dev; i++)
+        {
+            try
+            {
+                Attribute &att = dev_list[i]->get_device_attr()->get_attr_by_name(attr_name.c_str());
+                vector<Tango::Attr *> &attr_list = device_class->get_class_attr()->get_attr_list();
+                if (attr_list[att.get_attr_idx()]->get_cl_name() != rem_attr->get_cl_name())
+                    nb_except++;
+            }
+            catch (Tango::DevFailed &)
+            {
+                nb_except++;
+            }
+        }
+        if (nb_except == (nb_dev - 1))
+        {
+            device_class->get_class_attr()->remove_attr(attr_name, rem_attr->get_cl_name());
+            update_idx = true;
+        }
+    }
 
 //
 // Now, remove the attribute from the MultiAttribute object
 //
 
-	dev_attr->remove_attribute(attr_name,update_idx);
+    dev_attr->remove_attribute(attr_name, update_idx);
 
 //
 // Delete Attr object if wanted
 //
 
-	if ((free_it == true) && (update_idx == true))
-		delete rem_attr;
+    if ((free_it == true) && (update_idx == true))
+        delete rem_attr;
 
 //
 // Eventually start or update device interface change event thread
 //
 
-	push_dev_intr(ev_client);
+    push_dev_intr(ev_client);
 
 }
 
@@ -3482,25 +3490,25 @@ void DeviceImpl::remove_attribute(Tango::Attr *rem_attr, bool free_it,bool clean
 //
 //------------------------------------------------------------------------------------------------------------------
 
-void DeviceImpl::remove_attribute(string &rem_attr_name, bool free_it,bool clean_db)
+void DeviceImpl::remove_attribute(string &rem_attr_name, bool free_it, bool clean_db)
 {
 
-	try
-	{
-		Attr &att = device_class->get_class_attr()->get_attr(rem_attr_name);
-		remove_attribute(&att,free_it,clean_db);
-	}
-	catch (Tango::DevFailed &e)
-	{
-		TangoSys_OMemStream o;
+    try
+    {
+        Attr &att = device_class->get_class_attr()->get_attr(rem_attr_name);
+        remove_attribute(&att, free_it, clean_db);
+    }
+    catch (Tango::DevFailed &e)
+    {
+        TangoSys_OMemStream o;
 
-		o << "Attribute " << rem_attr_name << " is not defined as attribute for your device.";
-		o << "\nCan't remove it" << ends;
+        o << "Attribute " << rem_attr_name << " is not defined as attribute for your device.";
+        o << "\nCan't remove it" << ends;
 
-		Except::re_throw_exception(e,(const char *)API_AttrNotFound,
-					o.str(),
-					(const char *)"DeviceImpl::remove_attribute");
-	}
+        Except::re_throw_exception(e, (const char *) API_AttrNotFound,
+                                   o.str(),
+                                   (const char *) "DeviceImpl::remove_attribute");
+    }
 
 }
 
@@ -3519,116 +3527,117 @@ void DeviceImpl::remove_attribute(string &rem_attr_name, bool free_it,bool clean
 //
 //--------------------------------------------------------------------------------------------------------------------
 
-void DeviceImpl::add_command(Tango::Command *new_cmd,bool device_level)
+void DeviceImpl::add_command(Tango::Command *new_cmd, bool device_level)
 {
 //
 // Take the device monitor in order to protect the command list
 //
 
-	AutoTangoMonitor sync(this,true);
+    AutoTangoMonitor sync(this, true);
 
 //
 // Check that this command is not already defined for this device. If it is already there, immediately returns.
 //
 
-	string &cmd_name = new_cmd->get_name();
-	bool already_there = true;
-	bool throw_ex = false;
-	try
-	{
-		Tango::Command &al_cmd = device_class->get_cmd_by_name(cmd_name);
-		if ((al_cmd.get_in_type() != new_cmd->get_in_type()) ||
-		    (al_cmd.get_out_type() != new_cmd->get_out_type()))
-		{
-			throw_ex = true;
-		}
-	}
-	catch (Tango::DevFailed &)
-	{
-		already_there = false;
-	}
+    string &cmd_name = new_cmd->get_name();
+    bool already_there = true;
+    bool throw_ex = false;
+    try
+    {
+        Tango::Command &al_cmd = device_class->get_cmd_by_name(cmd_name);
+        if ((al_cmd.get_in_type() != new_cmd->get_in_type()) ||
+            (al_cmd.get_out_type() != new_cmd->get_out_type()))
+        {
+            throw_ex = true;
+        }
+    }
+    catch (Tango::DevFailed &)
+    {
+        already_there = false;
+    }
 
-	if (already_there == false)
-	{
-		already_there = true;
-		try
-		{
-			Tango::Command &al_cmd_dev = get_local_cmd_by_name(cmd_name);
-			if ((al_cmd_dev.get_in_type() != new_cmd->get_in_type()) ||
-				(al_cmd_dev.get_out_type() != new_cmd->get_out_type()))
-			{
-				throw_ex = true;
-			}
-		}
-		catch (Tango::DevFailed &)
-		{
-			already_there = false;
-		}
-	}
+    if (already_there == false)
+    {
+        already_there = true;
+        try
+        {
+            Tango::Command &al_cmd_dev = get_local_cmd_by_name(cmd_name);
+            if ((al_cmd_dev.get_in_type() != new_cmd->get_in_type()) ||
+                (al_cmd_dev.get_out_type() != new_cmd->get_out_type()))
+            {
+                throw_ex = true;
+            }
+        }
+        catch (Tango::DevFailed &)
+        {
+            already_there = false;
+        }
+    }
 
 //
 // Throw exception if the device already have a command with the same name but with a different definition
 //
 
-	if (throw_ex == true)
-	{
-		TangoSys_OMemStream o;
+    if (throw_ex == true)
+    {
+        TangoSys_OMemStream o;
 
-		o << "Device " << get_name() << " -> Command " << cmd_name << " already exists for your device but with other definition";
-		o << "\n(command input data type or command output data type)" << ends;
+        o << "Device " << get_name() << " -> Command " << cmd_name
+          << " already exists for your device but with other definition";
+        o << "\n(command input data type or command output data type)" << ends;
 
-		Except::throw_exception(API_CommandNotFound,o.str(),"DeviceImpl::add_command");
-	}
+        Except::throw_exception(API_CommandNotFound, o.str(), "DeviceImpl::add_command");
+    }
 
-	if (already_there == true)
-	{
-		delete new_cmd;
-		return;
-	}
+    if (already_there == true)
+    {
+        delete new_cmd;
+        return;
+    }
 
 //
 // If device is IDL 5 or more and if enabled, and if there is some client(s) listening on the device interface
 // change event, get device interface.
 //
 
-	ZmqEventSupplier *event_supplier_zmq = Util::instance()->get_zmq_event_supplier();
-	bool ev_client = event_supplier_zmq->any_dev_intr_client(this);
+    ZmqEventSupplier *event_supplier_zmq = Util::instance()->get_zmq_event_supplier();
+    bool ev_client = event_supplier_zmq->any_dev_intr_client(this);
 
-	if (idl_version >= MIN_IDL_DEV_INTR && is_intr_change_ev_enable() == true)
-	{
-		if (ev_client == true)
-		{
-			bool th_running;
-			{
-				omni_mutex_lock lo(devintr_mon);
-				th_running = devintr_shared.th_running;
-			}
+    if (idl_version >= MIN_IDL_DEV_INTR && is_intr_change_ev_enable() == true)
+    {
+        if (ev_client == true)
+        {
+            bool th_running;
+            {
+                omni_mutex_lock lo(devintr_mon);
+                th_running = devintr_shared.th_running;
+            }
 
-			if (th_running == false)
-				devintr_shared.interface.get_interface(this);
-		}
-	}
+            if (th_running == false)
+                devintr_shared.interface.get_interface(this);
+        }
+    }
 
 //
 // Add this command to the command list
 //
 
-	if (device_level == false)
-	{
-		vector<Tango::Command *> &cmd_list = device_class->get_command_list();
-		cmd_list.push_back(new_cmd);
-	}
-	else
-	{
-		vector<Tango::Command *> &dev_cmd_list = get_local_command_list();
-		dev_cmd_list.push_back(new_cmd);
-	}
+    if (device_level == false)
+    {
+        vector<Tango::Command *> &cmd_list = device_class->get_command_list();
+        cmd_list.push_back(new_cmd);
+    }
+    else
+    {
+        vector<Tango::Command *> &dev_cmd_list = get_local_command_list();
+        dev_cmd_list.push_back(new_cmd);
+    }
 
 //
 // Eventually start or update device interface change event thread
 //
 
-	push_dev_intr(ev_client);
+    push_dev_intr(ev_client);
 }
 
 //+------------------------------------------------------------------------------------------------------------------
@@ -3647,106 +3656,106 @@ void DeviceImpl::add_command(Tango::Command *new_cmd,bool device_level)
 //
 //-------------------------------------------------------------------------------------------------------------------
 
-void DeviceImpl::remove_command(Tango::Command *rem_cmd, bool free_it,bool clean_db)
+void DeviceImpl::remove_command(Tango::Command *rem_cmd, bool free_it, bool clean_db)
 {
 
 //
 // Take the device monitor in order to protect the command list
 //
 
-	AutoTangoMonitor sync(this,true);
+    AutoTangoMonitor sync(this, true);
 
 //
 // Check that the class or the device support this command
 //
 
-	string &cmd_name = rem_cmd->get_name();
-	bool device_cmd = false;
+    string &cmd_name = rem_cmd->get_name();
+    bool device_cmd = false;
 
-	try
-	{
-		device_class->get_cmd_by_name(cmd_name);
-	}
-	catch (Tango::DevFailed &)
-	{
-		try
-		{
-			get_local_cmd_by_name(cmd_name);
-			device_cmd = true;
-		}
-		catch (Tango::DevFailed &)
-		{
-			TangoSys_OMemStream o;
+    try
+    {
+        device_class->get_cmd_by_name(cmd_name);
+    }
+    catch (Tango::DevFailed &)
+    {
+        try
+        {
+            get_local_cmd_by_name(cmd_name);
+            device_cmd = true;
+        }
+        catch (Tango::DevFailed &)
+        {
+            TangoSys_OMemStream o;
 
-			o << "Command " << cmd_name << " is not defined as command for your device.";
-			o << "\nCan't remove it" << ends;
+            o << "Command " << cmd_name << " is not defined as command for your device.";
+            o << "\nCan't remove it" << ends;
 
-			Except::throw_exception(API_CommandNotFound,o.str(),"DeviceImpl::remove_command");
-		}
-	}
+            Except::throw_exception(API_CommandNotFound, o.str(), "DeviceImpl::remove_command");
+        }
+    }
 
 //
 // If device is IDL 5 or more and if enabled, and if there is some client(s) listening on the device interface
 // change event, get device interface.
 //
 
-	ZmqEventSupplier *event_supplier_zmq = Util::instance()->get_zmq_event_supplier();
-	bool ev_client = event_supplier_zmq->any_dev_intr_client(this);
+    ZmqEventSupplier *event_supplier_zmq = Util::instance()->get_zmq_event_supplier();
+    bool ev_client = event_supplier_zmq->any_dev_intr_client(this);
 
-	if (idl_version >= MIN_IDL_DEV_INTR && is_intr_change_ev_enable() == true)
-	{
-		if (ev_client == true)
-		{
-			bool th_running;
-			{
-				omni_mutex_lock lo(devintr_mon);
-				th_running = devintr_shared.th_running;
-			}
+    if (idl_version >= MIN_IDL_DEV_INTR && is_intr_change_ev_enable() == true)
+    {
+        if (ev_client == true)
+        {
+            bool th_running;
+            {
+                omni_mutex_lock lo(devintr_mon);
+                th_running = devintr_shared.th_running;
+            }
 
-			if (th_running == false)
-				devintr_shared.interface.get_interface(this);
-		}
-	}
+            if (th_running == false)
+                devintr_shared.interface.get_interface(this);
+        }
+    }
 
 //
 // stop any configured polling for this command first!
 //
 
-	vector<string> &poll_cmd = get_polled_cmd();
-	vector<string>::iterator ite_cmd;
+    vector<string> &poll_cmd = get_polled_cmd();
+    vector<string>::iterator ite_cmd;
 
-	string cmd_name_low(cmd_name);
-	transform(cmd_name_low.begin(),cmd_name_low.end(),cmd_name_low.begin(),::tolower);
+    string cmd_name_low(cmd_name);
+    transform(cmd_name_low.begin(), cmd_name_low.end(), cmd_name_low.begin(), ::tolower);
 
 //
 // Try to find the command in the list of polled commands
 //
 
-	Tango::Util *tg = Tango::Util::instance();
-	ite_cmd = find(poll_cmd.begin(),poll_cmd.end(), cmd_name_low);
-	if (ite_cmd != poll_cmd.end())
-	{
-		// stop the polling and clean-up the database
+    Tango::Util *tg = Tango::Util::instance();
+    ite_cmd = find(poll_cmd.begin(), poll_cmd.end(), cmd_name_low);
+    if (ite_cmd != poll_cmd.end())
+    {
+        // stop the polling and clean-up the database
 
-		DServer *adm_dev = tg->get_dserver_device();
+        DServer *adm_dev = tg->get_dserver_device();
 
-		DevVarStringArray send;
-		send.length(3);
+        DevVarStringArray send;
+        send.length(3);
 
-		send[0] = CORBA::string_dup(device_name.c_str());
-		send[1] = CORBA::string_dup("command");
-		send[2] = CORBA::string_dup(cmd_name.c_str());
+        send[0] = CORBA::string_dup(device_name.c_str());
+        send[1] = CORBA::string_dup("command");
+        send[2] = CORBA::string_dup(cmd_name.c_str());
 
-		if (tg->is_svr_shutting_down() == true)
-		{
+        if (tg->is_svr_shutting_down() == true)
+        {
 
 //
 // There is no need to stop the polling because we are in the server shutdown sequence and the polling is
 // already stopped.
 //
 
-			if (clean_db == true && Tango::Util::_UseDb == true)
-			{
+            if (clean_db == true && Tango::Util::_UseDb == true)
+            {
 
 //
 // Memorize the fact that the dynamic polling properties has to be removed from db.
@@ -3758,36 +3767,36 @@ void DeviceImpl::remove_command(Tango::Command *rem_cmd, bool free_it,bool clean
                     tg->get_full_polled_cmd_list() = poll_cmd;
                     tg->get_dyn_cmd_dev_name() = device_name;
                 }
-			}
-		}
-		else
-		{
-			if (tg->is_device_restarting(get_name()) == false)
-				adm_dev->rem_obj_polling(&send,clean_db);
-		}
-	}
+            }
+        }
+        else
+        {
+            if (tg->is_device_restarting(get_name()) == false)
+                adm_dev->rem_obj_polling(&send, clean_db);
+        }
+    }
 
 //
 // Now, remove the command from the command list
 //
 
-	if (device_cmd == false)
-		device_class->remove_command(cmd_name_low);
-	else
-		remove_local_command(cmd_name_low);
+    if (device_cmd == false)
+        device_class->remove_command(cmd_name_low);
+    else
+        remove_local_command(cmd_name_low);
 
 //
 // Delete Command object if wanted
 //
 
-	if (free_it == true)
-		delete rem_cmd;
+    if (free_it == true)
+        delete rem_cmd;
 
 //
 // Eventually start or update device interface change event thread
 //
 
-	push_dev_intr(ev_client);
+    push_dev_intr(ev_client);
 }
 
 //+-----------------------------------------------------------------------------------------------------------------
@@ -3806,35 +3815,35 @@ void DeviceImpl::remove_command(Tango::Command *rem_cmd, bool free_it,bool clean
 //
 //------------------------------------------------------------------------------------------------------------------
 
-void DeviceImpl::remove_command(const string &rem_cmd_name, bool free_it,bool clean_db)
+void DeviceImpl::remove_command(const string &rem_cmd_name, bool free_it, bool clean_db)
 {
 
 //
 // Search for command first at class level and then at device level (for dynamic cmd)
 //
 
-	try
-	{
-		Command &cmd = device_class->get_cmd_by_name(rem_cmd_name);
-		remove_command(&cmd,free_it,clean_db);
-	}
-	catch (Tango::DevFailed &e)
-	{
-		try
-		{
-			Command &cmd = get_local_cmd_by_name(rem_cmd_name);
-			remove_command(&cmd,free_it,clean_db);
-		}
-		catch (Tango::DevFailed &e)
-		{
-			TangoSys_OMemStream o;
+    try
+    {
+        Command &cmd = device_class->get_cmd_by_name(rem_cmd_name);
+        remove_command(&cmd, free_it, clean_db);
+    }
+    catch (Tango::DevFailed &e)
+    {
+        try
+        {
+            Command &cmd = get_local_cmd_by_name(rem_cmd_name);
+            remove_command(&cmd, free_it, clean_db);
+        }
+        catch (Tango::DevFailed &e)
+        {
+            TangoSys_OMemStream o;
 
-			o << "Command " << rem_cmd_name << " is not defined as a command for your device.";
-			o << "\nCan't remove it" << ends;
+            o << "Command " << rem_cmd_name << " is not defined as a command for your device.";
+            o << "\nCan't remove it" << ends;
 
-			Except::re_throw_exception(e,API_CommandNotFound,o.str(),"DeviceImpl::remove_command");
-		}
-	}
+            Except::re_throw_exception(e, API_CommandNotFound, o.str(), "DeviceImpl::remove_command");
+        }
+    }
 
 }
 
@@ -3851,58 +3860,58 @@ void DeviceImpl::remove_command(const string &rem_cmd_name, bool free_it,bool cl
 
 void DeviceImpl::poll_lists_2_v5()
 {
-	bool db_update = false;
+    bool db_update = false;
 
-	vector<string> &poll_cmd = get_polled_cmd();
-	vector<string> &poll_attr = get_polled_attr();
+    vector<string> &poll_cmd = get_polled_cmd();
+    vector<string> &poll_attr = get_polled_attr();
 
-	vector<string>::iterator ite_state;
-	vector<string>::iterator ite_status;
+    vector<string>::iterator ite_state;
+    vector<string>::iterator ite_status;
 
 //
 // Try to find state in list of polled command(s). If found, remove it from poll cmd and move it to poll attr
 //
 
-	ite_state = find(poll_cmd.begin(),poll_cmd.end(),"state");
-	if (ite_state != poll_cmd.end())
-	{
-		poll_attr.push_back(*ite_state);
-		poll_attr.push_back(*(ite_state + 1));
-		poll_cmd.erase(ite_state,ite_state + 2);
-		db_update = true;
-	}
+    ite_state = find(poll_cmd.begin(), poll_cmd.end(), "state");
+    if (ite_state != poll_cmd.end())
+    {
+        poll_attr.push_back(*ite_state);
+        poll_attr.push_back(*(ite_state + 1));
+        poll_cmd.erase(ite_state, ite_state + 2);
+        db_update = true;
+    }
 
 //
 // The same for status
 //
 
-	ite_status = find(poll_cmd.begin(),poll_cmd.end(),"status");
-	if (ite_status != poll_cmd.end())
-	{
-		poll_attr.push_back(*ite_status);
-		poll_attr.push_back(*(ite_status + 1));
-		poll_cmd.erase(ite_status,ite_status + 2);
-		db_update = true;
-	}
+    ite_status = find(poll_cmd.begin(), poll_cmd.end(), "status");
+    if (ite_status != poll_cmd.end())
+    {
+        poll_attr.push_back(*ite_status);
+        poll_attr.push_back(*(ite_status + 1));
+        poll_cmd.erase(ite_status, ite_status + 2);
+        db_update = true;
+    }
 
 //
 // Now update database if needed
 //
 
-	if (db_update == true)
-	{
-		DbDatum p_cmd("polled_cmd");
-		DbDatum p_attr("polled_attr");
+    if (db_update == true)
+    {
+        DbDatum p_cmd("polled_cmd");
+        DbDatum p_attr("polled_attr");
 
-		p_cmd << poll_cmd;
-		p_attr << poll_attr;
+        p_cmd << poll_cmd;
+        p_attr << poll_attr;
 
-		DbData db_data;
-		db_data.push_back(p_cmd);
-		db_data.push_back(p_attr);
+        DbData db_data;
+        db_data.push_back(p_cmd);
+        db_data.push_back(p_attr);
 
-		get_db_device()->put_property(db_data);
-	}
+        get_db_device()->put_property(db_data);
+    }
 
 }
 
@@ -3924,71 +3933,71 @@ void DeviceImpl::poll_lists_2_v5()
 
 void DeviceImpl::init_cmd_poll_ext_trig(string cmd_name)
 {
-	string  cmd_lowercase(cmd_name);
-   	transform(cmd_lowercase.begin(),cmd_lowercase.end(),cmd_lowercase.begin(),::tolower);
+    string cmd_lowercase(cmd_name);
+    transform(cmd_lowercase.begin(), cmd_lowercase.end(), cmd_lowercase.begin(), ::tolower);
 
 //
 // never do the for the state or status commands, they are handled as attributes!
 //
 
-	if ( cmd_name == "state" || cmd_name == "status" )
-	{
-		TangoSys_OMemStream o;
+    if (cmd_name == "state" || cmd_name == "status")
+    {
+        TangoSys_OMemStream o;
 
-		o << "State and status are handled as attributes for the polling" << ends;
-		Except::throw_exception((const char *)API_CommandNotFound,
-				      o.str(),
-				      (const char *)"DeviceImpl::init_poll_ext_trig");
-	}
+        o << "State and status are handled as attributes for the polling" << ends;
+        Except::throw_exception((const char *) API_CommandNotFound,
+                                o.str(),
+                                (const char *) "DeviceImpl::init_poll_ext_trig");
+    }
 
 //
 // check whether the command exists for the device and can be polled
 //
 
-	check_command_exists (cmd_lowercase);
+    check_command_exists(cmd_lowercase);
 
 //
 // check wether the database is used
 //
 
-	Tango::Util *tg = Tango::Util::instance();
-	if ( tg->_UseDb == true )
-	{
-		vector <string> &poll_list = get_polled_cmd();
-		Tango::DbData poll_data;
-		bool found = false;
+    Tango::Util *tg = Tango::Util::instance();
+    if (tg->_UseDb == true)
+    {
+        vector<string> &poll_list = get_polled_cmd();
+        Tango::DbData poll_data;
+        bool found = false;
 
-		poll_data.push_back(Tango::DbDatum("polled_cmd"));
+        poll_data.push_back(Tango::DbDatum("polled_cmd"));
 
-		if (poll_list.empty() == false)
-		{
+        if (poll_list.empty() == false)
+        {
 
 //
 // search the attribute in the list of polled attributes
 //
 
-			for (unsigned int i = 0;i < poll_list.size();i = i+2)
-			{
-				string  name_lowercase(poll_list[i]);
-				transform(name_lowercase.begin(),name_lowercase.end(),name_lowercase.begin(),::tolower);
+            for (unsigned int i = 0; i < poll_list.size(); i = i + 2)
+            {
+                string name_lowercase(poll_list[i]);
+                transform(name_lowercase.begin(), name_lowercase.end(), name_lowercase.begin(), ::tolower);
 
-				if ( name_lowercase ==  cmd_lowercase)
-				{
-					poll_list[i+1] = "0";
-					found = true;
-				}
-			}
-		}
+                if (name_lowercase == cmd_lowercase)
+                {
+                    poll_list[i + 1] = "0";
+                    found = true;
+                }
+            }
+        }
 
-		if ( found == false )
-		{
-			poll_list.push_back (cmd_lowercase);
-			poll_list.push_back ("0");
-		}
+        if (found == false)
+        {
+            poll_list.push_back(cmd_lowercase);
+            poll_list.push_back("0");
+        }
 
-		poll_data[0] << poll_list;
-		tg->get_database()->put_device_property(device_name, poll_data);
-	}
+        poll_data[0] << poll_list;
+        tg->get_database()->put_device_property(device_name, poll_data);
+    }
 }
 
 //+--------------------------------------------------------------------------------------------------------------------
@@ -4010,99 +4019,99 @@ void DeviceImpl::init_cmd_poll_period()
 // check wether the database is used
 //
 
-	Tango::Util *tg = Tango::Util::instance();
-	if ( tg->_UseDb == true )
-	{
-		vector <string> &poll_list = get_polled_cmd();
-		Tango::DbData poll_data;
+    Tango::Util *tg = Tango::Util::instance();
+    if (tg->_UseDb == true)
+    {
+        vector<string> &poll_list = get_polled_cmd();
+        Tango::DbData poll_data;
 
-		poll_data.push_back(Tango::DbDatum("polled_cmd"));
+        poll_data.push_back(Tango::DbDatum("polled_cmd"));
 
 //
 // get the command list
 //
 
-		vector<Command *> &cmd_list = device_class->get_command_list();
+        vector<Command *> &cmd_list = device_class->get_command_list();
 
 //
 // loop over the command list
 //
 
-		unsigned long added_cmd = 0;
-		unsigned long i;
-		for (i = 0;i < cmd_list.size();i++)
-		{
-			long poll_period;
-			poll_period = cmd_list[i]->get_polling_period();
+        unsigned long added_cmd = 0;
+        unsigned long i;
+        for (i = 0; i < cmd_list.size(); i++)
+        {
+            long poll_period;
+            poll_period = cmd_list[i]->get_polling_period();
 
 //
 // check the validity of the polling period. must be longer than min polling period
 //
 
-			if ( poll_period < MIN_POLL_PERIOD )
-			{
-				continue;
-			}
+            if (poll_period < MIN_POLL_PERIOD)
+            {
+                continue;
+            }
 
 //
 // never do the for the state or status commands, they are handled as attributes!
 //
 
-			string cmd_name = cmd_list[i]->get_lower_name();
-			if ( cmd_name == "state" || cmd_name == "status" )
-			{
-				continue;
-			}
+            string cmd_name = cmd_list[i]->get_lower_name();
+            if (cmd_name == "state" || cmd_name == "status")
+            {
+                continue;
+            }
 
 //
 // Can only handle commands without input argument
 //
 
-			if (cmd_list[i]->get_in_type() != Tango::DEV_VOID)
-			{
-				continue;
-			}
+            if (cmd_list[i]->get_in_type() != Tango::DEV_VOID)
+            {
+                continue;
+            }
 
 //
 // search the command in the list of polled commands
 //
 
-			bool found = false;
-			for (unsigned int i = 0;i < poll_list.size();i = i+2)
-			{
-           		string  name_lowercase(poll_list[i]);
-            	transform(name_lowercase.begin(),name_lowercase.end(),name_lowercase.begin(),::tolower);
+            bool found = false;
+            for (unsigned int i = 0; i < poll_list.size(); i = i + 2)
+            {
+                string name_lowercase(poll_list[i]);
+                transform(name_lowercase.begin(), name_lowercase.end(), name_lowercase.begin(), ::tolower);
 
-				if ( name_lowercase == cmd_name)
-				{
-					found = true;
-					break;
-				}
-			}
+                if (name_lowercase == cmd_name)
+                {
+                    found = true;
+                    break;
+                }
+            }
 
-			if ( found == false )
-			{
-				string period_str;
-				stringstream str;
-				str << poll_period << ends;
-				str >> period_str;
+            if (found == false)
+            {
+                string period_str;
+                stringstream str;
+                str << poll_period << ends;
+                str >> period_str;
 
-				poll_list.push_back (cmd_name);
-				poll_list.push_back (period_str);
-				added_cmd++;
-			}
-		}
+                poll_list.push_back(cmd_name);
+                poll_list.push_back(period_str);
+                added_cmd++;
+            }
+        }
 
 //
 // only write to the database when a polling need to be added
 //
 
-		if ( added_cmd > 0 )
-		{
-			poll_data[0] << poll_list;
-			tg->get_database()->put_device_property(device_name, poll_data);
-		}
-	}
+        if (added_cmd > 0)
+        {
+            poll_data[0] << poll_list;
+            tg->get_database()->put_device_property(device_name, poll_data);
+        }
+    }
 }
 
 //+-----------------------------------------------------------------------------------------------------------------
@@ -4122,78 +4131,78 @@ void DeviceImpl::init_cmd_poll_period()
 
 void DeviceImpl::init_attr_poll_ext_trig(string attr_name)
 {
-	string  attr_lowercase(attr_name);
-   	transform(attr_lowercase.begin(),attr_lowercase.end(),attr_lowercase.begin(),::tolower);
+    string attr_lowercase(attr_name);
+    transform(attr_lowercase.begin(), attr_lowercase.end(), attr_lowercase.begin(), ::tolower);
 
 //
 // check whether the attribute exists for the device and can be polled
 //
 
-	dev_attr->get_attr_by_name (attr_lowercase.c_str());
+    dev_attr->get_attr_by_name(attr_lowercase.c_str());
 
 //
 // check wether the database is used
 //
 
-	Tango::Util *tg = Tango::Util::instance();
-	if ( tg->_UseDb == true )
-	{
-		vector <string> &poll_list = get_polled_attr();
-		Tango::DbData poll_data;
-		bool found = false;
+    Tango::Util *tg = Tango::Util::instance();
+    if (tg->_UseDb == true)
+    {
+        vector<string> &poll_list = get_polled_attr();
+        Tango::DbData poll_data;
+        bool found = false;
 
-		poll_data.push_back(Tango::DbDatum("polled_attr"));
+        poll_data.push_back(Tango::DbDatum("polled_attr"));
 
 //
 // read the polling configuration from the database
 //
 
-		if (poll_list.empty() == false)
-		{
+        if (poll_list.empty() == false)
+        {
 
 //
 // search the attribute in the list of polled attributes
 //
 
-			for (unsigned int i = 0;i < poll_list.size();i = i+2)
-			{
+            for (unsigned int i = 0; i < poll_list.size(); i = i + 2)
+            {
 
 //
 // Convert to lower case before comparison
 //
 
-				string  name_lowercase(poll_list[i]);
-				transform(name_lowercase.begin(),name_lowercase.end(),name_lowercase.begin(),::tolower);
+                string name_lowercase(poll_list[i]);
+                transform(name_lowercase.begin(), name_lowercase.end(), name_lowercase.begin(), ::tolower);
 
-				if ( name_lowercase ==  attr_lowercase)
-				{
-					if ( poll_list[i+1] == "0" )
+                if (name_lowercase == attr_lowercase)
+                {
+                    if (poll_list[i + 1] == "0")
                     {
 
 //
 // The configuration is already correct, no need for further action
 //
 
-						return;
+                        return;
                     }
-					else
+                    else
                     {
-						poll_list[i+1] = "0";
-						found = true;
+                        poll_list[i + 1] = "0";
+                        found = true;
                     }
-				}
-			}
-		}
+                }
+            }
+        }
 
-		if ( found == false )
-		{
-			poll_list.push_back (attr_lowercase);
-			poll_list.push_back ("0");
-		}
+        if (found == false)
+        {
+            poll_list.push_back(attr_lowercase);
+            poll_list.push_back("0");
+        }
 
-		poll_data[0] << poll_list;
-		tg->get_database()->put_device_property(device_name, poll_data);
-	}
+        poll_data[0] << poll_list;
+        tg->get_database()->put_device_property(device_name, poll_data);
+    }
 }
 
 //+-----------------------------------------------------------------------------------------------------------------
@@ -4215,29 +4224,29 @@ void DeviceImpl::init_attr_poll_period()
 // check wether the database is used
 //
 
-	Tango::Util *tg = Tango::Util::instance();
-	if ( tg->_UseDb == true )
-	{
-		vector <string> &poll_list = get_polled_attr();
-		Tango::DbData poll_data;
+    Tango::Util *tg = Tango::Util::instance();
+    if (tg->_UseDb == true)
+    {
+        vector<string> &poll_list = get_polled_attr();
+        Tango::DbData poll_data;
 
-		poll_data.push_back(Tango::DbDatum("polled_attr"));
+        poll_data.push_back(Tango::DbDatum("polled_attr"));
 
 //
 // get the multi attribute object
 //
 
-		vector<Attribute *> &attr_list = dev_attr->get_attribute_list();
+        vector<Attribute *> &attr_list = dev_attr->get_attribute_list();
 
 //
 // loop over the attribute list
 //
 
-		unsigned long added_attr = 0;
-		unsigned long i;
-		for (i = 0;i < attr_list.size();i++)
-		{
-			string &attr_name = attr_list[i]->get_name_lower();
+        unsigned long added_attr = 0;
+        unsigned long i;
+        for (i = 0; i < attr_list.size(); i++)
+        {
+            string &attr_name = attr_list[i]->get_name_lower();
 
 //
 // Special case for state and status attributes. They are polled as attribute but they are managed by Pogo as
@@ -4251,7 +4260,7 @@ void DeviceImpl::init_attr_poll_period()
                 long state_poll_period = state_cmd.get_polling_period();
                 if (state_poll_period != 0)
                 {
-                   attr_list[i]->set_polling_period(state_poll_period);
+                    attr_list[i]->set_polling_period(state_poll_period);
                 }
             }
 
@@ -4261,72 +4270,72 @@ void DeviceImpl::init_attr_poll_period()
                 long status_poll_period = status_cmd.get_polling_period();
                 if (status_poll_period != 0)
                 {
-                   attr_list[i]->set_polling_period(status_poll_period);
+                    attr_list[i]->set_polling_period(status_poll_period);
                 }
             }
 
-			long poll_period;
-			poll_period = attr_list[i]->get_polling_period();
+            long poll_period;
+            poll_period = attr_list[i]->get_polling_period();
 
 //
 // check the validity of the polling period. must be longer than 20ms
 //
 
-			if ( poll_period < MIN_POLL_PERIOD )
-			{
-				continue;
-			}
+            if (poll_period < MIN_POLL_PERIOD)
+            {
+                continue;
+            }
 
 //
 // search the attribute in the list of polled attributes
 //
 
-			bool found = false;
-			for (unsigned int i = 0;i < poll_list.size();i = i+2)
-			{
+            bool found = false;
+            for (unsigned int i = 0; i < poll_list.size(); i = i + 2)
+            {
 
 //
 // Convert to lower case before comparison
 //
 
-                string  name_lowercase(poll_list[i]);
-                transform(name_lowercase.begin(),name_lowercase.end(),name_lowercase.begin(),::tolower);
+                string name_lowercase(poll_list[i]);
+                transform(name_lowercase.begin(), name_lowercase.end(), name_lowercase.begin(), ::tolower);
 
-				if ( name_lowercase == attr_name)
-				{
-					found = true;
-					break;
-				}
-			}
+                if (name_lowercase == attr_name)
+                {
+                    found = true;
+                    break;
+                }
+            }
 
-			if ( found == false )
-			{
-				string period_str;
-				stringstream str;
-				str << poll_period << ends;
-				str >> period_str;
+            if (found == false)
+            {
+                string period_str;
+                stringstream str;
+                str << poll_period << ends;
+                str >> period_str;
 
-				poll_list.push_back (attr_name);
-				poll_list.push_back (period_str);
-				added_attr++;
-			}
-		}
+                poll_list.push_back(attr_name);
+                poll_list.push_back(period_str);
+                added_attr++;
+            }
+        }
 
 //
 // only write to the database when a polling need to be added
 //
 
-		if ( added_attr > 0 )
-		{
-			poll_data[0] << poll_list;
-			tg->get_database()->put_device_property(device_name, poll_data);
-		}
+        if (added_attr > 0)
+        {
+            poll_data[0] << poll_list;
+            tg->get_database()->put_device_property(device_name, poll_data);
+        }
 
 //
 // Another loop to correctly initialize polling period data in Attribute instance
 //
 
-        for (unsigned int i = 0;i < poll_list.size();i = i+2)
+        for (unsigned int i = 0; i < poll_list.size(); i = i + 2)
         {
             try
             {
@@ -4336,11 +4345,12 @@ void DeviceImpl::init_attr_poll_period()
                 ss << poll_list[i + 1];
                 ss >> per;
                 if (ss)
-                   att.set_polling_period(per);
+                    att.set_polling_period(per);
             }
-            catch (Tango::DevFailed &) {}
+            catch (Tango::DevFailed &)
+            {}
         }
-	}
+    }
 }
 
 //+-----------------------------------------------------------------------------------------------------------------
@@ -4362,50 +4372,50 @@ void DeviceImpl::push_att_conf_event(Attribute *attr)
     EventSupplier *event_supplier_nd = NULL;
     EventSupplier *event_supplier_zmq = NULL;
 
-	Tango::Util *tg = Tango::Util::instance();
+    Tango::Util *tg = Tango::Util::instance();
 
     if (attr->use_notifd_event() == true)
         event_supplier_nd = tg->get_notifd_event_supplier();
     if (attr->use_zmq_event() == true)
         event_supplier_zmq = tg->get_zmq_event_supplier();
 
-	if ((event_supplier_nd != NULL) || (event_supplier_zmq != NULL))
-	{
-	    EventSupplier::SuppliedEventData ad;
-	    ::memset(&ad,0,sizeof(ad));
+    if ((event_supplier_nd != NULL) || (event_supplier_zmq != NULL))
+    {
+        EventSupplier::SuppliedEventData ad;
+        ::memset(&ad, 0, sizeof(ad));
 
-		long vers = get_dev_idl_version();
-		if (vers <= 2)
-		{
-			Tango::AttributeConfig_2 attr_conf_2;
-			attr->get_properties(attr_conf_2);
-			ad.attr_conf_2 = &attr_conf_2;
-			if (event_supplier_nd != NULL)
-                event_supplier_nd->push_att_conf_events(this,ad,(Tango::DevFailed *)NULL,attr->get_name());
+        long vers = get_dev_idl_version();
+        if (vers <= 2)
+        {
+            Tango::AttributeConfig_2 attr_conf_2;
+            attr->get_properties(attr_conf_2);
+            ad.attr_conf_2 = &attr_conf_2;
+            if (event_supplier_nd != NULL)
+                event_supplier_nd->push_att_conf_events(this, ad, (Tango::DevFailed *) NULL, attr->get_name());
             if (event_supplier_zmq != NULL)
-                event_supplier_zmq->push_att_conf_events(this,ad,(Tango::DevFailed *)NULL,attr->get_name());
-		}
-		else if (vers <= 4)
-		{
-			Tango::AttributeConfig_3 attr_conf_3;
-			attr->get_properties(attr_conf_3);
+                event_supplier_zmq->push_att_conf_events(this, ad, (Tango::DevFailed *) NULL, attr->get_name());
+        }
+        else if (vers <= 4)
+        {
+            Tango::AttributeConfig_3 attr_conf_3;
+            attr->get_properties(attr_conf_3);
             ad.attr_conf_3 = &attr_conf_3;
             if (event_supplier_nd != NULL)
-                event_supplier_nd->push_att_conf_events(this,ad,(Tango::DevFailed *)NULL,attr->get_name());
+                event_supplier_nd->push_att_conf_events(this, ad, (Tango::DevFailed *) NULL, attr->get_name());
             if (event_supplier_zmq != NULL)
-                event_supplier_zmq->push_att_conf_events(this,ad,(Tango::DevFailed *)NULL,attr->get_name());
-		}
-		else
-		{
-			Tango::AttributeConfig_5 attr_conf_5;
-			attr->get_properties(attr_conf_5);
+                event_supplier_zmq->push_att_conf_events(this, ad, (Tango::DevFailed *) NULL, attr->get_name());
+        }
+        else
+        {
+            Tango::AttributeConfig_5 attr_conf_5;
+            attr->get_properties(attr_conf_5);
             ad.attr_conf_5 = &attr_conf_5;
             if (event_supplier_nd != NULL)
-                event_supplier_nd->push_att_conf_events(this,ad,(Tango::DevFailed *)NULL,attr->get_name());
+                event_supplier_nd->push_att_conf_events(this, ad, (Tango::DevFailed *) NULL, attr->get_name());
             if (event_supplier_zmq != NULL)
-                event_supplier_zmq->push_att_conf_events(this,ad,(Tango::DevFailed *)NULL,attr->get_name());
-		}
-	}
+                event_supplier_zmq->push_att_conf_events(this, ad, (Tango::DevFailed *) NULL, attr->get_name());
+        }
+    }
 }
 
 //+----------------------------------------------------------------------------------------------------------------
@@ -4420,8 +4430,8 @@ void DeviceImpl::push_att_conf_event(Attribute *attr)
 
 Tango::client_addr *DeviceImpl::get_client_ident()
 {
-	omni_thread::value_t *ip = omni_thread::self()->get_value(key);
-	return (client_addr *)ip;
+    omni_thread::value_t *ip = omni_thread::self()->get_value(key);
+    return (client_addr *) ip;
 }
 
 //+-----------------------------------------------------------------------------------------------------------------
@@ -4439,51 +4449,51 @@ Tango::client_addr *DeviceImpl::get_client_ident()
 //
 //-----------------------------------------------------------------------------------------------------------------
 
-void DeviceImpl::lock(client_addr *cl,int validity)
+void DeviceImpl::lock(client_addr *cl, int validity)
 {
 
 //
 // Check if the device is already locked and if it is a valid lock. If the lock is not valid any more, clear it
 //
 
-	if (device_locked == true)
-	{
-		if (valid_lock() == true)
-		{
-			if (*cl != *(locker_client))
-			{
-				TangoSys_OMemStream o;
-				o << "Device " << get_name() << " is already locked by another client" << ends;
-				Except::throw_exception((const char *)API_DeviceLocked,o.str(),
-								(const char *)"Device_Impl::lock");
-			}
-		}
-		else
-		{
-			basic_unlock();
-		}
-	}
+    if (device_locked == true)
+    {
+        if (valid_lock() == true)
+        {
+            if (*cl != *(locker_client))
+            {
+                TangoSys_OMemStream o;
+                o << "Device " << get_name() << " is already locked by another client" << ends;
+                Except::throw_exception((const char *) API_DeviceLocked, o.str(),
+                                        (const char *) "Device_Impl::lock");
+            }
+        }
+        else
+        {
+            basic_unlock();
+        }
+    }
 
 //
 // Lock the device
 //
 
-	device_locked = true;
-	if (locker_client == NULL)
-	{
-		locker_client = new client_addr(*cl);
-	}
+    device_locked = true;
+    if (locker_client == NULL)
+    {
+        locker_client = new client_addr(*cl);
+    }
 
-	locking_date = time(NULL);
-	lock_validity = validity;
-	lock_ctr++;
+    locking_date = time(NULL);
+    lock_validity = validity;
+    lock_ctr++;
 
 //
 // Also lock root device(s) in case it is needed (due to forwarded attributes)
 //
 
-	if (get_with_fwd_att() == true)
-		lock_root_devices(validity,true);
+    if (get_with_fwd_att() == true)
+        lock_root_devices(validity, true);
 }
 
 //+------------------------------------------------------------------------------------------------------------------
@@ -4508,39 +4518,39 @@ void DeviceImpl::relock(client_addr *cl)
 // locked by the same client and if this lock is valid
 //
 
-	if (device_locked == true)
-	{
-		if (valid_lock() == true)
-		{
-			if (*cl != *(locker_client))
-			{
-				TangoSys_OMemStream o;
-				o << get_name() << ": ";
-				o << "Device " << get_name() << " is already locked by another client" << ends;
-				Except::throw_exception((const char *)API_DeviceLocked,o.str(),
-								(const char *)"Device_Impl::relock");
-			}
+    if (device_locked == true)
+    {
+        if (valid_lock() == true)
+        {
+            if (*cl != *(locker_client))
+            {
+                TangoSys_OMemStream o;
+                o << get_name() << ": ";
+                o << "Device " << get_name() << " is already locked by another client" << ends;
+                Except::throw_exception((const char *) API_DeviceLocked, o.str(),
+                                        (const char *) "Device_Impl::relock");
+            }
 
-			device_locked = true;
-			locking_date = time(NULL);
-		}
-		else
-		{
-			TangoSys_OMemStream o;
-			o << get_name() << ": ";
-			o << "Device " << get_name() << " is not locked. Can't re-lock it" << ends;
-			Except::throw_exception((const char *)API_DeviceNotLocked,o.str(),
-							(const char *)"Device_Impl::relock");
-		}
-	}
-	else
-	{
-		TangoSys_OMemStream o;
-		o << get_name() << ": ";
-		o << "Device " << get_name() << " is not locked. Can't re-lock it" << ends;
-		Except::throw_exception((const char *)API_DeviceNotLocked,o.str(),
-						(const char *)"Device_Impl::relock");
-	}
+            device_locked = true;
+            locking_date = time(NULL);
+        }
+        else
+        {
+            TangoSys_OMemStream o;
+            o << get_name() << ": ";
+            o << "Device " << get_name() << " is not locked. Can't re-lock it" << ends;
+            Except::throw_exception((const char *) API_DeviceNotLocked, o.str(),
+                                    (const char *) "Device_Impl::relock");
+        }
+    }
+    else
+    {
+        TangoSys_OMemStream o;
+        o << get_name() << ": ";
+        o << "Device " << get_name() << " is not locked. Can't re-lock it" << ends;
+        Except::throw_exception((const char *) API_DeviceNotLocked, o.str(),
+                                (const char *) "Device_Impl::relock");
+    }
 
 }
 
@@ -4565,31 +4575,31 @@ Tango::DevLong DeviceImpl::unlock(bool forced)
 // Check if the device is already locked and if it is a valid lock. If the lock is not valid any more, clear it
 //
 
-	if (device_locked == true)
-	{
-		if (valid_lock() == true)
-		{
-			client_addr *cl = get_client_ident();
+    if (device_locked == true)
+    {
+        if (valid_lock() == true)
+        {
+            client_addr *cl = get_client_ident();
 
-			if (forced == false)
-			{
-				if (*cl != *(locker_client))
-				{
-					TangoSys_OMemStream o;
-					o << "Device " << get_name() << " is locked by another client, can't unlock it" << ends;
-					Except::throw_exception((const char *)API_DeviceLocked,o.str(),
-								(const char *)"Device_Impl::unlock");
-				}
-			}
-		}
-	}
+            if (forced == false)
+            {
+                if (*cl != *(locker_client))
+                {
+                    TangoSys_OMemStream o;
+                    o << "Device " << get_name() << " is locked by another client, can't unlock it" << ends;
+                    Except::throw_exception((const char *) API_DeviceLocked, o.str(),
+                                            (const char *) "Device_Impl::unlock");
+                }
+            }
+        }
+    }
 
-	if (lock_ctr > 0)
-		lock_ctr--;
-	if ((lock_ctr <= 0) || (forced == true))
-		basic_unlock(forced);
+    if (lock_ctr > 0)
+        lock_ctr--;
+    if ((lock_ctr <= 0) || (forced == true))
+        basic_unlock(forced);
 
-	return lock_ctr;
+    return lock_ctr;
 }
 
 //+-----------------------------------------------------------------------------------------------------------------
@@ -4608,20 +4618,20 @@ Tango::DevLong DeviceImpl::unlock(bool forced)
 
 void DeviceImpl::basic_unlock(bool forced)
 {
-	device_locked = false;
-	if (forced == true)
-		old_locker_client = locker_client;
-	else
-		delete locker_client;
-	locker_client = NULL;
-	lock_ctr = 0;
+    device_locked = false;
+    if (forced == true)
+        old_locker_client = locker_client;
+    else
+        delete locker_client;
+    locker_client = NULL;
+    lock_ctr = 0;
 
 //
 // Also unlock root device(s) in case it is needed (due to forwarded attributes)
 //
 
-	if (get_with_fwd_att() == true)
-		lock_root_devices(0,false);
+    if (get_with_fwd_att() == true)
+        lock_root_devices(0, false);
 }
 
 //+------------------------------------------------------------------------------------------------------------------
@@ -4637,11 +4647,11 @@ void DeviceImpl::basic_unlock(bool forced)
 
 bool DeviceImpl::valid_lock()
 {
-	time_t now = time(NULL);
-	if (now > (locking_date + lock_validity))
-		return false;
-	else
-		return true;
+    time_t now = time(NULL);
+    if (now > (locking_date + lock_validity))
+        return false;
+    else
+        return true;
 }
 
 //+-----------------------------------------------------------------------------------------------------------------
@@ -4664,68 +4674,68 @@ bool DeviceImpl::valid_lock()
 
 Tango::DevVarLongStringArray *DeviceImpl::lock_status()
 {
-	Tango::DevVarLongStringArray *dvlsa = new Tango::DevVarLongStringArray();
-	dvlsa->lvalue.length(6);
-	dvlsa->svalue.length(3);
+    Tango::DevVarLongStringArray *dvlsa = new Tango::DevVarLongStringArray();
+    dvlsa->lvalue.length(6);
+    dvlsa->svalue.length(3);
 
 //
 // Check if the device is already locked and if it is a valid lock. If the lock is not valid any more, clear it
 //
 
-	if (device_locked == true)
-	{
-		if (valid_lock() == true)
-		{
-			lock_stat = "Device " + device_name + " is locked by ";
-			ostringstream ostr;
-			ostr << *(locker_client) << ends;
-			lock_stat = lock_stat + ostr.str();
+    if (device_locked == true)
+    {
+        if (valid_lock() == true)
+        {
+            lock_stat = "Device " + device_name + " is locked by ";
+            ostringstream ostr;
+            ostr << *(locker_client) << ends;
+            lock_stat = lock_stat + ostr.str();
 
-			dvlsa->lvalue[0] = 1;
-			dvlsa->lvalue[1] = locker_client->client_pid;
-			const char *tmp = locker_client->client_ip;
-			dvlsa->svalue[1] = CORBA::string_dup(tmp);
-			if (locker_client->client_lang == Tango::JAVA)
-			{
-				dvlsa->svalue[2] = CORBA::string_dup(locker_client->java_main_class.c_str());
+            dvlsa->lvalue[0] = 1;
+            dvlsa->lvalue[1] = locker_client->client_pid;
+            const char *tmp = locker_client->client_ip;
+            dvlsa->svalue[1] = CORBA::string_dup(tmp);
+            if (locker_client->client_lang == Tango::JAVA)
+            {
+                dvlsa->svalue[2] = CORBA::string_dup(locker_client->java_main_class.c_str());
 
-				Tango::DevULong64 tmp_data = locker_client->java_ident[0];
-				dvlsa->lvalue[2] = (DevLong)((tmp_data & 0xFFFFFFFF00000000LL) >> 32);
-				dvlsa->lvalue[3] = (DevLong)(tmp_data & 0xFFFFFFFF);
+                Tango::DevULong64 tmp_data = locker_client->java_ident[0];
+                dvlsa->lvalue[2] = (DevLong) ((tmp_data & 0xFFFFFFFF00000000LL) >> 32);
+                dvlsa->lvalue[3] = (DevLong) (tmp_data & 0xFFFFFFFF);
 
-				tmp_data = locker_client->java_ident[1];
-				dvlsa->lvalue[4] = (DevLong)((tmp_data & 0xFFFFFFFF00000000LL) >> 32);
-				dvlsa->lvalue[5] = (DevLong)(tmp_data & 0xFFFFFFFF);
-			}
-			else
-			{
-				dvlsa->svalue[2] = CORBA::string_dup("Not defined");
-				for (long loop = 2;loop < 6;loop++)
-					dvlsa->lvalue[loop] = 0;
-			}
-		}
-		else
-		{
-			basic_unlock();
-			lock_stat = "Device " + device_name + " is not locked";
-			dvlsa->svalue[1] = CORBA::string_dup("Not defined");
-			dvlsa->svalue[2] = CORBA::string_dup("Not defined");
-			for (long loop = 0;loop < 6;loop++)
-				dvlsa->lvalue[loop] = 0;
-		}
-	}
-	else
-	{
-		lock_stat = "Device " + device_name + " is not locked";
-		dvlsa->svalue[1] = CORBA::string_dup("Not defined");
-		dvlsa->svalue[2] = CORBA::string_dup("Not defined");
-		for (long loop = 0;loop < 6;loop++)
-			dvlsa->lvalue[loop] = 0;
-	}
+                tmp_data = locker_client->java_ident[1];
+                dvlsa->lvalue[4] = (DevLong) ((tmp_data & 0xFFFFFFFF00000000LL) >> 32);
+                dvlsa->lvalue[5] = (DevLong) (tmp_data & 0xFFFFFFFF);
+            }
+            else
+            {
+                dvlsa->svalue[2] = CORBA::string_dup("Not defined");
+                for (long loop = 2; loop < 6; loop++)
+                    dvlsa->lvalue[loop] = 0;
+            }
+        }
+        else
+        {
+            basic_unlock();
+            lock_stat = "Device " + device_name + " is not locked";
+            dvlsa->svalue[1] = CORBA::string_dup("Not defined");
+            dvlsa->svalue[2] = CORBA::string_dup("Not defined");
+            for (long loop = 0; loop < 6; loop++)
+                dvlsa->lvalue[loop] = 0;
+        }
+    }
+    else
+    {
+        lock_stat = "Device " + device_name + " is not locked";
+        dvlsa->svalue[1] = CORBA::string_dup("Not defined");
+        dvlsa->svalue[2] = CORBA::string_dup("Not defined");
+        for (long loop = 0; loop < 6; loop++)
+            dvlsa->lvalue[loop] = 0;
+    }
 
-	dvlsa->svalue[0] = CORBA::string_dup(lock_stat.c_str());
+    dvlsa->svalue[0] = CORBA::string_dup(lock_stat.c_str());
 
-	return dvlsa;
+    return dvlsa;
 }
 
 //+------------------------------------------------------------------------------------------------------------------
@@ -4746,14 +4756,14 @@ Tango::DevVarLongStringArray *DeviceImpl::lock_status()
 //
 //------------------------------------------------------------------------------------------------------------------
 
-void DeviceImpl::set_locking_param(client_addr *cl,client_addr *old_cl,time_t date,DevLong ctr,DevLong valid)
+void DeviceImpl::set_locking_param(client_addr *cl, client_addr *old_cl, time_t date, DevLong ctr, DevLong valid)
 {
-	locker_client = cl;
-	old_locker_client = old_cl;
-	locking_date = date;
-	lock_ctr = ctr;
-	device_locked = true;
-	lock_validity = valid;
+    locker_client = cl;
+    old_locker_client = old_cl;
+    locking_date = date;
+    lock_ctr = ctr;
+    device_locked = true;
+    lock_validity = valid;
 }
 
 
@@ -4772,73 +4782,73 @@ void DeviceImpl::set_locking_param(client_addr *cl,client_addr *old_cl,time_t da
 //
 //------------------------------------------------------------------------------------------------------------------
 
-void DeviceImpl::check_lock(const char *meth,const char *cmd)
+void DeviceImpl::check_lock(const char *meth, const char *cmd)
 {
-	if (device_locked == true)
-	{
-		if (valid_lock() == true)
-		{
-			client_addr *cl = get_client_ident();
-			if (cl->client_ident == false)
-			{
+    if (device_locked == true)
+    {
+        if (valid_lock() == true)
+        {
+            client_addr *cl = get_client_ident();
+            if (cl->client_ident == false)
+            {
 
 //
 // Old client, before throwing the exception, in case the CORBA operation is a command_inout, checks if the command
 // is an "allowed" one
 //
 
-				if (cmd != NULL)
-				{
-					if (device_class->is_command_allowed(cmd) == false)
-					{
-						throw_locked_exception(meth);
-					}
-				}
-				else
-					throw_locked_exception(meth);
-			}
+                if (cmd != NULL)
+                {
+                    if (device_class->is_command_allowed(cmd) == false)
+                    {
+                        throw_locked_exception(meth);
+                    }
+                }
+                else
+                    throw_locked_exception(meth);
+            }
 
-			if (*cl != *(locker_client))
-			{
+            if (*cl != *(locker_client))
+            {
 
 //
 // Wrong client, before throwing the exception, in case the CORBA operation is a command_inout, checks if the command
 // is an "allowed" one
 //
 
-				if (cmd != NULL)
-				{
-					if (device_class->is_command_allowed(cmd) == false)
-					{
-						throw_locked_exception(meth);
-					}
-				}
-				else
-					throw_locked_exception(meth);
-			}
-		}
-		else
-		{
-			basic_unlock();
-		}
-	}
-	else
-	{
-		client_addr *cl = get_client_ident();
-		if (old_locker_client != NULL)
-		{
-			if (*cl == (*old_locker_client))
-			{
-				TangoSys_OMemStream o;
-				TangoSys_OMemStream o2;
-				o << "Device " << get_name() << " has been unlocked by an administrative client!!!" << ends;
-				o2 << "Device_Impl::" << meth << ends;
-				Except::throw_exception((const char *)DEVICE_UNLOCKED_REASON,o.str(),o2.str());
-			}
-			delete old_locker_client;
-			old_locker_client = NULL;
-		}
-	}
+                if (cmd != NULL)
+                {
+                    if (device_class->is_command_allowed(cmd) == false)
+                    {
+                        throw_locked_exception(meth);
+                    }
+                }
+                else
+                    throw_locked_exception(meth);
+            }
+        }
+        else
+        {
+            basic_unlock();
+        }
+    }
+    else
+    {
+        client_addr *cl = get_client_ident();
+        if (old_locker_client != NULL)
+        {
+            if (*cl == (*old_locker_client))
+            {
+                TangoSys_OMemStream o;
+                TangoSys_OMemStream o2;
+                o << "Device " << get_name() << " has been unlocked by an administrative client!!!" << ends;
+                o2 << "Device_Impl::" << meth << ends;
+                Except::throw_exception((const char *) DEVICE_UNLOCKED_REASON, o.str(), o2.str());
+            }
+            delete old_locker_client;
+            old_locker_client = NULL;
+        }
+    }
 }
 
 //+------------------------------------------------------------------------------------------------------------------
@@ -4857,11 +4867,11 @@ void DeviceImpl::check_lock(const char *meth,const char *cmd)
 
 void DeviceImpl::throw_locked_exception(const char *meth)
 {
-	TangoSys_OMemStream o;
-	TangoSys_OMemStream o2;
-	o << "Device " << get_name() << " is locked by another client" << ends;
-	o2 << "Device_Impl::" << meth << ends;
-	Except::throw_exception((const char *)API_DeviceLocked,o.str(),o2.str());
+    TangoSys_OMemStream o;
+    TangoSys_OMemStream o2;
+    o << "Device " << get_name() << " is locked by another client" << ends;
+    o2 << "Device_Impl::" << meth << ends;
+    Except::throw_exception((const char *) API_DeviceLocked, o.str(), o2.str());
 }
 
 //+------------------------------------------------------------------------------------------------------------------
@@ -4883,165 +4893,176 @@ void DeviceImpl::throw_locked_exception(const char *meth)
 //
 //-------------------------------------------------------------------------------------------------------------------
 
-void DeviceImpl::data_into_net_object(Attribute &att,AttributeIdlData &aid,
-										long index,AttrWriteType w_type,bool del_seq)
+void DeviceImpl::data_into_net_object(Attribute &att, AttributeIdlData &aid,
+                                      long index, AttrWriteType w_type, bool del_seq)
 {
 
 //
 // A big switch according to attribute data type
 //
 
-	switch (att.get_data_type())
-	{
-		case Tango::DEV_SHORT :
-		case Tango::DEV_ENUM :
-		{
-			DATA_IN_OBJECT(DevVarShortArray,get_short_value,dummy_short_att_value,short_att_value);
-			break;
-		}
+    switch (att.get_data_type())
+    {
+        case Tango::DEV_SHORT :
+        case Tango::DEV_ENUM :
+        {
+            DATA_IN_OBJECT(DevVarShortArray, get_short_value, dummy_short_att_value, short_att_value);
+            break;
+        }
 
-		case Tango::DEV_LONG :
-		{
-			DATA_IN_OBJECT(DevVarLongArray,get_long_value,dummy_long_att_value,long_att_value);
-			break;
-		}
+        case Tango::DEV_LONG :
+        {
+            DATA_IN_OBJECT(DevVarLongArray, get_long_value, dummy_long_att_value, long_att_value);
+            break;
+        }
 
-		case Tango::DEV_LONG64 :
-		{
-			DATA_IN_OBJECT(DevVarLong64Array,get_long64_value,dummy_long64_att_value,long64_att_value);
-			break;
-		}
+        case Tango::DEV_LONG64 :
+        {
+            DATA_IN_OBJECT(DevVarLong64Array, get_long64_value, dummy_long64_att_value, long64_att_value);
+            break;
+        }
 
-		case Tango::DEV_DOUBLE :
-		{
-			DATA_IN_OBJECT(DevVarDoubleArray,get_double_value,dummy_double_att_value,double_att_value);
-			break;
-		}
+        case Tango::DEV_DOUBLE :
+        {
+            DATA_IN_OBJECT(DevVarDoubleArray, get_double_value, dummy_double_att_value, double_att_value);
+            break;
+        }
 
-		case Tango::DEV_STRING :
-		{
-			DATA_IN_OBJECT(DevVarStringArray,get_string_value,dummy_string_att_value,string_att_value);
-			break;
-		}
+        case Tango::DEV_STRING :
+        {
+            DATA_IN_OBJECT(DevVarStringArray, get_string_value, dummy_string_att_value, string_att_value);
+            break;
+        }
 
-		case Tango::DEV_FLOAT :
-		{
-			DATA_IN_OBJECT(DevVarFloatArray,get_float_value,dummy_float_att_value,float_att_value);
-			break;
-		}
+        case Tango::DEV_FLOAT :
+        {
+            DATA_IN_OBJECT(DevVarFloatArray, get_float_value, dummy_float_att_value, float_att_value);
+            break;
+        }
 
-		case Tango::DEV_BOOLEAN :
-		{
-			DATA_IN_OBJECT(DevVarBooleanArray,get_boolean_value,dummy_boolean_att_value,bool_att_value);
-			break;
-		}
+        case Tango::DEV_BOOLEAN :
+        {
+            DATA_IN_OBJECT(DevVarBooleanArray, get_boolean_value, dummy_boolean_att_value, bool_att_value);
+            break;
+        }
 
-		case Tango::DEV_USHORT :
-		{
-			DATA_IN_OBJECT(DevVarUShortArray,get_ushort_value,dummy_ushort_att_value,ushort_att_value);
-			break;
-		}
+        case Tango::DEV_USHORT :
+        {
+            DATA_IN_OBJECT(DevVarUShortArray, get_ushort_value, dummy_ushort_att_value, ushort_att_value);
+            break;
+        }
 
-		case Tango::DEV_UCHAR :
-		{
-			DATA_IN_OBJECT(DevVarCharArray,get_uchar_value,dummy_uchar_att_value,uchar_att_value);
-			break;
-		}
+        case Tango::DEV_UCHAR :
+        {
+            DATA_IN_OBJECT(DevVarCharArray, get_uchar_value, dummy_uchar_att_value, uchar_att_value);
+            break;
+        }
 
-		case Tango::DEV_ULONG :
-		{
-			DATA_IN_OBJECT(DevVarULongArray,get_ulong_value,dummy_ulong_att_value,ulong_att_value);
-			break;
-		}
+        case Tango::DEV_ULONG :
+        {
+            DATA_IN_OBJECT(DevVarULongArray, get_ulong_value, dummy_ulong_att_value, ulong_att_value);
+            break;
+        }
 
-		case Tango::DEV_ULONG64 :
-		{
-			DATA_IN_OBJECT(DevVarULong64Array,get_ulong64_value,dummy_ulong64_att_value,ulong64_att_value);
-			break;
-		}
+        case Tango::DEV_ULONG64 :
+        {
+            DATA_IN_OBJECT(DevVarULong64Array, get_ulong64_value, dummy_ulong64_att_value, ulong64_att_value);
+            break;
+        }
 
-		case Tango::DEV_STATE :
-		{
-			DATA_IN_OBJECT(DevVarStateArray,get_state_value,dummy_state_att_value,state_att_value);
-			break;
-		}
+        case Tango::DEV_STATE :
+        {
+            DATA_IN_OBJECT(DevVarStateArray, get_state_value, dummy_state_att_value, state_att_value);
+            break;
+        }
 
-		case Tango::DEV_ENCODED :
-		{
-			if (aid.data_3 != Tango_nullptr)
-			{
-				(*aid.data_3)[index].err_list.length(1);
-				(*aid.data_3)[index].err_list[0].severity = Tango::ERR;
-				(*aid.data_3)[index].err_list[0].reason = CORBA::string_dup(API_NotSupportedFeature);
-				(*aid.data_3)[index].err_list[0].origin = CORBA::string_dup("Device_3Impl::read_attributes_no_except");
-				(*aid.data_3)[index].err_list[0].desc = CORBA::string_dup("The DevEncoded data type is available only for device implementing IDL 4 and above");
-				(*aid.data_3)[index].quality = Tango::ATTR_INVALID;
-				(*aid.data_3)[index].name = CORBA::string_dup(att.get_name().c_str());
-				clear_att_dim((*aid.data_3)[index]);
-			}
-			else
-			{
-				Tango::DevVarEncodedArray *ptr = att.get_encoded_value();
-				if (aid.data_5 != Tango_nullptr)
-				{
-					(*aid.data_5)[index].value.encoded_att_value(dummy_encoded_att_value);
-					DevVarEncodedArray &the_seq = (*aid.data_5)[index].value.encoded_att_value();
+        case Tango::DEV_ENCODED :
+        {
+            if (aid.data_3 != Tango_nullptr)
+            {
+                (*aid.data_3)[index].err_list.length(1);
+                (*aid.data_3)[index].err_list[0].severity = Tango::ERR;
+                (*aid.data_3)[index].err_list[0].reason = CORBA::string_dup(API_NotSupportedFeature);
+                (*aid.data_3)[index].err_list[0].origin = CORBA::string_dup("Device_3Impl::read_attributes_no_except");
+                (*aid.data_3)[index].err_list[0].desc = CORBA::string_dup(
+                    "The DevEncoded data type is available only for device implementing IDL 4 and above");
+                (*aid.data_3)[index].quality = Tango::ATTR_INVALID;
+                (*aid.data_3)[index].name = CORBA::string_dup(att.get_name().c_str());
+                clear_att_dim((*aid.data_3)[index]);
+            }
+            else
+            {
+                Tango::DevVarEncodedArray *ptr = att.get_encoded_value();
+                if (aid.data_5 != Tango_nullptr)
+                {
+                    (*aid.data_5)[index].value.encoded_att_value(dummy_encoded_att_value);
+                    DevVarEncodedArray &the_seq = (*aid.data_5)[index].value.encoded_att_value();
 
-					if ((w_type == Tango::READ) || (w_type == Tango::WRITE))
-						the_seq.length(1);
-					else
-						the_seq.length(2);
+                    if ((w_type == Tango::READ) || (w_type == Tango::WRITE))
+                        the_seq.length(1);
+                    else
+                        the_seq.length(2);
 
-					the_seq[0].encoded_format = CORBA::string_dup((*ptr)[0].encoded_format);
+                    the_seq[0].encoded_format = CORBA::string_dup((*ptr)[0].encoded_format);
 
-					if (ptr->release() == true)
-					{
-						unsigned long nb_data = (*ptr)[0].encoded_data.length();
-						the_seq[0].encoded_data.replace(nb_data,nb_data,(*ptr)[0].encoded_data.get_buffer(true),true);
-						(*ptr)[0].encoded_data.replace(0,0,NULL,false);
-					}
-					else
-						the_seq[0].encoded_data.replace((*ptr)[0].encoded_data.length(),(*ptr)[0].encoded_data.length(),(*ptr)[0].encoded_data.get_buffer());
+                    if (ptr->release() == true)
+                    {
+                        unsigned long nb_data = (*ptr)[0].encoded_data.length();
+                        the_seq[0].encoded_data
+                            .replace(nb_data, nb_data, (*ptr)[0].encoded_data.get_buffer(true), true);
+                        (*ptr)[0].encoded_data.replace(0, 0, NULL, false);
+                    }
+                    else
+                        the_seq[0].encoded_data.replace((*ptr)[0].encoded_data.length(),
+                                                        (*ptr)[0].encoded_data.length(),
+                                                        (*ptr)[0].encoded_data.get_buffer());
 
-					if ((w_type == Tango::READ_WRITE) || (w_type == Tango::READ_WITH_WRITE))
-					{
-						the_seq[1].encoded_format = CORBA::string_dup((*ptr)[1].encoded_format);
-						the_seq[1].encoded_data.replace((*ptr)[1].encoded_data.length(),(*ptr)[1].encoded_data.length(),(*ptr)[1].encoded_data.get_buffer());
-					}
-				}
-				else
-				{
-					(*aid.data_4)[index].value.encoded_att_value(dummy_encoded_att_value);
-					DevVarEncodedArray &the_seq = (*aid.data_4)[index].value.encoded_att_value();
+                    if ((w_type == Tango::READ_WRITE) || (w_type == Tango::READ_WITH_WRITE))
+                    {
+                        the_seq[1].encoded_format = CORBA::string_dup((*ptr)[1].encoded_format);
+                        the_seq[1].encoded_data.replace((*ptr)[1].encoded_data.length(),
+                                                        (*ptr)[1].encoded_data.length(),
+                                                        (*ptr)[1].encoded_data.get_buffer());
+                    }
+                }
+                else
+                {
+                    (*aid.data_4)[index].value.encoded_att_value(dummy_encoded_att_value);
+                    DevVarEncodedArray &the_seq = (*aid.data_4)[index].value.encoded_att_value();
 
-					if ((w_type == Tango::READ) || (w_type == Tango::WRITE))
-						the_seq.length(1);
-					else
-						the_seq.length(2);
+                    if ((w_type == Tango::READ) || (w_type == Tango::WRITE))
+                        the_seq.length(1);
+                    else
+                        the_seq.length(2);
 
-					the_seq[0].encoded_format = CORBA::string_dup((*ptr)[0].encoded_format);
+                    the_seq[0].encoded_format = CORBA::string_dup((*ptr)[0].encoded_format);
 
-					if (ptr->release() == true)
-					{
-						unsigned long nb_data = (*ptr)[0].encoded_data.length();
-						the_seq[0].encoded_data.replace(nb_data,nb_data,(*ptr)[0].encoded_data.get_buffer(true),true);
-						(*ptr)[0].encoded_data.replace(0,0,NULL,false);
-					}
-					else
-						the_seq[0].encoded_data.replace((*ptr)[0].encoded_data.length(),(*ptr)[0].encoded_data.length(),(*ptr)[0].encoded_data.get_buffer());
+                    if (ptr->release() == true)
+                    {
+                        unsigned long nb_data = (*ptr)[0].encoded_data.length();
+                        the_seq[0].encoded_data
+                            .replace(nb_data, nb_data, (*ptr)[0].encoded_data.get_buffer(true), true);
+                        (*ptr)[0].encoded_data.replace(0, 0, NULL, false);
+                    }
+                    else
+                        the_seq[0].encoded_data.replace((*ptr)[0].encoded_data.length(),
+                                                        (*ptr)[0].encoded_data.length(),
+                                                        (*ptr)[0].encoded_data.get_buffer());
 
-					if ((w_type == Tango::READ_WRITE) || (w_type == Tango::READ_WITH_WRITE))
-					{
-						the_seq[1].encoded_format = CORBA::string_dup((*ptr)[1].encoded_format);
-						the_seq[1].encoded_data.replace((*ptr)[1].encoded_data.length(),(*ptr)[1].encoded_data.length(),(*ptr)[1].encoded_data.get_buffer());
-					}
-				}
-				if (del_seq == true)
-					delete ptr;
-			}
-			break;
-		}
-	}
+                    if ((w_type == Tango::READ_WRITE) || (w_type == Tango::READ_WITH_WRITE))
+                    {
+                        the_seq[1].encoded_format = CORBA::string_dup((*ptr)[1].encoded_format);
+                        the_seq[1].encoded_data.replace((*ptr)[1].encoded_data.length(),
+                                                        (*ptr)[1].encoded_data.length(),
+                                                        (*ptr)[1].encoded_data.get_buffer());
+                    }
+                }
+                if (del_seq == true)
+                    delete ptr;
+            }
+            break;
+        }
+    }
 }
 
 //+------------------------------------------------------------------------------------------------------------------
@@ -5065,268 +5086,269 @@ void DeviceImpl::data_into_net_object(Attribute &att,AttributeIdlData &aid,
 //-------------------------------------------------------------------------------------------------------------------
 
 void DeviceImpl::polled_data_into_net_object(AttributeIdlData &aid,
-										long index,long type,long vers,PollObj *polled_att,
-										const DevVarStringArray &names)
+                                             long index, long type, long vers, PollObj *polled_att,
+                                             const DevVarStringArray &names)
 {
-	const Tango::DevVarDoubleArray *tmp_db;
-	Tango::DevVarDoubleArray *new_tmp_db;
-	const Tango::DevVarShortArray *tmp_sh;
-	Tango::DevVarShortArray *new_tmp_sh;
-	const Tango::DevVarLongArray *tmp_lg;
-	Tango::DevVarLongArray *new_tmp_lg;
-	const Tango::DevVarLong64Array *tmp_lg64;
-	Tango::DevVarLong64Array *new_tmp_lg64;
-	const Tango::DevVarStringArray *tmp_str;
-	Tango::DevVarStringArray *new_tmp_str;
-	const Tango::DevVarFloatArray *tmp_fl;
-	Tango::DevVarFloatArray *new_tmp_fl;
-	const Tango::DevVarBooleanArray *tmp_boo;
-	Tango::DevVarBooleanArray *new_tmp_boo;
-	const Tango::DevVarUShortArray *tmp_ush;
-	Tango::DevVarUShortArray *new_tmp_ush;
-	const Tango::DevVarCharArray *tmp_uch;
-	Tango::DevVarCharArray *new_tmp_uch;
-	const Tango::DevVarULongArray *tmp_ulg;
-	Tango::DevVarULongArray *new_tmp_ulg;
-	const Tango::DevVarULong64Array *tmp_ulg64;
-	Tango::DevVarULong64Array *new_tmp_ulg64;
-	const Tango::DevVarStateArray *tmp_state;
-	Tango::DevVarStateArray *new_tmp_state;
-	Tango::DevState sta;
+    const Tango::DevVarDoubleArray *tmp_db;
+    Tango::DevVarDoubleArray *new_tmp_db;
+    const Tango::DevVarShortArray *tmp_sh;
+    Tango::DevVarShortArray *new_tmp_sh;
+    const Tango::DevVarLongArray *tmp_lg;
+    Tango::DevVarLongArray *new_tmp_lg;
+    const Tango::DevVarLong64Array *tmp_lg64;
+    Tango::DevVarLong64Array *new_tmp_lg64;
+    const Tango::DevVarStringArray *tmp_str;
+    Tango::DevVarStringArray *new_tmp_str;
+    const Tango::DevVarFloatArray *tmp_fl;
+    Tango::DevVarFloatArray *new_tmp_fl;
+    const Tango::DevVarBooleanArray *tmp_boo;
+    Tango::DevVarBooleanArray *new_tmp_boo;
+    const Tango::DevVarUShortArray *tmp_ush;
+    Tango::DevVarUShortArray *new_tmp_ush;
+    const Tango::DevVarCharArray *tmp_uch;
+    Tango::DevVarCharArray *new_tmp_uch;
+    const Tango::DevVarULongArray *tmp_ulg;
+    Tango::DevVarULongArray *new_tmp_ulg;
+    const Tango::DevVarULong64Array *tmp_ulg64;
+    Tango::DevVarULong64Array *new_tmp_ulg64;
+    const Tango::DevVarStateArray *tmp_state;
+    Tango::DevVarStateArray *new_tmp_state;
+    Tango::DevState sta;
 
-	switch (type)
-	{
-	case Tango::DEV_SHORT :
-	case Tango::DEV_ENUM :
-		DATA_IN_NET_OBJECT(short_att_value,DevVarShortArray,short,new_tmp_sh,tmp_sh);
-		break;
+    switch (type)
+    {
+        case Tango::DEV_SHORT :
+        case Tango::DEV_ENUM :
+            DATA_IN_NET_OBJECT(short_att_value, DevVarShortArray, short, new_tmp_sh, tmp_sh);
+            break;
 
-    case Tango::DEV_DOUBLE :
-		DATA_IN_NET_OBJECT(double_att_value,DevVarDoubleArray,double,new_tmp_db,tmp_db);
-		break;
+        case Tango::DEV_DOUBLE :
+            DATA_IN_NET_OBJECT(double_att_value, DevVarDoubleArray, double, new_tmp_db, tmp_db);
+            break;
 
-	case Tango::DEV_LONG :
-		DATA_IN_NET_OBJECT(long_att_value,DevVarLongArray,DevLong,new_tmp_lg,tmp_lg);
-		break;
+        case Tango::DEV_LONG :
+            DATA_IN_NET_OBJECT(long_att_value, DevVarLongArray, DevLong, new_tmp_lg, tmp_lg);
+            break;
 
-	case Tango::DEV_LONG64 :
-		DATA_IN_NET_OBJECT(long64_att_value,DevVarLong64Array,DevLong64,new_tmp_lg64,tmp_lg64);
-		break;
+        case Tango::DEV_LONG64 :
+            DATA_IN_NET_OBJECT(long64_att_value, DevVarLong64Array, DevLong64, new_tmp_lg64, tmp_lg64);
+            break;
 
-	case Tango::DEV_STRING :
-		DATA_IN_NET_OBJECT(string_att_value,DevVarStringArray,char *,new_tmp_str,tmp_str);
-		break;
+        case Tango::DEV_STRING :
+            DATA_IN_NET_OBJECT(string_att_value, DevVarStringArray, char *, new_tmp_str, tmp_str);
+            break;
 
-	case Tango::DEV_FLOAT :
-		DATA_IN_NET_OBJECT(float_att_value,DevVarFloatArray,float,new_tmp_fl,tmp_fl);
-		break;
+        case Tango::DEV_FLOAT :
+            DATA_IN_NET_OBJECT(float_att_value, DevVarFloatArray, float, new_tmp_fl, tmp_fl);
+            break;
 
-	case Tango::DEV_BOOLEAN :
-		DATA_IN_NET_OBJECT(bool_att_value,DevVarBooleanArray,DevBoolean,new_tmp_boo,tmp_boo);
-		break;
+        case Tango::DEV_BOOLEAN :
+            DATA_IN_NET_OBJECT(bool_att_value, DevVarBooleanArray, DevBoolean, new_tmp_boo, tmp_boo);
+            break;
 
-	case Tango::DEV_USHORT :
-		DATA_IN_NET_OBJECT(ushort_att_value,DevVarUShortArray,DevUShort,new_tmp_ush,tmp_ush);
-		break;
+        case Tango::DEV_USHORT :
+            DATA_IN_NET_OBJECT(ushort_att_value, DevVarUShortArray, DevUShort, new_tmp_ush, tmp_ush);
+            break;
 
-	case Tango::DEV_UCHAR :
-		DATA_IN_NET_OBJECT(uchar_att_value,DevVarUCharArray,DevUChar,new_tmp_uch,tmp_uch);
-		break;
+        case Tango::DEV_UCHAR :
+            DATA_IN_NET_OBJECT(uchar_att_value, DevVarUCharArray, DevUChar, new_tmp_uch, tmp_uch);
+            break;
 
-	case Tango::DEV_ULONG :
-		DATA_IN_NET_OBJECT(ulong_att_value,DevVarULongArray,DevULong,new_tmp_ulg,tmp_ulg);
-		break;
+        case Tango::DEV_ULONG :
+            DATA_IN_NET_OBJECT(ulong_att_value, DevVarULongArray, DevULong, new_tmp_ulg, tmp_ulg);
+            break;
 
-	case Tango::DEV_ULONG64 :
-		DATA_IN_NET_OBJECT(ulong64_att_value,DevVarULong64Array,DevULong64,new_tmp_ulg64,tmp_ulg64);
-		break;
+        case Tango::DEV_ULONG64 :
+            DATA_IN_NET_OBJECT(ulong64_att_value, DevVarULong64Array, DevULong64, new_tmp_ulg64, tmp_ulg64);
+            break;
 
-	case Tango::DEV_STATE :
-		if (aid.data_5 != Tango_nullptr)
-		{
-			AttributeValue_5 &att_val = polled_att->get_last_attr_value_5(false);
-			if (att_val.value._d() == DEVICE_STATE)
-			{
-				sta = att_val.value.dev_state_att();
-				(*aid.data_5)[index].value.dev_state_att(sta);
-			}
-			else if (att_val.value._d() == ATT_STATE)
-			{
-				DevVarStateArray &union_seq = att_val.value.state_att_value();
-				(*aid.data_5)[index].value.state_att_value(union_seq);
-			}
-		}
-		else if (aid.data_4 != Tango_nullptr)
-		{
-			if (vers >= 5)
-			{
-				AttributeValue_5 &att_val = polled_att->get_last_attr_value_5(false);
-				if (att_val.value._d() == DEVICE_STATE)
-				{
-					sta = att_val.value.dev_state_att();
-					(*aid.data_4)[index].value.dev_state_att(sta);
-				}
-				else if (att_val.value._d() == ATT_STATE)
-				{
-					DevVarStateArray &union_seq = att_val.value.state_att_value();
-					(*aid.data_4)[index].value.state_att_value(union_seq);
-				}
-			}
-			else
-			{
-				AttributeValue_4 &att_val = polled_att->get_last_attr_value_4(false);
-				if (att_val.value._d() == DEVICE_STATE)
-				{
-					sta = att_val.value.dev_state_att();
-					(*aid.data_4)[index].value.dev_state_att(sta);
-				}
-				else if (att_val.value._d() == ATT_STATE)
-				{
-					DevVarStateArray &union_seq = att_val.value.state_att_value();
-					(*aid.data_4)[index].value.state_att_value(union_seq);
-				}
-			}
-		}
-		else
-		{
-			if (vers >= 5)
-			{
-				AttributeValue_5 &att_val = polled_att->get_last_attr_value_5(false);
-				if (att_val.value._d() == DEVICE_STATE)
-				{
-					sta = att_val.value.dev_state_att();
-					(*aid.data_3)[index].value <<= sta;
-				}
-				else if (att_val.value._d() == ATT_STATE)
-				{
-					DevVarStateArray &union_seq = att_val.value.state_att_value();
-					new_tmp_state = new DevVarStateArray(union_seq.length(),
-										union_seq.length(),
-										const_cast<DevState *>(union_seq.get_buffer()),
-										false);
-					(*aid.data_3)[index].value <<= new_tmp_state;
-				}
-			}
-			else if (vers == 4)
-			{
-				AttributeValue_4 &att_val = polled_att->get_last_attr_value_4(false);
-				if (att_val.value._d() == DEVICE_STATE)
-				{
-					sta = att_val.value.dev_state_att();
-					(*aid.data_3)[index].value <<= sta;
-				}
-				else if (att_val.value._d() == ATT_STATE)
-				{
-					DevVarStateArray &union_seq = att_val.value.state_att_value();
-					new_tmp_state = new DevVarStateArray(union_seq.length(),
-										union_seq.length(),
-										const_cast<DevState *>(union_seq.get_buffer()),
-										false);
-					(*aid.data_3)[index].value <<= new_tmp_state;
-				}
-			}
-			else
-			{
-				AttributeValue_3 &att_val = polled_att->get_last_attr_value_3(false);
-				CORBA::TypeCode_var ty;
-				ty = att_val.value.type();
+        case Tango::DEV_STATE :
+            if (aid.data_5 != Tango_nullptr)
+            {
+                AttributeValue_5 &att_val = polled_att->get_last_attr_value_5(false);
+                if (att_val.value._d() == DEVICE_STATE)
+                {
+                    sta = att_val.value.dev_state_att();
+                    (*aid.data_5)[index].value.dev_state_att(sta);
+                }
+                else if (att_val.value._d() == ATT_STATE)
+                {
+                    DevVarStateArray &union_seq = att_val.value.state_att_value();
+                    (*aid.data_5)[index].value.state_att_value(union_seq);
+                }
+            }
+            else if (aid.data_4 != Tango_nullptr)
+            {
+                if (vers >= 5)
+                {
+                    AttributeValue_5 &att_val = polled_att->get_last_attr_value_5(false);
+                    if (att_val.value._d() == DEVICE_STATE)
+                    {
+                        sta = att_val.value.dev_state_att();
+                        (*aid.data_4)[index].value.dev_state_att(sta);
+                    }
+                    else if (att_val.value._d() == ATT_STATE)
+                    {
+                        DevVarStateArray &union_seq = att_val.value.state_att_value();
+                        (*aid.data_4)[index].value.state_att_value(union_seq);
+                    }
+                }
+                else
+                {
+                    AttributeValue_4 &att_val = polled_att->get_last_attr_value_4(false);
+                    if (att_val.value._d() == DEVICE_STATE)
+                    {
+                        sta = att_val.value.dev_state_att();
+                        (*aid.data_4)[index].value.dev_state_att(sta);
+                    }
+                    else if (att_val.value._d() == ATT_STATE)
+                    {
+                        DevVarStateArray &union_seq = att_val.value.state_att_value();
+                        (*aid.data_4)[index].value.state_att_value(union_seq);
+                    }
+                }
+            }
+            else
+            {
+                if (vers >= 5)
+                {
+                    AttributeValue_5 &att_val = polled_att->get_last_attr_value_5(false);
+                    if (att_val.value._d() == DEVICE_STATE)
+                    {
+                        sta = att_val.value.dev_state_att();
+                        (*aid.data_3)[index].value <<= sta;
+                    }
+                    else if (att_val.value._d() == ATT_STATE)
+                    {
+                        DevVarStateArray &union_seq = att_val.value.state_att_value();
+                        new_tmp_state = new DevVarStateArray(union_seq.length(),
+                                                             union_seq.length(),
+                                                             const_cast<DevState *>(union_seq.get_buffer()),
+                                                             false);
+                        (*aid.data_3)[index].value <<= new_tmp_state;
+                    }
+                }
+                else if (vers == 4)
+                {
+                    AttributeValue_4 &att_val = polled_att->get_last_attr_value_4(false);
+                    if (att_val.value._d() == DEVICE_STATE)
+                    {
+                        sta = att_val.value.dev_state_att();
+                        (*aid.data_3)[index].value <<= sta;
+                    }
+                    else if (att_val.value._d() == ATT_STATE)
+                    {
+                        DevVarStateArray &union_seq = att_val.value.state_att_value();
+                        new_tmp_state = new DevVarStateArray(union_seq.length(),
+                                                             union_seq.length(),
+                                                             const_cast<DevState *>(union_seq.get_buffer()),
+                                                             false);
+                        (*aid.data_3)[index].value <<= new_tmp_state;
+                    }
+                }
+                else
+                {
+                    AttributeValue_3 &att_val = polled_att->get_last_attr_value_3(false);
+                    CORBA::TypeCode_var ty;
+                    ty = att_val.value.type();
 
-				if (ty->kind() == CORBA::tk_enum)
-				{
-					att_val.value >>= sta;
-					(*aid.data_3)[index].value <<= sta;
-				}
-				else
-				{
-					att_val.value >>= tmp_state;
-					new_tmp_state = new DevVarStateArray(tmp_state->length(),tmp_state->length(),
-									 const_cast<DevState *>(tmp_state->get_buffer()),false);
-					(*aid.data_3)[index].value <<= new_tmp_state;
-				}
-			}
-		}
-		break;
+                    if (ty->kind() == CORBA::tk_enum)
+                    {
+                        att_val.value >>= sta;
+                        (*aid.data_3)[index].value <<= sta;
+                    }
+                    else
+                    {
+                        att_val.value >>= tmp_state;
+                        new_tmp_state = new DevVarStateArray(tmp_state->length(), tmp_state->length(),
+                                                             const_cast<DevState *>(tmp_state->get_buffer()), false);
+                        (*aid.data_3)[index].value <<= new_tmp_state;
+                    }
+                }
+            }
+            break;
 
-	case Tango::DEV_ENCODED:
-		if (aid.data_5 != Tango_nullptr)
-		{
-			AttributeValue_5 &att_val = polled_att->get_last_attr_value_5(false);
-			DevVarEncodedArray &polled_seq = att_val.value.encoded_att_value();
+        case Tango::DEV_ENCODED:
+            if (aid.data_5 != Tango_nullptr)
+            {
+                AttributeValue_5 &att_val = polled_att->get_last_attr_value_5(false);
+                DevVarEncodedArray &polled_seq = att_val.value.encoded_att_value();
 
-			unsigned int nb_encoded = polled_seq.length();
+                unsigned int nb_encoded = polled_seq.length();
 
-			(*aid.data_5)[index].value.encoded_att_value(dummy_encoded_att_value);
-			DevVarEncodedArray &the_seq = (*aid.data_5)[index].value.encoded_att_value();
+                (*aid.data_5)[index].value.encoded_att_value(dummy_encoded_att_value);
+                DevVarEncodedArray &the_seq = (*aid.data_5)[index].value.encoded_att_value();
 
-			the_seq.length(nb_encoded);
-			for (unsigned int loop = 0;loop < nb_encoded;loop++)
-			{
-				the_seq[loop].encoded_format = CORBA::string_dup(polled_seq[loop].encoded_format);
-				unsigned char *tmp_enc = polled_seq[loop].encoded_data.get_buffer();
-				unsigned int nb_data = polled_seq[loop].encoded_data.length();
-				the_seq[loop].encoded_data.replace(nb_data,nb_data,tmp_enc);
-			}
-		}
-		else if (aid.data_4 != Tango_nullptr)
-		{
-			if (vers == 5)
-			{
-				AttributeValue_5 &att_val = polled_att->get_last_attr_value_5(false);
-				DevVarEncodedArray &polled_seq = att_val.value.encoded_att_value();
+                the_seq.length(nb_encoded);
+                for (unsigned int loop = 0; loop < nb_encoded; loop++)
+                {
+                    the_seq[loop].encoded_format = CORBA::string_dup(polled_seq[loop].encoded_format);
+                    unsigned char *tmp_enc = polled_seq[loop].encoded_data.get_buffer();
+                    unsigned int nb_data = polled_seq[loop].encoded_data.length();
+                    the_seq[loop].encoded_data.replace(nb_data, nb_data, tmp_enc);
+                }
+            }
+            else if (aid.data_4 != Tango_nullptr)
+            {
+                if (vers == 5)
+                {
+                    AttributeValue_5 &att_val = polled_att->get_last_attr_value_5(false);
+                    DevVarEncodedArray &polled_seq = att_val.value.encoded_att_value();
 
-				unsigned int nb_encoded = polled_seq.length();
+                    unsigned int nb_encoded = polled_seq.length();
 
-				(*aid.data_4)[index].value.encoded_att_value(dummy_encoded_att_value);
-				DevVarEncodedArray &the_seq = (*aid.data_4)[index].value.encoded_att_value();
+                    (*aid.data_4)[index].value.encoded_att_value(dummy_encoded_att_value);
+                    DevVarEncodedArray &the_seq = (*aid.data_4)[index].value.encoded_att_value();
 
-				the_seq.length(nb_encoded);
-				for (unsigned int loop = 0;loop < nb_encoded;loop++)
-				{
-					the_seq[loop].encoded_format = CORBA::string_dup(polled_seq[loop].encoded_format);
-					unsigned char *tmp_enc = polled_seq[loop].encoded_data.get_buffer();
-					unsigned int nb_data = polled_seq[loop].encoded_data.length();
-					the_seq[loop].encoded_data.replace(nb_data,nb_data,tmp_enc);
-				}
-			}
-			else
-			{
-				AttributeValue_4 &att_val = polled_att->get_last_attr_value_4(false);
-				DevVarEncodedArray &polled_seq = att_val.value.encoded_att_value();
+                    the_seq.length(nb_encoded);
+                    for (unsigned int loop = 0; loop < nb_encoded; loop++)
+                    {
+                        the_seq[loop].encoded_format = CORBA::string_dup(polled_seq[loop].encoded_format);
+                        unsigned char *tmp_enc = polled_seq[loop].encoded_data.get_buffer();
+                        unsigned int nb_data = polled_seq[loop].encoded_data.length();
+                        the_seq[loop].encoded_data.replace(nb_data, nb_data, tmp_enc);
+                    }
+                }
+                else
+                {
+                    AttributeValue_4 &att_val = polled_att->get_last_attr_value_4(false);
+                    DevVarEncodedArray &polled_seq = att_val.value.encoded_att_value();
 
-				unsigned int nb_encoded = polled_seq.length();
+                    unsigned int nb_encoded = polled_seq.length();
 
-				(*aid.data_4)[index].value.encoded_att_value(dummy_encoded_att_value);
-				DevVarEncodedArray &the_seq = (*aid.data_4)[index].value.encoded_att_value();
+                    (*aid.data_4)[index].value.encoded_att_value(dummy_encoded_att_value);
+                    DevVarEncodedArray &the_seq = (*aid.data_4)[index].value.encoded_att_value();
 
-				the_seq.length(nb_encoded);
-				for (unsigned int loop = 0;loop < nb_encoded;loop++)
-				{
-					the_seq[loop].encoded_format = CORBA::string_dup(polled_seq[loop].encoded_format);
-					unsigned char *tmp_enc = polled_seq[loop].encoded_data.get_buffer();
-					unsigned int nb_data = polled_seq[loop].encoded_data.length();
-					the_seq[loop].encoded_data.replace(nb_data,nb_data,tmp_enc);
-				}
-			}
-		}
-		else
-		{
-			TangoSys_OMemStream o;
-			o << "Data type for attribute " << names[index] << " is DEV_ENCODED.";
-			o << " It's not possible to retrieve this data type through the interface you are using (IDL V3)" << ends;
+                    the_seq.length(nb_encoded);
+                    for (unsigned int loop = 0; loop < nb_encoded; loop++)
+                    {
+                        the_seq[loop].encoded_format = CORBA::string_dup(polled_seq[loop].encoded_format);
+                        unsigned char *tmp_enc = polled_seq[loop].encoded_data.get_buffer();
+                        unsigned int nb_data = polled_seq[loop].encoded_data.length();
+                        the_seq[loop].encoded_data.replace(nb_data, nb_data, tmp_enc);
+                    }
+                }
+            }
+            else
+            {
+                TangoSys_OMemStream o;
+                o << "Data type for attribute " << names[index] << " is DEV_ENCODED.";
+                o << " It's not possible to retrieve this data type through the interface you are using (IDL V3)"
+                  << ends;
 
-			(*aid.data_3)[index].err_list.length(1);
-			(*aid.data_3)[index].err_list[0].severity = Tango::ERR;
-			(*aid.data_3)[index].err_list[0].reason = CORBA::string_dup(API_NotSupportedFeature);
-			(*aid.data_3)[index].err_list[0].origin = CORBA::string_dup("Device_3Impl::read_attributes_from_cache");
+                (*aid.data_3)[index].err_list.length(1);
+                (*aid.data_3)[index].err_list[0].severity = Tango::ERR;
+                (*aid.data_3)[index].err_list[0].reason = CORBA::string_dup(API_NotSupportedFeature);
+                (*aid.data_3)[index].err_list[0].origin = CORBA::string_dup("Device_3Impl::read_attributes_from_cache");
 
-			string s = o.str();
-			(*aid.data_3)[index].err_list[0].desc = CORBA::string_dup(s.c_str());
-			(*aid.data_3)[index].quality = Tango::ATTR_INVALID;
-			(*aid.data_3)[index].name = CORBA::string_dup(names[index]);
-			clear_att_dim((*aid.data_3)[index]);
-		}
-		break;
-	}
+                string s = o.str();
+                (*aid.data_3)[index].err_list[0].desc = CORBA::string_dup(s.c_str());
+                (*aid.data_3)[index].quality = Tango::ATTR_INVALID;
+                (*aid.data_3)[index].name = CORBA::string_dup(names[index]);
+                clear_att_dim((*aid.data_3)[index]);
+            }
+            break;
+    }
 }
 
 //+------------------------------------------------------------------------------------------------------------------
@@ -5362,21 +5384,21 @@ void DeviceImpl::att_conf_loop()
 // Run the loop for wrong attribute conf. or memorized att which failed at startup
 //
 
-    for (size_t i = 0;i < att_list.size();++i)
+    for (size_t i = 0; i < att_list.size(); ++i)
     {
         if (att_list[i]->is_startup_exception() == true ||
             att_list[i]->is_mem_exception() == true)
         {
             force_alarm_state = true;
             if (att_list[i]->is_startup_exception() == true)
-				wrong_conf_att_list.push_back(att_list[i]->get_name());
-			else
-				mem_att_list.push_back(att_list[i]->get_name());
+                wrong_conf_att_list.push_back(att_list[i]->get_name());
+            else
+                mem_att_list.push_back(att_list[i]->get_name());
         }
     }
 
-	if (force_alarm_state == false && fwd_att_wrong_conf.empty() == false)
-		force_alarm_state = true;
+    if (force_alarm_state == false && fwd_att_wrong_conf.empty() == false)
+        force_alarm_state = true;
 
     run_att_conf_loop = false;
 }
@@ -5392,7 +5414,7 @@ void DeviceImpl::att_conf_loop()
 
 void DeviceImpl::check_att_conf()
 {
-	dev_attr->check_idl_release(this);
+    dev_attr->check_idl_release(this);
 
     if (run_att_conf_loop == true)
         att_conf_loop();
@@ -5416,108 +5438,110 @@ void DeviceImpl::check_att_conf()
 //
 //---------------------------------------------------------------------------------------------------------------------
 
-void DeviceImpl::build_att_list_in_status_mess(size_t nb_att,AttErrorType att_type)
+void DeviceImpl::build_att_list_in_status_mess(size_t nb_att, AttErrorType att_type)
 {
 
 //
 // First, the wrongly configured forwarded attributes case
 //
 
-	if (att_type == Tango::DeviceImpl::FWD)
-	{
-		for (size_t i = 0;i < nb_att;++i)
-		{
-			alarm_status = alarm_status + "\nForwarded attribute " + fwd_att_wrong_conf[i].att_name;
-			if (fwd_att_wrong_conf[i].fae != FWD_ROOT_DEV_NOT_STARTED)
-				alarm_status = alarm_status + " is not correctly configured! ";
-			else
-				alarm_status = alarm_status + " not reachable! ";
+    if (att_type == Tango::DeviceImpl::FWD)
+    {
+        for (size_t i = 0; i < nb_att; ++i)
+        {
+            alarm_status = alarm_status + "\nForwarded attribute " + fwd_att_wrong_conf[i].att_name;
+            if (fwd_att_wrong_conf[i].fae != FWD_ROOT_DEV_NOT_STARTED)
+                alarm_status = alarm_status + " is not correctly configured! ";
+            else
+                alarm_status = alarm_status + " not reachable! ";
 
-			alarm_status = alarm_status + "Root attribute name = ";
-			alarm_status = alarm_status + fwd_att_wrong_conf[i].full_root_att_name;
-			if (fwd_att_wrong_conf[i].fae != FWD_ROOT_DEV_NOT_STARTED)
+            alarm_status = alarm_status + "Root attribute name = ";
+            alarm_status = alarm_status + fwd_att_wrong_conf[i].full_root_att_name;
+            if (fwd_att_wrong_conf[i].fae != FWD_ROOT_DEV_NOT_STARTED)
                 alarm_status = alarm_status + "\nYou can update it using the Jive tool";
-			alarm_status = alarm_status + "\nError: ";
-			switch(fwd_att_wrong_conf[i].fae)
-			{
-			case FWD_WRONG_ATTR:
-				alarm_status = alarm_status + "Attribute not found in root device";
-				break;
+            alarm_status = alarm_status + "\nError: ";
+            switch (fwd_att_wrong_conf[i].fae)
+            {
+                case FWD_WRONG_ATTR:
+                    alarm_status = alarm_status + "Attribute not found in root device";
+                    break;
 
-			case FWD_CONF_LOOP:
-				alarm_status = alarm_status + "Loop found in root attributes configuration";
-				break;
+                case FWD_CONF_LOOP:
+                    alarm_status = alarm_status + "Loop found in root attributes configuration";
+                    break;
 
-			case FWD_WRONG_DEV:
-				alarm_status = alarm_status + "Wrong root device";
-				break;
+                case FWD_WRONG_DEV:
+                    alarm_status = alarm_status + "Wrong root device";
+                    break;
 
-			case FWD_MISSING_ROOT:
-				alarm_status = alarm_status + "Missing or wrong root attribute definition";
-				break;
+                case FWD_MISSING_ROOT:
+                    alarm_status = alarm_status + "Missing or wrong root attribute definition";
+                    break;
 
-			case FWD_ROOT_DEV_LOCAL_DEV:
-				alarm_status = alarm_status + "Root device is local device";
-				break;
+                case FWD_ROOT_DEV_LOCAL_DEV:
+                    alarm_status = alarm_status + "Root device is local device";
+                    break;
 
-			case FWD_WRONG_SYNTAX:
-				alarm_status = alarm_status + "Wrong syntax in root attribute definition";
-				break;
+                case FWD_WRONG_SYNTAX:
+                    alarm_status = alarm_status + "Wrong syntax in root attribute definition";
+                    break;
 
-			case FWD_ROOT_DEV_NOT_STARTED:
-				alarm_status = alarm_status + "Root device not started yet. Polling (if any) for this attribute not available";
-				break;
+                case FWD_ROOT_DEV_NOT_STARTED:
+                    alarm_status =
+                        alarm_status + "Root device not started yet. Polling (if any) for this attribute not available";
+                    break;
 
-			case FWD_TOO_OLD_LOCAL_DEVICE:
-				alarm_status = alarm_status + "Local device too old (< IDL 5)";
-				break;
+                case FWD_TOO_OLD_LOCAL_DEVICE:
+                    alarm_status = alarm_status + "Local device too old (< IDL 5)";
+                    break;
 
-			case FWD_TOO_OLD_ROOT_DEVICE:
-				alarm_status = alarm_status + "Root device too old (< IDL 5)";
-				break;
+                case FWD_TOO_OLD_ROOT_DEVICE:
+                    alarm_status = alarm_status + "Root device too old (< IDL 5)";
+                    break;
 
-			case FWD_DOUBLE_USED:
-			{
-				alarm_status = alarm_status + "Root attribute already used in this device server process for attribute ";
-				Util *tg = Util::instance();
-				string root_name(fwd_att_wrong_conf[i].full_root_att_name);
-				transform(root_name.begin(),root_name.end(),root_name.begin(),::tolower);
-				string local_att_name = tg->get_root_att_reg().get_local_att_name(root_name);
-				alarm_status = alarm_status + local_att_name;
-				break;
-			}
+                case FWD_DOUBLE_USED:
+                {
+                    alarm_status =
+                        alarm_status + "Root attribute already used in this device server process for attribute ";
+                    Util *tg = Util::instance();
+                    string root_name(fwd_att_wrong_conf[i].full_root_att_name);
+                    transform(root_name.begin(), root_name.end(), root_name.begin(), ::tolower);
+                    string local_att_name = tg->get_root_att_reg().get_local_att_name(root_name);
+                    alarm_status = alarm_status + local_att_name;
+                    break;
+                }
 
-			default:
-				break;
-			}
-		}
-	}
-	else
-	{
+                default:
+                    break;
+            }
+        }
+    }
+    else
+    {
 
 //
 // For wrong conf. in db or memorized attributes which failed at startup
 //
 
-		if (nb_att > 1)
-			alarm_status = alarm_status + "s";
-		alarm_status = alarm_status + " ";
-		for (size_t i = 0;i < nb_att;++i)
-		{
-			if (att_type == Tango::DeviceImpl::CONF)
-				alarm_status = alarm_status + att_wrong_db_conf[i];
-			else
-				alarm_status = alarm_status + att_mem_failed[i];
+        if (nb_att > 1)
+            alarm_status = alarm_status + "s";
+        alarm_status = alarm_status + " ";
+        for (size_t i = 0; i < nb_att; ++i)
+        {
+            if (att_type == Tango::DeviceImpl::CONF)
+                alarm_status = alarm_status + att_wrong_db_conf[i];
+            else
+                alarm_status = alarm_status + att_mem_failed[i];
 
-			if ((nb_att > 1) && (i <= nb_att - 2))
-				alarm_status = alarm_status + ", ";
-		}
+            if ((nb_att > 1) && (i <= nb_att - 2))
+                alarm_status = alarm_status + ", ";
+        }
 
-		if (nb_att == 1)
-			alarm_status = alarm_status + " has ";
-		else
-			alarm_status = alarm_status + " have ";
-	}
+        if (nb_att == 1)
+            alarm_status = alarm_status + " has ";
+        else
+            alarm_status = alarm_status + " have ";
+    }
 }
 
 //----------------------------------------------------------------------------------------------------------------------
@@ -5535,48 +5559,48 @@ void DeviceImpl::build_att_list_in_status_mess(size_t nb_att,AttErrorType att_ty
 //
 //---------------------------------------------------------------------------------------------------------------------
 
-bool DeviceImpl::is_there_subscriber(const string &att_name,EventType event_type)
+bool DeviceImpl::is_there_subscriber(const string &att_name, EventType event_type)
 {
-	Attribute &att = dev_attr->get_attr_by_name(att_name.c_str());
+    Attribute &att = dev_attr->get_attr_by_name(att_name.c_str());
 
-	bool ret = false;
+    bool ret = false;
 
-	switch(event_type)
-	{
-	case CHANGE_EVENT:
-		ret = att.change_event_subscribed();
-		break;
+    switch (event_type)
+    {
+        case CHANGE_EVENT:
+            ret = att.change_event_subscribed();
+            break;
 
-	case QUALITY_EVENT:
-		ret = att.quality_event_subscribed();
-		break;
+        case QUALITY_EVENT:
+            ret = att.quality_event_subscribed();
+            break;
 
-	case PERIODIC_EVENT:
-		ret = att.periodic_event_subscribed();
-		break;
+        case PERIODIC_EVENT:
+            ret = att.periodic_event_subscribed();
+            break;
 
-	case ARCHIVE_EVENT:
-		ret = att.archive_event_subscribed();
-		break;
+        case ARCHIVE_EVENT:
+            ret = att.archive_event_subscribed();
+            break;
 
-	case USER_EVENT:
-		ret = att.user_event_subscribed();
-		break;
+        case USER_EVENT:
+            ret = att.user_event_subscribed();
+            break;
 
-	case ATTR_CONF_EVENT:
-		ret = att.attr_conf_event_subscribed();
-		break;
+        case ATTR_CONF_EVENT:
+            ret = att.attr_conf_event_subscribed();
+            break;
 
-	case DATA_READY_EVENT:
-		ret = att.data_ready_event_subscribed();
-		break;
+        case DATA_READY_EVENT:
+            ret = att.data_ready_event_subscribed();
+            break;
 
-	default:
-		Except::throw_exception(API_UnsupportedFeature,"Unsupported event type","Device::get_cmd_by_name");
-		break;
-	}
+        default:
+            Except::throw_exception(API_UnsupportedFeature, "Unsupported event type", "Device::get_cmd_by_name");
+            break;
+    }
 
-	return ret;
+    return ret;
 }
 
 //----------------------------------------------------------------------------------------------------------------------
@@ -5595,17 +5619,17 @@ bool DeviceImpl::is_there_subscriber(const string &att_name,EventType event_type
 
 void DeviceImpl::rem_wrong_fwd_att(const string &root_att_name)
 {
-	vector<FwdWrongConf>::iterator ite;
-	for (ite = fwd_att_wrong_conf.begin();ite != fwd_att_wrong_conf.end();++ite)
-	{
-		string local_name(ite->full_root_att_name);
-		transform(local_name.begin(),local_name.end(),local_name.begin(),::tolower);
-		if (local_name == root_att_name)
-		{
-			fwd_att_wrong_conf.erase(ite);
-			break;
-		}
-	}
+    vector<FwdWrongConf>::iterator ite;
+    for (ite = fwd_att_wrong_conf.begin(); ite != fwd_att_wrong_conf.end(); ++ite)
+    {
+        string local_name(ite->full_root_att_name);
+        transform(local_name.begin(), local_name.end(), local_name.begin(), ::tolower);
+        if (local_name == root_att_name)
+        {
+            fwd_att_wrong_conf.erase(ite);
+            break;
+        }
+    }
 }
 
 //----------------------------------------------------------------------------------------------------------------------
@@ -5623,19 +5647,19 @@ void DeviceImpl::rem_wrong_fwd_att(const string &root_att_name)
 //
 //---------------------------------------------------------------------------------------------------------------------
 
-void DeviceImpl::update_wrong_conf_att(const string &root_att_name,FwdAttError err)
+void DeviceImpl::update_wrong_conf_att(const string &root_att_name, FwdAttError err)
 {
-	vector<FwdWrongConf>::iterator ite;
-	for (ite = fwd_att_wrong_conf.begin();ite != fwd_att_wrong_conf.end();++ite)
-	{
-		string local_name(ite->full_root_att_name);
-		transform(local_name.begin(),local_name.end(),local_name.begin(),::tolower);
-		if (local_name == root_att_name)
-		{
-			ite->fae = err;
-			break;
-		}
-	}
+    vector<FwdWrongConf>::iterator ite;
+    for (ite = fwd_att_wrong_conf.begin(); ite != fwd_att_wrong_conf.end(); ++ite)
+    {
+        string local_name(ite->full_root_att_name);
+        transform(local_name.begin(), local_name.end(), local_name.begin(), ::tolower);
+        if (local_name == root_att_name)
+        {
+            ite->fae = err;
+            break;
+        }
+    }
 }
 
 //----------------------------------------------------------------------------------------------------------------------
@@ -5653,41 +5677,41 @@ void DeviceImpl::update_wrong_conf_att(const string &root_att_name,FwdAttError e
 //
 //---------------------------------------------------------------------------------------------------------------------
 
-void DeviceImpl::lock_root_devices(int validity,bool lock_action)
+void DeviceImpl::lock_root_devices(int validity, bool lock_action)
 {
 //
 // Get list of root device(s)
 //
 
-	vector<string> root_devs;
-	vector<string>::iterator ite;
-	vector<Attribute *> att_list = dev_attr->get_attribute_list();
-	for (size_t j = 0;j < att_list.size();j++)
-	{
-		if (att_list[j]->is_fwd_att() == true)
-		{
-			FwdAttribute *fwd_att = static_cast<FwdAttribute *>(att_list[j]);
-			string &dev_name = fwd_att->get_fwd_dev_name();
-			ite = find(root_devs.begin(),root_devs.end(),dev_name);
-			if (ite == root_devs.end())
-				root_devs.push_back(dev_name);
-		}
-	}
+    vector<string> root_devs;
+    vector<string>::iterator ite;
+    vector<Attribute *> att_list = dev_attr->get_attribute_list();
+    for (size_t j = 0; j < att_list.size(); j++)
+    {
+        if (att_list[j]->is_fwd_att() == true)
+        {
+            FwdAttribute *fwd_att = static_cast<FwdAttribute *>(att_list[j]);
+            string &dev_name = fwd_att->get_fwd_dev_name();
+            ite = find(root_devs.begin(), root_devs.end(), dev_name);
+            if (ite == root_devs.end())
+                root_devs.push_back(dev_name);
+        }
+    }
 
 //
 // Lock/Unlock all these devices
 //
 
-	RootAttRegistry &rar = Util::instance()->get_root_att_reg();
-	for (size_t loop = 0;loop < root_devs.size();loop++)
-	{
-		DeviceProxy *dp = rar.get_root_att_dp(root_devs[loop]);
+    RootAttRegistry &rar = Util::instance()->get_root_att_reg();
+    for (size_t loop = 0; loop < root_devs.size(); loop++)
+    {
+        DeviceProxy *dp = rar.get_root_att_dp(root_devs[loop]);
 
-		if (lock_action == true)
-			dp->lock(validity);
-		else
-			dp->unlock();
-	}
+        if (lock_action == true)
+            dp->lock(validity);
+        else
+            dp->unlock();
+    }
 }
 
 //+----------------------------------------------------------------------------
@@ -5702,33 +5726,33 @@ void DeviceImpl::lock_root_devices(int validity,bool lock_action)
 
 Command &DeviceImpl::get_local_cmd_by_name(const string &cmd_name)
 {
-	vector<Command *>::iterator pos;
+    vector<Command *>::iterator pos;
 
 #ifdef HAS_LAMBDA_FUNC
-	pos = find_if(command_list.begin(),command_list.end(),
-					[&] (Command *cmd) -> bool
-					{
-						if (cmd_name.size() != cmd->get_lower_name().size())
-							return false;
-						string tmp_name(cmd_name);
-						transform(tmp_name.begin(),tmp_name.end(),tmp_name.begin(),::tolower);
-						return cmd->get_lower_name() == tmp_name;
-					});
+    pos = find_if(command_list.begin(), command_list.end(),
+                  [&](Command *cmd) -> bool
+                  {
+                      if (cmd_name.size() != cmd->get_lower_name().size())
+                          return false;
+                      string tmp_name(cmd_name);
+                      transform(tmp_name.begin(), tmp_name.end(), tmp_name.begin(), ::tolower);
+                      return cmd->get_lower_name() == tmp_name;
+                  });
 #else
-	pos = find_if(command_list.begin(),command_list.end(),
+                                                                                                                            pos = find_if(command_list.begin(),command_list.end(),
 				bind2nd(WantedCmd<Command *,const char *,bool>(),cmd_name.c_str()));
 #endif
 
-	if (pos == command_list.end())
-	{
-		cout3 << "DeviceImpl::get_cmd_by_name throwing exception" << endl;
-		TangoSys_OMemStream o;
+    if (pos == command_list.end())
+    {
+        cout3 << "DeviceImpl::get_cmd_by_name throwing exception" << endl;
+        TangoSys_OMemStream o;
 
-		o << cmd_name << " command not found" << ends;
-		Except::throw_exception(API_CommandNotFound,o.str(),"Device::get_cmd_by_name");
-	}
+        o << cmd_name << " command not found" << ends;
+        Except::throw_exception(API_CommandNotFound, o.str(), "Device::get_cmd_by_name");
+    }
 
-	return *(*pos);
+    return *(*pos);
 }
 
 //+----------------------------------------------------------------------------
@@ -5743,33 +5767,33 @@ Command &DeviceImpl::get_local_cmd_by_name(const string &cmd_name)
 
 void DeviceImpl::remove_local_command(const string &cmd_name)
 {
-	vector<Command *>::iterator pos;
+    vector<Command *>::iterator pos;
 
 #ifdef HAS_LAMBDA_FUNC
-	pos = find_if(command_list.begin(),command_list.end(),
-					[&] (Command *cmd) -> bool
-					{
-						if (cmd_name.size() != cmd->get_lower_name().size())
-							return false;
-						return cmd->get_lower_name() == cmd_name;
-					});
+    pos = find_if(command_list.begin(), command_list.end(),
+                  [&](Command *cmd) -> bool
+                  {
+                      if (cmd_name.size() != cmd->get_lower_name().size())
+                          return false;
+                      return cmd->get_lower_name() == cmd_name;
+                  });
 #else
-	pos = find_if(command_list.begin(),command_list.end(),
+                                                                                                                            pos = find_if(command_list.begin(),command_list.end(),
 				bind2nd(WantedCmd<Command *,const char *,bool>(),cmd_name.c_str()));
 #endif
 
-	if (pos == command_list.end())
-	{
-		cout3 << "DeviceImpl::remove_local_command throwing exception" << endl;
-		TangoSys_OMemStream o;
+    if (pos == command_list.end())
+    {
+        cout3 << "DeviceImpl::remove_local_command throwing exception" << endl;
+        TangoSys_OMemStream o;
 
-		o << cmd_name << " command not found" << ends;
-		Except::throw_exception((const char *)API_CommandNotFound,
-				      o.str(),
-				      (const char *)"DeviceImpl::remove_local_command");
-	}
+        o << cmd_name << " command not found" << ends;
+        Except::throw_exception((const char *) API_CommandNotFound,
+                                o.str(),
+                                (const char *) "DeviceImpl::remove_local_command");
+    }
 
-	command_list.erase(pos);
+    command_list.erase(pos);
 }
 
 //+-----------------------------------------------------------------------------------------------------------------
@@ -5788,21 +5812,21 @@ void DeviceImpl::remove_local_command(const string &cmd_name)
 
 void DeviceImpl::get_event_param(vector<EventPar> &eve)
 {
-	ZmqEventSupplier *event_supplier_zmq = Util::instance()->get_zmq_event_supplier();
+    ZmqEventSupplier *event_supplier_zmq = Util::instance()->get_zmq_event_supplier();
 
-	if (event_supplier_zmq->any_dev_intr_client(this) == true)
-	{
-		EventPar ep;
+    if (event_supplier_zmq->any_dev_intr_client(this) == true)
+    {
+        EventPar ep;
 
-		ep.notifd = false;
-		ep.zmq = true;
-		ep.attr_id = -1;
-		ep.quality = false;
-		ep.data_ready = false;
-		ep.dev_intr_change = true;
+        ep.notifd = false;
+        ep.zmq = true;
+        ep.attr_id = -1;
+        ep.quality = false;
+        ep.data_ready = false;
+        ep.dev_intr_change = true;
 
-		eve.push_back(ep);
-	}
+        eve.push_back(ep);
+    }
 }
 
 //+-----------------------------------------------------------------------------------------------------------------
@@ -5821,15 +5845,15 @@ void DeviceImpl::get_event_param(vector<EventPar> &eve)
 
 void DeviceImpl::set_event_param(vector<EventPar> &eve)
 {
-	for (size_t loop = 0;loop < eve.size();loop++)
-	{
-		if (eve[loop].attr_id == -1)
-		{
-			if (eve[loop].dev_intr_change == true)
-				set_event_intr_change_subscription(time(NULL));
-			break;
-		}
-	}
+    for (size_t loop = 0; loop < eve.size(); loop++)
+    {
+        if (eve[loop].attr_id == -1)
+        {
+            if (eve[loop].dev_intr_change == true)
+                set_event_intr_change_subscription(time(NULL));
+            break;
+        }
+    }
 }
 
 //+-----------------------------------------------------------------------------------------------------------------
@@ -5856,48 +5880,48 @@ void DeviceImpl::push_dev_intr(bool ev_client)
 // the event in case of attributes/commands added/removed in a loop in order to minimize the event number.
 //
 
-	if (idl_version >= MIN_IDL_DEV_INTR && is_intr_change_ev_enable() == true && ev_client == true)
-	{
-		bool th_running;
-		{
-			omni_mutex_lock lo(devintr_mon);
-			th_running = devintr_shared.th_running;
-		}
+    if (idl_version >= MIN_IDL_DEV_INTR && is_intr_change_ev_enable() == true && ev_client == true)
+    {
+        bool th_running;
+        {
+            omni_mutex_lock lo(devintr_mon);
+            th_running = devintr_shared.th_running;
+        }
 
-		if (th_running == false)
-		{
-			devintr_shared.cmd_pending = false;
-			devintr_thread = new DevIntrThread(devintr_shared,devintr_mon,this);
-			devintr_shared.th_running = true;
+        if (th_running == false)
+        {
+            devintr_shared.cmd_pending = false;
+            devintr_thread = new DevIntrThread(devintr_shared, devintr_mon, this);
+            devintr_shared.th_running = true;
 
-			devintr_thread->start();
-		}
-		else
-		{
-			int interupted;
+            devintr_thread->start();
+        }
+        else
+        {
+            int interupted;
 
-			omni_mutex_lock sync(devintr_mon);
+            omni_mutex_lock sync(devintr_mon);
 
-			devintr_shared.cmd_pending = true;
-			devintr_shared.cmd_code = DEV_INTR_SLEEP;
+            devintr_shared.cmd_pending = true;
+            devintr_shared.cmd_code = DEV_INTR_SLEEP;
 
-			devintr_mon.signal();
+            devintr_mon.signal();
 
-			cout4 << "Cmd sent to device interface change thread" << endl;
+            cout4 << "Cmd sent to device interface change thread" << endl;
 
-			while (devintr_shared.cmd_pending == true)
-			{
-				interupted = devintr_mon.wait(DEFAULT_TIMEOUT);
+            while (devintr_shared.cmd_pending == true)
+            {
+                interupted = devintr_mon.wait(DEFAULT_TIMEOUT);
 
-				if ((devintr_shared.cmd_pending == true) && (interupted == 0))
-				{
-					cout4 << "TIME OUT" << endl;
-					Except::throw_exception(API_CommandTimedOut,"Device interface change event thread blocked !!!",
-											"DeviceImpl::push_dev_intr");
-				}
-			}
-		}
-	}
+                if ((devintr_shared.cmd_pending == true) && (interupted == 0))
+                {
+                    cout4 << "TIME OUT" << endl;
+                    Except::throw_exception(API_CommandTimedOut, "Device interface change event thread blocked !!!",
+                                            "DeviceImpl::push_dev_intr");
+                }
+            }
+        }
+    }
 }
 
 //+-----------------------------------------------------------------------------------------------------------------
@@ -5913,10 +5937,10 @@ void DeviceImpl::push_dev_intr(bool ev_client)
 
 void DeviceImpl::end_pipe_config()
 {
-	cout4 << "Entering end_pipe_config for device " << device_name << endl;
+    cout4 << "Entering end_pipe_config for device " << device_name << endl;
 
-	vector<Pipe *> &pipe_list = device_class->get_pipe_list(device_name_lower);
-	size_t nb_pipe = pipe_list.size();
+    vector<Pipe *> &pipe_list = device_class->get_pipe_list(device_name_lower);
+    size_t nb_pipe = pipe_list.size();
 
 //
 // First get device pipe configuration from db
@@ -5924,15 +5948,15 @@ void DeviceImpl::end_pipe_config()
 
     cout4 << nb_pipe << " pipe(s)" << endl;
 
-	if (nb_pipe != 0)
-	{
-		Tango::Util *tg = Tango::Util::instance();
-		Tango::DbData db_list;
+    if (nb_pipe != 0)
+    {
+        Tango::Util *tg = Tango::Util::instance();
+        Tango::DbData db_list;
 
-		if (tg->_UseDb == true)
-		{
-			for (size_t i = 0;i < nb_pipe;i++)
-				db_list.push_back(DbDatum(pipe_list[i]->get_name()));
+        if (tg->_UseDb == true)
+        {
+            for (size_t i = 0; i < nb_pipe; i++)
+                db_list.push_back(DbDatum(pipe_list[i]->get_name()));
 
 //
 // On some small and old computers, this request could take time if at the same time some other processes also access
@@ -5943,73 +5967,73 @@ void DeviceImpl::end_pipe_config()
             int old_db_timeout = 0;
             if (Util::_FileDb == false)
                 old_db_timeout = tg->get_database()->get_timeout_millis();
-			try
-			{
-			    if (old_db_timeout != 0)
+            try
+            {
+                if (old_db_timeout != 0)
                     tg->get_database()->set_timeout_millis(6000);
-				tg->get_database()->get_device_pipe_property(device_name,db_list,tg->get_db_cache());
-				if (old_db_timeout != 0)
+                tg->get_database()->get_device_pipe_property(device_name, db_list, tg->get_db_cache());
+                if (old_db_timeout != 0)
                     tg->get_database()->set_timeout_millis(old_db_timeout);
-			}
-			catch (Tango::DevFailed &)
-			{
-			    cout4 << "Exception while accessing database" << endl;
+            }
+            catch (Tango::DevFailed &)
+            {
+                cout4 << "Exception while accessing database" << endl;
 
-				tg->get_database()->set_timeout_millis(old_db_timeout);
-				stringstream ss;
-				ss << "Can't get device pipe properties for device " << device_name << ends;
+                tg->get_database()->set_timeout_millis(old_db_timeout);
+                stringstream ss;
+                ss << "Can't get device pipe properties for device " << device_name << ends;
 
-				Except::throw_exception(API_DatabaseAccess,ss.str(),"DeviceImpl::end_pipe_config");
-			}
+                Except::throw_exception(API_DatabaseAccess, ss.str(), "DeviceImpl::end_pipe_config");
+            }
 
 //
 // A loop for each pipe
 //
 
-			long ind = 0;
-			for (size_t i = 0;i < nb_pipe;i++)
-			{
+            long ind = 0;
+            for (size_t i = 0; i < nb_pipe; i++)
+            {
 //
 // If pipe has some properties defined at device level, build a vector of PipeProperty with them
 //
 
-				long nb_prop = 0;
-				vector<PipeProperty> dev_prop;
+                long nb_prop = 0;
+                vector<PipeProperty> dev_prop;
 
-				db_list[ind] >> nb_prop;
-				ind++;
+                db_list[ind] >> nb_prop;
+                ind++;
 
-				for (long j = 0;j < nb_prop;j++)
-				{
-					if (db_list[ind].size() > 1)
-					{
-						string tmp(db_list[ind].value_string[0]);
-						long nb = db_list[ind].size();
-						for (int k = 1;k < nb;k++)
-						{
-							tmp = tmp + ",";
-							tmp = tmp + db_list[ind].value_string[k];
-						}
-						dev_prop.push_back(PipeProperty(db_list[ind].name,tmp));
-					}
-					else
-						dev_prop.push_back(PipeProperty(db_list[ind].name,db_list[ind].value_string[0]));
-					ind++;
-				}
+                for (long j = 0; j < nb_prop; j++)
+                {
+                    if (db_list[ind].size() > 1)
+                    {
+                        string tmp(db_list[ind].value_string[0]);
+                        long nb = db_list[ind].size();
+                        for (int k = 1; k < nb; k++)
+                        {
+                            tmp = tmp + ",";
+                            tmp = tmp + db_list[ind].value_string[k];
+                        }
+                        dev_prop.push_back(PipeProperty(db_list[ind].name, tmp));
+                    }
+                    else
+                        dev_prop.push_back(PipeProperty(db_list[ind].name, db_list[ind].value_string[0]));
+                    ind++;
+                }
 
-				Pipe *pi_ptr = pipe_list[i];
+                Pipe *pi_ptr = pipe_list[i];
 
 //
 // Call method which will aggregate prop definition retrieved at different levels
 //
 
-				set_pipe_prop(dev_prop,pi_ptr,LABEL);
-				set_pipe_prop(dev_prop,pi_ptr,DESCRIPTION);
-			}
-		}
-	}
+                set_pipe_prop(dev_prop, pi_ptr, LABEL);
+                set_pipe_prop(dev_prop, pi_ptr, DESCRIPTION);
+            }
+        }
+    }
 
-	cout4 << "Leaving end_pipe_config for device " << device_name << endl;
+    cout4 << "Leaving end_pipe_config for device " << device_name << endl;
 }
 
 //+-----------------------------------------------------------------------------------------------------------------
@@ -6031,9 +6055,9 @@ void DeviceImpl::end_pipe_config()
 //
 //------------------------------------------------------------------------------------------------------------------
 
-void DeviceImpl::set_pipe_prop(vector<PipeProperty> &dev_prop,Pipe *pi_ptr,PipePropType ppt)
+void DeviceImpl::set_pipe_prop(vector<PipeProperty> &dev_prop, Pipe *pi_ptr, PipePropType ppt)
 {
-	cout4 << "Entering set_pipe_prop() method" << endl;
+    cout4 << "Entering set_pipe_prop() method" << endl;
 //
 // Final init of pipe prop with following priorities:
 // - Device pipe
@@ -6042,80 +6066,81 @@ void DeviceImpl::set_pipe_prop(vector<PipeProperty> &dev_prop,Pipe *pi_ptr,PipeP
 // The pipe instance we have here already has config set to user default (if any)
 //
 
-	bool found = false;
-	string req_p_name;
-	if (ppt == LABEL)
-		req_p_name = "label";
-	else
-		req_p_name = "description";
+    bool found = false;
+    string req_p_name;
+    if (ppt == LABEL)
+        req_p_name = "label";
+    else
+        req_p_name = "description";
 
-	vector<PipeProperty>::iterator dev_ite;
-	for (dev_ite = dev_prop.begin();dev_ite != dev_prop.end();++dev_ite)
-	{
-		string p_name = dev_ite->get_name();
-		transform(p_name.begin(),p_name.end(),p_name.begin(),::tolower);
+    vector<PipeProperty>::iterator dev_ite;
+    for (dev_ite = dev_prop.begin(); dev_ite != dev_prop.end(); ++dev_ite)
+    {
+        string p_name = dev_ite->get_name();
+        transform(p_name.begin(), p_name.end(), p_name.begin(), ::tolower);
 
-		if (p_name == req_p_name)
-		{
-			found = true;
-			break;
-		}
-	}
+        if (p_name == req_p_name)
+        {
+            found = true;
+            break;
+        }
+    }
 
-	if (found == true)
-	{
-		if (ppt == LABEL)
-			pi_ptr->set_label(dev_ite->get_value());
-		else
-			pi_ptr->set_desc(dev_ite->get_value());
-	}
-	else
-	{
+    if (found == true)
+    {
+        if (ppt == LABEL)
+            pi_ptr->set_label(dev_ite->get_value());
+        else
+            pi_ptr->set_desc(dev_ite->get_value());
+    }
+    else
+    {
 
 //
 // Prop not defined at device level. If the prop is still the lib default one, search if it is defined at class
 // level
 //
 
-		bool still_default;
-		if (ppt == LABEL)
-			still_default = pi_ptr->is_label_lib_default();
-		else
-			still_default = pi_ptr->is_desc_lib_default();
+        bool still_default;
+        if (ppt == LABEL)
+            still_default = pi_ptr->is_label_lib_default();
+        else
+            still_default = pi_ptr->is_desc_lib_default();
 
-		if (still_default == true)
-		{
-			try
-			{
-				vector<PipeProperty> &cl_pi_prop = device_class->get_class_pipe()->get_prop_list(pi_ptr->get_name());
+        if (still_default == true)
+        {
+            try
+            {
+                vector<PipeProperty> &cl_pi_prop = device_class->get_class_pipe()->get_prop_list(pi_ptr->get_name());
 
-				bool found = false;
-				vector<PipeProperty>::iterator class_ite;
-				for (class_ite = cl_pi_prop.begin();class_ite != cl_pi_prop.end();++class_ite)
-				{
-					string p_name = class_ite->get_name();
-					transform(p_name.begin(),p_name.end(),p_name.begin(),::tolower);
+                bool found = false;
+                vector<PipeProperty>::iterator class_ite;
+                for (class_ite = cl_pi_prop.begin(); class_ite != cl_pi_prop.end(); ++class_ite)
+                {
+                    string p_name = class_ite->get_name();
+                    transform(p_name.begin(), p_name.end(), p_name.begin(), ::tolower);
 
-					if (p_name == req_p_name)
-					{
-						found = true;
-						break;
-					}
-				}
+                    if (p_name == req_p_name)
+                    {
+                        found = true;
+                        break;
+                    }
+                }
 
-				if (found == true)
-				{
-					if (ppt == LABEL)
-						pi_ptr->set_label(class_ite->get_value());
-					else
-						pi_ptr->set_desc(class_ite->get_value());
-				}
-			}
-			catch (Tango::DevFailed &) {}
-		}
-	}
+                if (found == true)
+                {
+                    if (ppt == LABEL)
+                        pi_ptr->set_label(class_ite->get_value());
+                    else
+                        pi_ptr->set_desc(class_ite->get_value());
+                }
+            }
+            catch (Tango::DevFailed &)
+            {}
+        }
+    }
 
-	cout4 << "Leaving set_pipe_prop() method" << endl;
+    cout4 << "Leaving set_pipe_prop() method" << endl;
 }
 
 } // End of Tango namespace

--- a/cppapi/server/eventsupplier.cpp
+++ b/cppapi/server/eventsupplier.cpp
@@ -661,13 +661,17 @@ bool EventSupplier::detect_and_push_archive_event(DeviceImpl *device_impl,
         else
         {
 #ifdef _TG_WINDOWS_
-            double tmp = (double)arch_period * DELTA_PERIODIC;
-            double int_part,eve_round;
-            double frac = modf(tmp,&int_part);
+            double tmp = (double) arch_period * DELTA_PERIODIC;
+            double int_part, eve_round;
+            double frac = modf(tmp, &int_part);
             if (frac >= 0.5)
+            {
                 eve_round = ceil(tmp);
+            }
             else
+            {
                 eve_round = floor(tmp);
+            }
 #else
             double eve_round = round((double) arch_period * DELTA_PERIODIC);
 #endif
@@ -690,7 +694,7 @@ bool EventSupplier::detect_and_push_archive_event(DeviceImpl *device_impl,
 //
 
 
-    if (!attr.prev_archive_event.inited)
+    if (attr.prev_archive_event.inited == false)
     {
         if (except != NULL)
         {

--- a/cppapi/server/eventsupplier.cpp
+++ b/cppapi/server/eventsupplier.cpp
@@ -39,13 +39,18 @@
 #include <float.h>
 #endif // _TG_WINDOWS_
 
-namespace Tango {
+namespace Tango
+{
 
-omni_mutex		EventSupplier::event_mutex;
-omni_mutex		EventSupplier::detect_mutex;
-omni_mutex		EventSupplier::push_mutex;
-omni_condition 	EventSupplier::push_cond(&EventSupplier::push_mutex);
-string      	EventSupplier::fqdn_prefix;
+omni_mutex        EventSupplier::event_mutex;
+
+omni_mutex        EventSupplier::detect_mutex;
+
+omni_mutex        EventSupplier::push_mutex;
+
+omni_condition    EventSupplier::push_cond(&EventSupplier::push_mutex);
+
+string        EventSupplier::fqdn_prefix;
 
 //---------------------------------------------------------------------------------------------------------------------
 //
@@ -62,7 +67,8 @@ string      	EventSupplier::fqdn_prefix;
 //--------------------------------------------------------------------------------------------------------------------
 
 
-EventSupplier::EventSupplier(Util *tg):one_subscription_cmd(false)
+EventSupplier::EventSupplier(Util *tg)
+    : one_subscription_cmd(false)
 {
     if (fqdn_prefix.empty() == true)
     {
@@ -74,7 +80,7 @@ EventSupplier::EventSupplier(Util *tg):one_subscription_cmd(false)
             Database *db = tg->get_database();
             fqdn_prefix = fqdn_prefix + db->get_db_host() + ':' + db->get_db_port() + '/';
         }
-        transform(fqdn_prefix.begin(),fqdn_prefix.end(),fqdn_prefix.begin(),::tolower);
+        transform(fqdn_prefix.begin(), fqdn_prefix.end(), fqdn_prefix.begin(), ::tolower);
     }
 }
 
@@ -96,13 +102,13 @@ EventSupplier::EventSupplier(Util *tg):one_subscription_cmd(false)
 //
 //--------------------------------------------------------------------------------------------------------------------
 
-SendEventType EventSupplier::detect_and_push_events(DeviceImpl *device_impl,struct SuppliedEventData &attr_value,
-												DevFailed *except,string &attr_name,struct timeval *time_bef_attr)
+SendEventType EventSupplier::detect_and_push_events(DeviceImpl *device_impl, struct SuppliedEventData &attr_value,
+                                                    DevFailed *except, string &attr_name, struct timeval *time_bef_attr)
 {
     string event, domain_name;
     time_t now, change3_subscription, periodic3_subscription, archive3_subscription;
-    time_t change4_subscription, periodic4_subscription,archive4_subscription;
-    time_t change5_subscription, periodic5_subscription,archive5_subscription;
+    time_t change4_subscription, periodic4_subscription, archive4_subscription;
+    time_t change5_subscription, periodic5_subscription, archive5_subscription;
     SendEventType ret;
     cout3 << "EventSupplier::detect_and_push_events(): called for attribute " << attr_name << endl;
 
@@ -111,22 +117,23 @@ SendEventType EventSupplier::detect_and_push_events(DeviceImpl *device_impl,stru
     now = time(NULL);
 
     {
-    	omni_mutex_lock oml(event_mutex);
+        omni_mutex_lock oml(event_mutex);
 
-		change3_subscription = now - attr.event_change3_subscription;
-		periodic3_subscription = now - attr.event_periodic3_subscription;
-		archive3_subscription = now - attr.event_archive3_subscription;
+        change3_subscription = now - attr.event_change3_subscription;
+        periodic3_subscription = now - attr.event_periodic3_subscription;
+        archive3_subscription = now - attr.event_archive3_subscription;
 
-		change4_subscription = now - attr.event_change4_subscription;
-		periodic4_subscription = now - attr.event_periodic4_subscription;
-		archive4_subscription = now - attr.event_archive4_subscription;
+        change4_subscription = now - attr.event_change4_subscription;
+        periodic4_subscription = now - attr.event_periodic4_subscription;
+        archive4_subscription = now - attr.event_archive4_subscription;
 
-		change5_subscription = now - attr.event_change5_subscription;
-		periodic5_subscription = now - attr.event_periodic5_subscription;
-		archive5_subscription = now - attr.event_archive5_subscription;
+        change5_subscription = now - attr.event_change5_subscription;
+        periodic5_subscription = now - attr.event_periodic5_subscription;
+        archive5_subscription = now - attr.event_archive5_subscription;
     }
 
-    cout3 << "EventSupplier::detect_and_push_events(): last subscription for change5 " << change5_subscription << " periodic5 " << periodic5_subscription << " archive5 " << archive5_subscription << endl;
+    cout3 << "EventSupplier::detect_and_push_events(): last subscription for change5 " << change5_subscription
+          << " periodic5 " << periodic5_subscription << " archive5 " << archive5_subscription << endl;
 
 //
 // For change event
@@ -134,34 +141,34 @@ SendEventType EventSupplier::detect_and_push_events(DeviceImpl *device_impl,stru
 //
 
     ret.change = false;
-    vector<int> client_libs = attr.get_client_lib(CHANGE_EVENT); 	// We want a copy
+    vector<int> client_libs = attr.get_client_lib(CHANGE_EVENT);    // We want a copy
 
     vector<int>::iterator ite;
-    for (ite = client_libs.begin();ite != client_libs.end();++ite)
-	{
-		switch (*ite)
-		{
-			case 5:
-			if (change5_subscription >= EVENT_RESUBSCRIBE_PERIOD)
-				attr.remove_client_lib(5,string(EventName[CHANGE_EVENT]));
-			break;
+    for (ite = client_libs.begin(); ite != client_libs.end(); ++ite)
+    {
+        switch (*ite)
+        {
+            case 5:
+                if (change5_subscription >= EVENT_RESUBSCRIBE_PERIOD)
+                    attr.remove_client_lib(5, string(EventName[CHANGE_EVENT]));
+                break;
 
-			case 4:
-			if (change4_subscription >= EVENT_RESUBSCRIBE_PERIOD)
-				attr.remove_client_lib(4,string(EventName[CHANGE_EVENT]));
-			break;
+            case 4:
+                if (change4_subscription >= EVENT_RESUBSCRIBE_PERIOD)
+                    attr.remove_client_lib(4, string(EventName[CHANGE_EVENT]));
+                break;
 
-			default:
-			if (change3_subscription >= EVENT_RESUBSCRIBE_PERIOD)
-				attr.remove_client_lib(3,string(EventName[CHANGE_EVENT]));
-			break;
-		}
+            default:
+                if (change3_subscription >= EVENT_RESUBSCRIBE_PERIOD)
+                    attr.remove_client_lib(3, string(EventName[CHANGE_EVENT]));
+                break;
+        }
 
-	}
+    }
 
     if (client_libs.empty() == false)
     {
-        if (detect_and_push_change_event(device_impl,attr_value,attr,attr_name,except) == true)
+        if (detect_and_push_change_event(device_impl, attr_value, attr, attr_name, except) == true)
             ret.change = true;
     }
 
@@ -171,33 +178,33 @@ SendEventType EventSupplier::detect_and_push_events(DeviceImpl *device_impl,stru
 
     ret.periodic = false;
     client_libs.clear();
-    client_libs = attr.get_client_lib(PERIODIC_EVENT); 	// We want a copy
+    client_libs = attr.get_client_lib(PERIODIC_EVENT);    // We want a copy
 
-    for (ite = client_libs.begin();ite != client_libs.end();++ite)
-	{
-		switch (*ite)
-		{
-			case 5:
-			if (periodic5_subscription >= EVENT_RESUBSCRIBE_PERIOD)
-				attr.remove_client_lib(5,string(EventName[PERIODIC_EVENT]));
-			break;
+    for (ite = client_libs.begin(); ite != client_libs.end(); ++ite)
+    {
+        switch (*ite)
+        {
+            case 5:
+                if (periodic5_subscription >= EVENT_RESUBSCRIBE_PERIOD)
+                    attr.remove_client_lib(5, string(EventName[PERIODIC_EVENT]));
+                break;
 
-			case 4:
-			if (periodic4_subscription >= EVENT_RESUBSCRIBE_PERIOD)
-				attr.remove_client_lib(4,string(EventName[PERIODIC_EVENT]));
-			break;
+            case 4:
+                if (periodic4_subscription >= EVENT_RESUBSCRIBE_PERIOD)
+                    attr.remove_client_lib(4, string(EventName[PERIODIC_EVENT]));
+                break;
 
-			default:
-			if (periodic3_subscription >= EVENT_RESUBSCRIBE_PERIOD)
-				attr.remove_client_lib(3,string(EventName[PERIODIC_EVENT]));
-			break;
-		}
+            default:
+                if (periodic3_subscription >= EVENT_RESUBSCRIBE_PERIOD)
+                    attr.remove_client_lib(3, string(EventName[PERIODIC_EVENT]));
+                break;
+        }
 
-	}
+    }
 
     if (client_libs.empty() == false)
     {
-        if (detect_and_push_periodic_event(device_impl,attr_value,attr,attr_name,except,time_bef_attr) == true)
+        if (detect_and_push_periodic_event(device_impl, attr_value, attr, attr_name, except, time_bef_attr) == true)
             ret.periodic = true;
     }
 
@@ -207,33 +214,33 @@ SendEventType EventSupplier::detect_and_push_events(DeviceImpl *device_impl,stru
 
     ret.archive = false;
     client_libs.clear();
-    client_libs = attr.get_client_lib(ARCHIVE_EVENT); 	// We want a copy
+    client_libs = attr.get_client_lib(ARCHIVE_EVENT);    // We want a copy
 
-    for (ite = client_libs.begin();ite != client_libs.end();++ite)
-	{
-		switch (*ite)
-		{
-			case 5:
-			if (archive5_subscription >= EVENT_RESUBSCRIBE_PERIOD)
-				attr.remove_client_lib(5,string(EventName[ARCHIVE_EVENT]));
-			break;
+    for (ite = client_libs.begin(); ite != client_libs.end(); ++ite)
+    {
+        switch (*ite)
+        {
+            case 5:
+                if (archive5_subscription >= EVENT_RESUBSCRIBE_PERIOD)
+                    attr.remove_client_lib(5, string(EventName[ARCHIVE_EVENT]));
+                break;
 
-			case 4:
-			if (archive4_subscription >= EVENT_RESUBSCRIBE_PERIOD)
-				attr.remove_client_lib(4,string(EventName[ARCHIVE_EVENT]));
-			break;
+            case 4:
+                if (archive4_subscription >= EVENT_RESUBSCRIBE_PERIOD)
+                    attr.remove_client_lib(4, string(EventName[ARCHIVE_EVENT]));
+                break;
 
-			default:
-			if (archive3_subscription >= EVENT_RESUBSCRIBE_PERIOD)
-				attr.remove_client_lib(3,string(EventName[ARCHIVE_EVENT]));
-			break;
-		}
+            default:
+                if (archive3_subscription >= EVENT_RESUBSCRIBE_PERIOD)
+                    attr.remove_client_lib(3, string(EventName[ARCHIVE_EVENT]));
+                break;
+        }
 
-	}
+    }
 
     if (client_libs.empty() == false)
     {
-        if (detect_and_push_archive_event(device_impl,attr_value,attr,attr_name,except,time_bef_attr) == true)
+        if (detect_and_push_archive_event(device_impl, attr_value, attr, attr_name, except, time_bef_attr) == true)
             ret.archive = true;
     }
 
@@ -259,14 +266,14 @@ SendEventType EventSupplier::detect_and_push_events(DeviceImpl *device_impl,stru
 //
 //--------------------------------------------------------------------------------------------------------------------
 
-bool EventSupplier::detect_and_push_change_event(DeviceImpl *device_impl,struct SuppliedEventData &attr_value,
-                     Attribute &attr,string &attr_name,DevFailed *except,bool user_push)
+bool EventSupplier::detect_and_push_change_event(DeviceImpl *device_impl, struct SuppliedEventData &attr_value,
+                                                 Attribute &attr, string &attr_name, DevFailed *except, bool user_push)
 {
     string event, domain_name;
     double delta_change_rel = 0.0;
     double delta_change_abs = 0.0;
-    bool is_change      = false;
-    bool force_change   = false;
+    bool is_change = false;
+    bool force_change = false;
     bool quality_change = false;
     bool ret = false;
 
@@ -297,12 +304,12 @@ bool EventSupplier::detect_and_push_change_event(DeviceImpl *device_impl,struct 
     {
         if (except != NULL)
         {
-            attr.prev_change_event.err    = true;
+            attr.prev_change_event.err = true;
             attr.prev_change_event.except = *except;
         }
         else
         {
-			if (attr_value.attr_val_5 != NULL)
+            if (attr_value.attr_val_5 != NULL)
                 attr.prev_change_event.value_4 = attr_value.attr_val_5->value;
             else if (attr_value.attr_val_4 != NULL)
                 attr.prev_change_event.value_4 = attr_value.attr_val_4->value;
@@ -325,15 +332,23 @@ bool EventSupplier::detect_and_push_change_event(DeviceImpl *device_impl,struct 
 // Determine delta_change in percent compared with previous event sent
 //
 
-        is_change = detect_change(attr,attr_value,false,delta_change_rel,delta_change_abs,except,force_change,device_impl);
-        cout3 << "EventSupplier::detect_and_push_change_event(): rel_change " << delta_change_rel << " abs_change " << delta_change_abs << " is change = " << is_change << endl;
+        is_change = detect_change(attr,
+                                  attr_value,
+                                  false,
+                                  delta_change_rel,
+                                  delta_change_abs,
+                                  except,
+                                  force_change,
+                                  device_impl);
+        cout3 << "EventSupplier::detect_and_push_change_event(): rel_change " << delta_change_rel << " abs_change "
+              << delta_change_abs << " is change = " << is_change << endl;
     }
 
 //
 // Check whether the data quality has changed. Fire event on a quality change.
 //
 
-    if ((except == NULL) && (attr.prev_change_event.quality != the_quality ))
+    if ((except == NULL) && (attr.prev_change_event.quality != the_quality))
     {
         is_change = true;
         quality_change = true;
@@ -348,7 +363,7 @@ bool EventSupplier::detect_and_push_change_event(DeviceImpl *device_impl,struct 
 
         if (except != NULL)
         {
-            attr.prev_change_event.err    = true;
+            attr.prev_change_event.err = true;
             attr.prev_change_event.except = *except;
         }
         else
@@ -358,11 +373,11 @@ bool EventSupplier::detect_and_push_change_event(DeviceImpl *device_impl,struct 
             else if (attr_value.attr_val_4 != NULL)
                 attr.prev_change_event.value_4 = attr_value.attr_val_4->value;
             else if (attr_value.attr_val_3 != NULL)
-                attr.prev_change_event.value   = attr_value.attr_val_3->value;
+                attr.prev_change_event.value = attr_value.attr_val_3->value;
             else
-                attr.prev_change_event.value   = attr_value.attr_val->value;
+                attr.prev_change_event.value = attr_value.attr_val->value;
             attr.prev_change_event.quality = the_quality;
-            attr.prev_change_event.err     = false;
+            attr.prev_change_event.err = false;
         }
 
 //
@@ -377,78 +392,78 @@ bool EventSupplier::detect_and_push_change_event(DeviceImpl *device_impl,struct 
 
         filterable_names.push_back("forced_event");
         if (force_change == true)
-            filterable_data.push_back((double)1.0);
+            filterable_data.push_back((double) 1.0);
         else
-            filterable_data.push_back((double)0.0);
+            filterable_data.push_back((double) 0.0);
 
         filterable_names.push_back("quality");
         if (quality_change == true)
-            filterable_data.push_back((double)1.0);
+            filterable_data.push_back((double) 1.0);
         else
-            filterable_data.push_back((double)0.0);
+            filterable_data.push_back((double) 0.0);
 
-		vector<int> &client_libs = attr.get_client_lib(CHANGE_EVENT);
-		vector<int>::iterator ite;
-		string ev_name = EventName[CHANGE_EVENT];
-		bool inc_ctr = true;
+        vector<int> &client_libs = attr.get_client_lib(CHANGE_EVENT);
+        vector<int>::iterator ite;
+        string ev_name = EventName[CHANGE_EVENT];
+        bool inc_ctr = true;
 
-		for (ite = client_libs.begin();ite != client_libs.end();++ite)
-		{
-			bool need_free = false;
-			bool name_changed = false;
+        for (ite = client_libs.begin(); ite != client_libs.end(); ++ite)
+        {
+            bool need_free = false;
+            bool name_changed = false;
 
-			struct SuppliedEventData sent_value;
-		    ::memset(&sent_value,0,sizeof(sent_value));
+            struct SuppliedEventData sent_value;
+            ::memset(&sent_value, 0, sizeof(sent_value));
 
-			switch (*ite)
-			{
-				case 5:
-				{
-					convert_att_event_to_5(attr_value,sent_value,need_free,attr);
-					ev_name = EVENT_COMPAT_IDL5 + ev_name;
-					name_changed = true;
-				}
-				break;
+            switch (*ite)
+            {
+                case 5:
+                {
+                    convert_att_event_to_5(attr_value, sent_value, need_free, attr);
+                    ev_name = EVENT_COMPAT_IDL5 + ev_name;
+                    name_changed = true;
+                }
+                    break;
 
-				case 4:
-				{
-					convert_att_event_to_4(attr_value,sent_value,need_free,attr);
-				}
-				break;
+                case 4:
+                {
+                    convert_att_event_to_4(attr_value, sent_value, need_free, attr);
+                }
+                    break;
 
-				default:
-				{
-					convert_att_event_to_3(attr_value,sent_value,need_free,attr);
-				}
-				break;
-			}
+                default:
+                {
+                    convert_att_event_to_3(attr_value, sent_value, need_free, attr);
+                }
+                    break;
+            }
 
-			push_event(device_impl,
-				   ev_name,
-				   filterable_names,
-				   filterable_data,
-				   filterable_names_lg,
-				   filterable_data_lg,
-				   sent_value,
-				   attr_name,
-				   except,
-				   inc_ctr);
+            push_event(device_impl,
+                       ev_name,
+                       filterable_names,
+                       filterable_data,
+                       filterable_names_lg,
+                       filterable_data_lg,
+                       sent_value,
+                       attr_name,
+                       except,
+                       inc_ctr);
 
-			inc_ctr = false;
-			if (need_free == true)
-			{
-				if (sent_value.attr_val_5 != NULL)
-					delete sent_value.attr_val_5;
-				else if (sent_value.attr_val_4 != NULL)
-					delete sent_value.attr_val_4;
-				else if (sent_value.attr_val_3 != NULL)
-					delete sent_value.attr_val_3;
-				else
-					delete sent_value.attr_val;
-			}
-			if (name_changed == true)
-				ev_name = EventName[CHANGE_EVENT];
-		}
+            inc_ctr = false;
+            if (need_free == true)
+            {
+                if (sent_value.attr_val_5 != NULL)
+                    delete sent_value.attr_val_5;
+                else if (sent_value.attr_val_4 != NULL)
+                    delete sent_value.attr_val_4;
+                else if (sent_value.attr_val_3 != NULL)
+                    delete sent_value.attr_val_3;
+                else
+                    delete sent_value.attr_val;
+            }
+            if (name_changed == true)
+                ev_name = EventName[CHANGE_EVENT];
+        }
         ret = true;
 
     }
@@ -477,23 +492,27 @@ bool EventSupplier::detect_and_push_change_event(DeviceImpl *device_impl,struct 
 //
 //------------------------------------------------------------------------------------------------------------------
 
-bool EventSupplier::detect_and_push_archive_event(DeviceImpl *device_impl,SuppliedEventData &attr_value,
-                    Attribute &attr,string &attr_name,DevFailed *except,struct timeval *time_bef_attr,
-                    bool user_push)
+bool EventSupplier::detect_and_push_archive_event(DeviceImpl *device_impl,
+                                                  SuppliedEventData &attr_value,
+                                                  Attribute &attr,
+                                                  string &attr_name,
+                                                  DevFailed *except,
+                                                  struct timeval *time_bef_attr,
+                                                  bool user_push)
 {
-	string event, domain_name;
-	double delta_change_rel = 0.0;
-	double delta_change_abs = 0.0;
-	bool is_change = false;
-	bool force_change = false;
-	bool period_change = false;
-	bool quality_change = false;
-	bool ret = false;
+    string event, domain_name;
+    double delta_change_rel = 0.0;
+    double delta_change_abs = 0.0;
+    bool is_change = false;
+    bool force_change = false;
+    bool period_change = false;
+    bool quality_change = false;
+    bool ret = false;
 
-	cout3 << "EventSupplier::detect_and_push_archive_event(): called for attribute " << attr_name << endl;
+    cout3 << "EventSupplier::detect_and_push_archive_event(): called for attribute " << attr_name << endl;
 
-	double now_ms, ms_since_last_periodic;
-	Tango::AttrQuality the_quality;
+    double now_ms, ms_since_last_periodic;
+    Tango::AttrQuality the_quality;
 
     if (attr_value.attr_val_5 != NULL)
         the_quality = attr_value.attr_val_5->quality;
@@ -504,26 +523,26 @@ bool EventSupplier::detect_and_push_archive_event(DeviceImpl *device_impl,Suppli
     else
         the_quality = attr_value.attr_val->quality;
 
-	struct timeval now;
-	if (time_bef_attr == NULL)
-	{
+    struct timeval now;
+    if (time_bef_attr == NULL)
+    {
 #ifdef _TG_WINDOWS_
-		struct _timeb now_win;
+        struct _timeb now_win;
 
-		_ftime(&now_win);
-		now.tv_sec = (unsigned long)now_win.time;
-		now.tv_usec = (long)now_win.millitm * 1000;
+        _ftime(&now_win);
+        now.tv_sec = (unsigned long)now_win.time;
+        now.tv_usec = (long)now_win.millitm * 1000;
 #else
-		gettimeofday(&now,NULL);
+        gettimeofday(&now, NULL);
 #endif
-		now.tv_sec = now.tv_sec - DELTA_T;
-	}
+        now.tv_sec = now.tv_sec - DELTA_T;
+    }
 
 //
 // get the mutex to synchronize the sending of events
 //
 
-	omni_mutex_lock l(event_mutex);
+    omni_mutex_lock l(event_mutex);
 
 //
 // Do not get time now. This method is executed after the attribute has been read.
@@ -532,17 +551,17 @@ bool EventSupplier::detect_and_push_archive_event(DeviceImpl *device_impl,Suppli
 // Use the time taken in the polling thread before the attribute was read. This one is much more stable
 //
 
-	if (time_bef_attr != NULL)
-		now_ms = (double)time_bef_attr->tv_sec * 1000. + (double)time_bef_attr->tv_usec / 1000.;
-	else
-		now_ms = (double)now.tv_sec * 1000. + (double)now.tv_usec / 1000.;
-	ms_since_last_periodic = now_ms - attr.archive_last_periodic;
+    if (time_bef_attr != NULL)
+        now_ms = (double) time_bef_attr->tv_sec * 1000. + (double) time_bef_attr->tv_usec / 1000.;
+    else
+        now_ms = (double) now.tv_sec * 1000. + (double) now.tv_usec / 1000.;
+    ms_since_last_periodic = now_ms - attr.archive_last_periodic;
 
-	int arch_period;
-	TangoMonitor &mon1 = device_impl->get_att_conf_monitor();
-	mon1.get_monitor();
-	arch_period = attr.archive_period;
-	mon1.rel_monitor();
+    int arch_period;
+    TangoMonitor &mon1 = device_impl->get_att_conf_monitor();
+    mon1.get_monitor();
+    arch_period = attr.archive_period;
+    mon1.rel_monitor();
 
 //
 // Specify the precision interval for the archive period testing 2% are used for periods < 5000 ms and
@@ -551,224 +570,233 @@ bool EventSupplier::detect_and_push_archive_event(DeviceImpl *device_impl,Suppli
 // archive event
 //
 
-	if (arch_period != INT_MAX)
-	{
-		if ( arch_period >= 5000 )
-		{
-			arch_period = arch_period - DELTA_PERIODIC_LONG;
-		}
-		else
-		{
+    if (arch_period != INT_MAX)
+    {
+        if (arch_period >= 5000)
+        {
+            arch_period = arch_period - DELTA_PERIODIC_LONG;
+        }
+        else
+        {
 #ifdef _TG_WINDOWS_
-			double tmp = (double)arch_period * DELTA_PERIODIC;
-			double int_part,eve_round;
-			double frac = modf(tmp,&int_part);
-			if (frac >= 0.5)
-				eve_round = ceil(tmp);
-			else
-				eve_round = floor(tmp);
+            double tmp = (double)arch_period * DELTA_PERIODIC;
+            double int_part,eve_round;
+            double frac = modf(tmp,&int_part);
+            if (frac >= 0.5)
+                eve_round = ceil(tmp);
+            else
+                eve_round = floor(tmp);
 #else
-			double eve_round = round((double)arch_period * DELTA_PERIODIC);
+            double eve_round = round((double) arch_period * DELTA_PERIODIC);
 #endif
-			arch_period = (int)eve_round;
-		}
+            arch_period = (int) eve_round;
+        }
 
-        cout3 << "EventSupplier::detect_and_push_archive_event(): ms_since_last_periodic = " << ms_since_last_periodic << ", arch_period = " << arch_period << ", attr.prev_archive_event.inited = " << attr.prev_archive_event.inited << endl;
+        cout3 << "EventSupplier::detect_and_push_archive_event(): ms_since_last_periodic = " << ms_since_last_periodic
+              << ", arch_period = " << arch_period << ", attr.prev_archive_event.inited = "
+              << attr.prev_archive_event.inited << endl;
 
-		if ((ms_since_last_periodic > arch_period) && (attr.prev_archive_event.inited == true))
-		{
-			is_change = true;
-			period_change = true;
-		}
-	}
+        if ((ms_since_last_periodic > arch_period) && (attr.prev_archive_event.inited == true))
+        {
+            is_change = true;
+            period_change = true;
+        }
+    }
 
 //
 // If no attribute of this name is registered with change then insert the current value
 //
 
 
-	if (!attr.prev_archive_event.inited)
-	{
-		if (except != NULL)
-		{
-			attr.prev_archive_event.err    = true;
-			attr.prev_archive_event.except = *except;
-		}
-		else
-		{
-			if (attr_value.attr_val_5 != NULL)
+    if (!attr.prev_archive_event.inited)
+    {
+        if (except != NULL)
+        {
+            attr.prev_archive_event.err = true;
+            attr.prev_archive_event.except = *except;
+        }
+        else
+        {
+            if (attr_value.attr_val_5 != NULL)
                 attr.prev_archive_event.value_4 = attr_value.attr_val_5->value;
-			else if (attr_value.attr_val_4 != NULL)
+            else if (attr_value.attr_val_4 != NULL)
                 attr.prev_archive_event.value_4 = attr_value.attr_val_4->value;
             else if (attr_value.attr_val_3 != NULL)
                 attr.prev_archive_event.value = attr_value.attr_val_3->value;
             else
                 attr.prev_archive_event.value = attr_value.attr_val->value;
 
-			attr.prev_archive_event.quality = the_quality;
-			attr.prev_archive_event.err = false;
-		}
-		attr.archive_last_periodic = now_ms;
-		attr.archive_last_event = now_ms;
-		attr.prev_archive_event.inited = true;
-		if (user_push == true)
+            attr.prev_archive_event.quality = the_quality;
+            attr.prev_archive_event.err = false;
+        }
+        attr.archive_last_periodic = now_ms;
+        attr.archive_last_event = now_ms;
+        attr.prev_archive_event.inited = true;
+        if (user_push == true)
             is_change = true;
-	}
-	else
-	{
+    }
+    else
+    {
 
 //
 // determine delta_change in percent compared with previous event sent
 //
 
-		if (is_change == false)
-		{
-			is_change = detect_change(attr,attr_value,true,delta_change_rel,delta_change_abs,except,force_change,device_impl);
-		}
-	}
+        if (is_change == false)
+        {
+            is_change = detect_change(attr,
+                                      attr_value,
+                                      true,
+                                      delta_change_rel,
+                                      delta_change_abs,
+                                      except,
+                                      force_change,
+                                      device_impl);
+        }
+    }
 
 //
 // check whether the data quality has changed. Fire event on a quality change.
 //
 
-	if ( except == NULL &&
-		 attr.prev_archive_event.quality != the_quality )
-	{
-		is_change = true;
-		quality_change = true;
-	}
+    if (except == NULL &&
+        attr.prev_archive_event.quality != the_quality)
+    {
+        is_change = true;
+        quality_change = true;
+    }
 
-	if (is_change)
-	{
-		vector<string> filterable_names;
-		vector<double> filterable_data;
-		vector<string> filterable_names_lg;
-		vector<long> filterable_data_lg;
+    if (is_change)
+    {
+        vector<string> filterable_names;
+        vector<double> filterable_data;
+        vector<string> filterable_names_lg;
+        vector<long> filterable_data_lg;
 
-		domain_name = device_impl->get_name() + "/" + attr_name;
+        domain_name = device_impl->get_name() + "/" + attr_name;
 
-		if (except != NULL)
-		{
-			attr.prev_archive_event.err    = true;
-			attr.prev_archive_event.except = *except;
-		}
-		else
-		{
-			if (attr_value.attr_val_5 != NULL)
+        if (except != NULL)
+        {
+            attr.prev_archive_event.err = true;
+            attr.prev_archive_event.except = *except;
+        }
+        else
+        {
+            if (attr_value.attr_val_5 != NULL)
                 attr.prev_archive_event.value_4 = attr_value.attr_val_5->value;
-			else if (attr_value.attr_val_4 != NULL)
+            else if (attr_value.attr_val_4 != NULL)
                 attr.prev_archive_event.value_4 = attr_value.attr_val_4->value;
             else if (attr_value.attr_val_3 != NULL)
-                attr.prev_archive_event.value   = attr_value.attr_val_3->value;
+                attr.prev_archive_event.value = attr_value.attr_val_3->value;
             else
-                attr.prev_archive_event.value   = attr_value.attr_val->value;
-			attr.prev_archive_event.quality = the_quality;
-			attr.prev_archive_event.err     = false;
-		}
+                attr.prev_archive_event.value = attr_value.attr_val->value;
+            attr.prev_archive_event.quality = the_quality;
+            attr.prev_archive_event.err = false;
+        }
 
 //
 // Prepare to push the event
 //
 
-		filterable_names_lg.push_back("counter");
-		if (period_change == true)
-		{
-			attr.archive_periodic_counter++;
-			attr.archive_last_periodic = now_ms;
-			filterable_data_lg.push_back(attr.archive_periodic_counter);
-		}
-		else
-		{
-			filterable_data_lg.push_back(-1);
-		}
+        filterable_names_lg.push_back("counter");
+        if (period_change == true)
+        {
+            attr.archive_periodic_counter++;
+            attr.archive_last_periodic = now_ms;
+            filterable_data_lg.push_back(attr.archive_periodic_counter);
+        }
+        else
+        {
+            filterable_data_lg.push_back(-1);
+        }
 
-		filterable_names.push_back("delta_change_rel");
-		filterable_data.push_back(delta_change_rel);
-		filterable_names.push_back("delta_change_abs");
-		filterable_data.push_back(delta_change_abs);
-		filterable_names.push_back("forced_event");
-		if (force_change == true)
-			filterable_data.push_back((double)1.0);
-		else
-			filterable_data.push_back((double)0.0);
+        filterable_names.push_back("delta_change_rel");
+        filterable_data.push_back(delta_change_rel);
+        filterable_names.push_back("delta_change_abs");
+        filterable_data.push_back(delta_change_abs);
+        filterable_names.push_back("forced_event");
+        if (force_change == true)
+            filterable_data.push_back((double) 1.0);
+        else
+            filterable_data.push_back((double) 0.0);
 
-		filterable_names.push_back("quality");
-		if (quality_change == true)
-			filterable_data.push_back((double)1.0);
-		else
-			filterable_data.push_back((double)0.0);
+        filterable_names.push_back("quality");
+        if (quality_change == true)
+            filterable_data.push_back((double) 1.0);
+        else
+            filterable_data.push_back((double) 0.0);
 
-		filterable_names.push_back("delta_event");
-		filterable_data.push_back(now_ms - attr.archive_last_event);
-		attr.archive_last_event = now_ms;
+        filterable_names.push_back("delta_event");
+        filterable_data.push_back(now_ms - attr.archive_last_event);
+        attr.archive_last_event = now_ms;
 
-		vector<int> &client_libs = attr.get_client_lib(ARCHIVE_EVENT);
-		vector<int>::iterator ite;
-		string ev_name = EventName[ARCHIVE_EVENT];
-		bool inc_ctr = true;
+        vector<int> &client_libs = attr.get_client_lib(ARCHIVE_EVENT);
+        vector<int>::iterator ite;
+        string ev_name = EventName[ARCHIVE_EVENT];
+        bool inc_ctr = true;
 
-		for (ite = client_libs.begin();ite != client_libs.end();++ite)
-		{
-			bool need_free = false;
-			bool name_changed = false;
+        for (ite = client_libs.begin(); ite != client_libs.end(); ++ite)
+        {
+            bool need_free = false;
+            bool name_changed = false;
 
-			struct SuppliedEventData sent_value;
-		    ::memset(&sent_value,0,sizeof(sent_value));
+            struct SuppliedEventData sent_value;
+            ::memset(&sent_value, 0, sizeof(sent_value));
 
-			switch (*ite)
-			{
-				case 5:
-				{
-					convert_att_event_to_5(attr_value,sent_value,need_free,attr);
-					ev_name = EVENT_COMPAT_IDL5 + ev_name;
-					name_changed = true;
-				}
-				break;
+            switch (*ite)
+            {
+                case 5:
+                {
+                    convert_att_event_to_5(attr_value, sent_value, need_free, attr);
+                    ev_name = EVENT_COMPAT_IDL5 + ev_name;
+                    name_changed = true;
+                }
+                    break;
 
-				case 4:
-				{
-					convert_att_event_to_4(attr_value,sent_value,need_free,attr);
-				}
-				break;
+                case 4:
+                {
+                    convert_att_event_to_4(attr_value, sent_value, need_free, attr);
+                }
+                    break;
 
-				default:
-				{
-					convert_att_event_to_3(attr_value,sent_value,need_free,attr);
-				}
-				break;
-			}
+                default:
+                {
+                    convert_att_event_to_3(attr_value, sent_value, need_free, attr);
+                }
+                    break;
+            }
 
-			push_event(device_impl,
-				   ev_name,
-				   filterable_names,
-				   filterable_data,
-				   filterable_names_lg,
-				   filterable_data_lg,
-				   sent_value,
-				   attr_name,
-				   except,
-				   inc_ctr);
+            push_event(device_impl,
+                       ev_name,
+                       filterable_names,
+                       filterable_data,
+                       filterable_names_lg,
+                       filterable_data_lg,
+                       sent_value,
+                       attr_name,
+                       except,
+                       inc_ctr);
 
-			inc_ctr = false;
-			if (need_free == true)
-			{
-				if (sent_value.attr_val_5 != NULL)
-					delete sent_value.attr_val_5;
-				else if (sent_value.attr_val_4 != NULL)
-					delete sent_value.attr_val_4;
-				else if (sent_value.attr_val_3 != NULL)
-					delete sent_value.attr_val_3;
-				else
-					delete sent_value.attr_val;
-			}
-			if (name_changed == true)
-				ev_name = EventName[ARCHIVE_EVENT];
-		}
+            inc_ctr = false;
+            if (need_free == true)
+            {
+                if (sent_value.attr_val_5 != NULL)
+                    delete sent_value.attr_val_5;
+                else if (sent_value.attr_val_4 != NULL)
+                    delete sent_value.attr_val_4;
+                else if (sent_value.attr_val_3 != NULL)
+                    delete sent_value.attr_val_3;
+                else
+                    delete sent_value.attr_val;
+            }
+            if (name_changed == true)
+                ev_name = EventName[ARCHIVE_EVENT];
+        }
 
         ret = true;
-	}
+    }
 
-	return ret;
+    return ret;
 }
 
 //+------------------------------------------------------------------------------------------------------------------
@@ -790,27 +818,31 @@ bool EventSupplier::detect_and_push_archive_event(DeviceImpl *device_impl,Suppli
 //
 //------------------------------------------------------------------------------------------------------------------
 
-bool EventSupplier::detect_and_push_periodic_event(DeviceImpl *device_impl,struct SuppliedEventData &attr_value,
-                    Attribute &attr,string &attr_name,DevFailed *except,struct timeval *time_bef_attr)
+bool EventSupplier::detect_and_push_periodic_event(DeviceImpl *device_impl,
+                                                   struct SuppliedEventData &attr_value,
+                                                   Attribute &attr,
+                                                   string &attr_name,
+                                                   DevFailed *except,
+                                                   struct timeval *time_bef_attr)
 {
-	string event, domain_name;
-	double now_ms, ms_since_last_periodic;
-	bool ret = false;
+    string event, domain_name;
+    double now_ms, ms_since_last_periodic;
+    bool ret = false;
 
-	struct timeval now;
-	if (time_bef_attr == NULL)
-	{
+    struct timeval now;
+    if (time_bef_attr == NULL)
+    {
 #ifdef _TG_WINDOWS_
-		struct _timeb now_win;
+        struct _timeb now_win;
 
-		_ftime(&now_win);
-		now.tv_sec = (unsigned long)now_win.time;
-		now.tv_usec = (long)now_win.millitm * 1000;
+        _ftime(&now_win);
+        now.tv_sec = (unsigned long)now_win.time;
+        now.tv_usec = (long)now_win.millitm * 1000;
 #else
-		gettimeofday(&now,NULL);
+        gettimeofday(&now, NULL);
 #endif
-		now.tv_sec = now.tv_sec - DELTA_T;
-	}
+        now.tv_sec = now.tv_sec - DELTA_T;
+    }
 
 //
 // Do not get time now. This metthod is executed after the attribute has been read.
@@ -820,144 +852,146 @@ bool EventSupplier::detect_and_push_periodic_event(DeviceImpl *device_impl,struc
 // more stable
 //
 
-	if (time_bef_attr != NULL)
-		now_ms = (double)time_bef_attr->tv_sec * 1000. + (double)time_bef_attr->tv_usec / 1000.;
-	else
-		now_ms = (double)now.tv_sec * 1000. + (double)now.tv_usec / 1000.;
+    if (time_bef_attr != NULL)
+        now_ms = (double) time_bef_attr->tv_sec * 1000. + (double) time_bef_attr->tv_usec / 1000.;
+    else
+        now_ms = (double) now.tv_sec * 1000. + (double) now.tv_usec / 1000.;
 
 //
 // get the mutex to synchronize the sending of events
 //
 
-	omni_mutex_lock l(event_mutex);
+    omni_mutex_lock l(event_mutex);
 
 //
 // get the event period
 //
 
-	int eve_period;
-	TangoMonitor &mon1 = device_impl->get_att_conf_monitor();
-	mon1.get_monitor();
-	eve_period = attr.event_period;
-	mon1.rel_monitor();
+    int eve_period;
+    TangoMonitor &mon1 = device_impl->get_att_conf_monitor();
+    mon1.get_monitor();
+    eve_period = attr.event_period;
+    mon1.rel_monitor();
 
 //
 // Specify the precision interval for the event period testing 2% are used for periods < 5000 ms and
 // 100ms are used for periods > 5000 ms.
 //
 
-	if ( eve_period >= 5000 )
-	{
-		 eve_period = eve_period - DELTA_PERIODIC_LONG;
-	}
-	else
-	{
+    if (eve_period >= 5000)
+    {
+        eve_period = eve_period - DELTA_PERIODIC_LONG;
+    }
+    else
+    {
 #ifdef _TG_WINDOWS_
-		double tmp = (double)eve_period * DELTA_PERIODIC;
-		double int_part,eve_round;
-		double frac = modf(tmp,&int_part);
-		if (frac >= 0.5)
-			eve_round = ceil(tmp);
-		else
-			eve_round = floor(tmp);
+        double tmp = (double)eve_period * DELTA_PERIODIC;
+        double int_part,eve_round;
+        double frac = modf(tmp,&int_part);
+        if (frac >= 0.5)
+            eve_round = ceil(tmp);
+        else
+            eve_round = floor(tmp);
 #else
-		double eve_round = round((double)eve_period * DELTA_PERIODIC);
+        double eve_round = round((double) eve_period * DELTA_PERIODIC);
 #endif
-		eve_period = (int)eve_round;
-	}
+        eve_period = (int) eve_round;
+    }
 
 //
 // calculate the time
 //
 
-	ms_since_last_periodic = now_ms - attr.last_periodic;
-	cout3 << "EventSupplier::detect_and_push_is_periodic_event(): delta since last periodic " << ms_since_last_periodic << " event_period " << eve_period << " for " << device_impl->get_name()+"/"+attr_name << endl;
+    ms_since_last_periodic = now_ms - attr.last_periodic;
+    cout3 << "EventSupplier::detect_and_push_is_periodic_event(): delta since last periodic " << ms_since_last_periodic
+          << " event_period " << eve_period << " for " << device_impl->get_name() + "/" + attr_name << endl;
 
-	if ( ms_since_last_periodic > eve_period )
-	{
+    if (ms_since_last_periodic > eve_period)
+    {
 
 //
 // Prepare to push the event
 //
 
-		vector<string> filterable_names;
-		vector<double> filterable_data;
-		vector<string> filterable_names_lg;
-		vector<long> filterable_data_lg;
+        vector<string> filterable_names;
+        vector<double> filterable_data;
+        vector<string> filterable_names_lg;
+        vector<long> filterable_data_lg;
 
-		attr.periodic_counter++;
-		attr.last_periodic = now_ms;
-		filterable_names_lg.push_back("counter");
-		filterable_data_lg.push_back(attr.periodic_counter);
+        attr.periodic_counter++;
+        attr.last_periodic = now_ms;
+        filterable_names_lg.push_back("counter");
+        filterable_data_lg.push_back(attr.periodic_counter);
 
-		vector<int> &client_libs = attr.get_client_lib(PERIODIC_EVENT);
-		vector<int>::iterator ite;
-		string ev_name = EventName[PERIODIC_EVENT];
-		bool inc_ctr = true;
+        vector<int> &client_libs = attr.get_client_lib(PERIODIC_EVENT);
+        vector<int>::iterator ite;
+        string ev_name = EventName[PERIODIC_EVENT];
+        bool inc_ctr = true;
 
-		cout3 << "EventSupplier::detect_and_push_is_periodic_event(): detected periodic event for " << device_impl->get_name()+"/"+attr_name << endl;
+        cout3 << "EventSupplier::detect_and_push_is_periodic_event(): detected periodic event for "
+              << device_impl->get_name() + "/" + attr_name << endl;
 
-		for (ite = client_libs.begin();ite != client_libs.end();++ite)
-		{
-			bool need_free = false;
-			bool name_changed = false;
+        for (ite = client_libs.begin(); ite != client_libs.end(); ++ite)
+        {
+            bool need_free = false;
+            bool name_changed = false;
 
-			struct SuppliedEventData sent_value;
-		    ::memset(&sent_value,0,sizeof(sent_value));
+            struct SuppliedEventData sent_value;
+            ::memset(&sent_value, 0, sizeof(sent_value));
 
-			switch (*ite)
-			{
-				case 5:
-				{
-					convert_att_event_to_5(attr_value,sent_value,need_free,attr);
-					ev_name = EVENT_COMPAT_IDL5 + ev_name;
-					name_changed = true;
-				}
-				break;
+            switch (*ite)
+            {
+                case 5:
+                {
+                    convert_att_event_to_5(attr_value, sent_value, need_free, attr);
+                    ev_name = EVENT_COMPAT_IDL5 + ev_name;
+                    name_changed = true;
+                }
+                    break;
 
-				case 4:
-				{
-					convert_att_event_to_4(attr_value,sent_value,need_free,attr);
-				}
-				break;
+                case 4:
+                {
+                    convert_att_event_to_4(attr_value, sent_value, need_free, attr);
+                }
+                    break;
 
-				default:
-				{
-					convert_att_event_to_3(attr_value,sent_value,need_free,attr);
-				}
-				break;
-			}
+                default:
+                {
+                    convert_att_event_to_3(attr_value, sent_value, need_free, attr);
+                }
+                    break;
+            }
 
-			push_event(device_impl,
-				   ev_name,
-				   filterable_names,
-				   filterable_data,
-				   filterable_names_lg,
-				   filterable_data_lg,
-				   sent_value,
-				   attr_name,
-				   except,
-				   inc_ctr);
+            push_event(device_impl,
+                       ev_name,
+                       filterable_names,
+                       filterable_data,
+                       filterable_names_lg,
+                       filterable_data_lg,
+                       sent_value,
+                       attr_name,
+                       except,
+                       inc_ctr);
 
-			inc_ctr = false;
-			if (need_free == true)
-			{
-				if (sent_value.attr_val_5 != NULL)
-					delete sent_value.attr_val_5;
-				else if (sent_value.attr_val_4 != NULL)
-					delete sent_value.attr_val_4;
-				else if (sent_value.attr_val_3 != NULL)
-					delete sent_value.attr_val_3;
-				else
-					delete sent_value.attr_val;
-			}
-			if (name_changed == true)
-				ev_name = EventName[PERIODIC_EVENT];
-		}
+            inc_ctr = false;
+            if (need_free == true)
+            {
+                if (sent_value.attr_val_5 != NULL)
+                    delete sent_value.attr_val_5;
+                else if (sent_value.attr_val_4 != NULL)
+                    delete sent_value.attr_val_4;
+                else if (sent_value.attr_val_3 != NULL)
+                    delete sent_value.attr_val_3;
+                else
+                    delete sent_value.attr_val;
+            }
+            if (name_changed == true)
+                ev_name = EventName[PERIODIC_EVENT];
+        }
         ret = true;
-	}
+    }
 
-	return ret;
+    return ret;
 }
 
 
@@ -984,9 +1018,9 @@ bool EventSupplier::detect_and_push_periodic_event(DeviceImpl *device_impl,struc
 //
 //-------------------------------------------------------------------------------------------------------------------
 
-bool EventSupplier::detect_change(Attribute &attr,struct SuppliedEventData &attr_value,bool archive,
-              double &delta_change_rel,double &delta_change_abs,DevFailed *except,
-              bool &force_change,DeviceImpl *dev)
+bool EventSupplier::detect_change(Attribute &attr, struct SuppliedEventData &attr_value, bool archive,
+                                  double &delta_change_rel, double &delta_change_abs, DevFailed *except,
+                                  bool &force_change, DeviceImpl *dev)
 {
     bool is_change = false;
 
@@ -1030,9 +1064,9 @@ bool EventSupplier::detect_change(Attribute &attr,struct SuppliedEventData &attr
 
         if (except != NULL)
         {
-            if ( attr.prev_archive_event.err == true )
+            if (attr.prev_archive_event.err == true)
             {
-                if ( Except::compare_exception (*except, attr.prev_archive_event.except) == true )
+                if (Except::compare_exception(*except, attr.prev_archive_event.except) == true)
                 {
                     force_change = false;
                     return false;
@@ -1059,7 +1093,7 @@ bool EventSupplier::detect_change(Attribute &attr,struct SuppliedEventData &attr
 
         if (the_new_quality == Tango::ATTR_INVALID)
         {
-            if ( attr.prev_archive_event.quality == Tango::ATTR_INVALID )
+            if (attr.prev_archive_event.quality == Tango::ATTR_INVALID)
             {
                 force_change = false;
                 return false;
@@ -1088,9 +1122,9 @@ bool EventSupplier::detect_change(Attribute &attr,struct SuppliedEventData &attr
 
         if (except != NULL)
         {
-            if ( attr.prev_change_event.err == true )
+            if (attr.prev_change_event.err == true)
             {
-                if ( Except::compare_exception (*except, attr.prev_change_event.except) == true )
+                if (Except::compare_exception(*except, attr.prev_change_event.except) == true)
                 {
                     force_change = false;
                     return false;
@@ -1117,10 +1151,10 @@ bool EventSupplier::detect_change(Attribute &attr,struct SuppliedEventData &attr
 
         if (the_new_quality == Tango::ATTR_INVALID)
         {
-            if ( attr.prev_change_event.quality == Tango::ATTR_INVALID )
+            if (attr.prev_change_event.quality == Tango::ATTR_INVALID)
             {
-                    force_change = false;
-                    return false;
+                force_change = false;
+                return false;
             }
 
             force_change = true;
@@ -1168,7 +1202,7 @@ bool EventSupplier::detect_change(Attribute &attr,struct SuppliedEventData &attr
         abs_change[1] = attr.abs_change[1];
         inited = attr.prev_change_event.inited;
         if ((attr.prev_change_event.quality != Tango::ATTR_INVALID) && (the_new_quality != Tango::ATTR_INVALID))
-                enable_check = true;
+            enable_check = true;
     }
     else
     {
@@ -1178,7 +1212,7 @@ bool EventSupplier::detect_change(Attribute &attr,struct SuppliedEventData &attr
         abs_change[1] = attr.archive_abs_change[1];
         inited = attr.prev_archive_event.inited;
         if ((attr.prev_archive_event.quality != Tango::ATTR_INVALID) && (the_new_quality != Tango::ATTR_INVALID))
-                enable_check = true;
+            enable_check = true;
     }
     mon1.rel_monitor();
 
@@ -1186,28 +1220,28 @@ bool EventSupplier::detect_change(Attribute &attr,struct SuppliedEventData &attr
     {
         if (enable_check == true)
         {
-            unsigned int curr_seq_nb,prev_seq_nb;
+            unsigned int curr_seq_nb, prev_seq_nb;
             unsigned int i;
 
-			if (the_new_any != NULL)
-				ty = the_new_any->type();
+            if (the_new_any != NULL)
+                ty = the_new_any->type();
 
 //
 // First, analyse the DevEncoded data type
 //
 
             if (((attr_value.attr_val_5 != NULL) && (attr_value.attr_val_5->value._d() == ATT_ENCODED)) ||
-				((attr_value.attr_val_4 != NULL) && (attr_value.attr_val_4->value._d() == ATT_ENCODED)))
+                ((attr_value.attr_val_4 != NULL) && (attr_value.attr_val_4->value._d() == ATT_ENCODED)))
             {
-                unsigned int curr_seq_str_nb,prev_seq_str_nb;
-                const char *curr_encoded_format,*prev_encoded_format;
-                const Tango::DevVarUCharArray *curr_data_ptr,*prev_data_ptr;
+                unsigned int curr_seq_str_nb, prev_seq_str_nb;
+                const char *curr_encoded_format, *prev_encoded_format;
+                const Tango::DevVarUCharArray *curr_data_ptr, *prev_data_ptr;
 
-				const Tango::DevVarEncodedArray *un_seq;
-				if (attr_value.attr_val_5 != NULL)
-					un_seq = &(attr_value.attr_val_5->value.encoded_att_value());
-				else
-					un_seq = &(attr_value.attr_val_4->value.encoded_att_value());
+                const Tango::DevVarEncodedArray *un_seq;
+                if (attr_value.attr_val_5 != NULL)
+                    un_seq = &(attr_value.attr_val_5->value.encoded_att_value());
+                else
+                    un_seq = &(attr_value.attr_val_4->value.encoded_att_value());
 
                 curr_seq_str_nb = strlen((*un_seq)[0].encoded_format.in());
                 curr_seq_nb = (*un_seq)[0].encoded_data.length();
@@ -1236,22 +1270,24 @@ bool EventSupplier::detect_change(Attribute &attr,struct SuppliedEventData &attr
                     return true;
                 }
 
-                if (strcmp(curr_encoded_format,prev_encoded_format) != 0)
+                if (strcmp(curr_encoded_format, prev_encoded_format) != 0)
                 {
                     delta_change_rel = delta_change_abs = 100.;
                     is_change = true;
-                    return(is_change);
+                    return (is_change);
                 }
 
-                if ((rel_change[0] != INT_MAX) || (rel_change[1] != INT_MAX) || (abs_change[0] != INT_MAX) || (abs_change[1] != INT_MAX))
+                if ((rel_change[0] != INT_MAX) || (rel_change[1] != INT_MAX) || (abs_change[0] != INT_MAX)
+                    || (abs_change[1] != INT_MAX))
                 {
-                    for (i=0; i< curr_seq_nb; i++)
+                    for (i = 0; i < curr_seq_nb; i++)
                     {
                         if (rel_change[0] != INT_MAX)
                         {
                             if ((*prev_data_ptr)[i] != 0)
                             {
-                                delta_change_rel = ((*curr_data_ptr)[i] - (*prev_data_ptr)[i])*100/(*prev_data_ptr)[i];
+                                delta_change_rel =
+                                    ((*curr_data_ptr)[i] - (*prev_data_ptr)[i]) * 100 / (*prev_data_ptr)[i];
                             }
                             else
                             {
@@ -1262,7 +1298,7 @@ bool EventSupplier::detect_change(Attribute &attr,struct SuppliedEventData &attr
                             if (delta_change_rel <= rel_change[0] || delta_change_rel >= rel_change[1])
                             {
                                 is_change = true;
-                                return(is_change);
+                                return (is_change);
                             }
                         }
                         if (abs_change[0] != INT_MAX)
@@ -1271,7 +1307,7 @@ bool EventSupplier::detect_change(Attribute &attr,struct SuppliedEventData &attr
                             if (delta_change_abs <= abs_change[0] || delta_change_abs >= abs_change[1])
                             {
                                 is_change = true;
-                                return(is_change);
+                                return (is_change);
                             }
                         }
                     }
@@ -1342,11 +1378,11 @@ bool EventSupplier::detect_change(Attribute &attr,struct SuppliedEventData &attr
 
                 if ((attr_value.attr_val_5 != NULL) && (attr_value.attr_val_5->value._d() == ATT_LONG))
                 {
-                	GET_SEQ(long_type,curr_seq_lo,long_att_value,prev_seq_lo,attr_value.attr_val_5);
+                    GET_SEQ(long_type, curr_seq_lo, long_att_value, prev_seq_lo, attr_value.attr_val_5);
                 }
                 else if ((attr_value.attr_val_4 != NULL) && (attr_value.attr_val_4->value._d() == ATT_LONG))
                 {
-                	GET_SEQ(long_type,curr_seq_lo,long_att_value,prev_seq_lo,attr_value.attr_val_4);
+                    GET_SEQ(long_type, curr_seq_lo, long_att_value, prev_seq_lo, attr_value.attr_val_4);
                 }
                 else if ((the_new_any != NULL) && (ty_seq->kind() == CORBA::tk_long))
                 {
@@ -1367,13 +1403,13 @@ bool EventSupplier::detect_change(Attribute &attr,struct SuppliedEventData &attr
                         force_change = true;
                         return true;
                     }
-                    for (i=0; i<curr_seq_lo->length(); i++)
+                    for (i = 0; i < curr_seq_lo->length(); i++)
                     {
                         if (rel_change[0] != INT_MAX)
                         {
                             if ((*prev_seq_lo)[i] != 0)
                             {
-                                delta_change_rel = ((*curr_seq_lo)[i] - (*prev_seq_lo)[i])*100/(*prev_seq_lo)[i];
+                                delta_change_rel = ((*curr_seq_lo)[i] - (*prev_seq_lo)[i]) * 100 / (*prev_seq_lo)[i];
                             }
                             else
                             {
@@ -1384,7 +1420,7 @@ bool EventSupplier::detect_change(Attribute &attr,struct SuppliedEventData &attr
                             if (delta_change_rel <= rel_change[0] || delta_change_rel >= rel_change[1])
                             {
                                 is_change = true;
-                                return(is_change);
+                                return (is_change);
                             }
                         }
                         if (abs_change[0] != INT_MAX)
@@ -1393,7 +1429,7 @@ bool EventSupplier::detect_change(Attribute &attr,struct SuppliedEventData &attr
                             if (delta_change_abs <= abs_change[0] || delta_change_abs >= abs_change[1])
                             {
                                 is_change = true;
-                                return(is_change);
+                                return (is_change);
                             }
                         }
                     }
@@ -1408,11 +1444,11 @@ bool EventSupplier::detect_change(Attribute &attr,struct SuppliedEventData &attr
 
                 if ((attr_value.attr_val_5 != NULL) && (attr_value.attr_val_5->value._d() == ATT_LONG64))
                 {
-                	GET_SEQ(long_long_type,curr_seq_64,long64_att_value,prev_seq_64,attr_value.attr_val_5);
+                    GET_SEQ(long_long_type, curr_seq_64, long64_att_value, prev_seq_64, attr_value.attr_val_5);
                 }
                 else if ((attr_value.attr_val_4 != NULL) && (attr_value.attr_val_4->value._d() == ATT_LONG64))
                 {
-                	GET_SEQ(long_long_type,curr_seq_64,long64_att_value,prev_seq_64,attr_value.attr_val_4);
+                    GET_SEQ(long_long_type, curr_seq_64, long64_att_value, prev_seq_64, attr_value.attr_val_4);
                 }
                 else if ((the_new_any != NULL) && (ty_seq->kind() == CORBA::tk_longlong))
                 {
@@ -1433,13 +1469,14 @@ bool EventSupplier::detect_change(Attribute &attr,struct SuppliedEventData &attr
                         force_change = true;
                         return true;
                     }
-                    for (i=0; i<curr_seq_64->length(); i++)
+                    for (i = 0; i < curr_seq_64->length(); i++)
                     {
                         if (rel_change[0] != INT_MAX)
                         {
                             if ((*prev_seq_64)[i] != 0)
                             {
-                                delta_change_rel = (double)(((*curr_seq_64)[i] - (*prev_seq_64)[i])*100/(*prev_seq_64)[i]);
+                                delta_change_rel =
+                                    (double) (((*curr_seq_64)[i] - (*prev_seq_64)[i]) * 100 / (*prev_seq_64)[i]);
                             }
                             else
                             {
@@ -1449,16 +1486,16 @@ bool EventSupplier::detect_change(Attribute &attr,struct SuppliedEventData &attr
                             if (delta_change_rel <= rel_change[0] || delta_change_rel >= rel_change[1])
                             {
                                 is_change = true;
-                                return(is_change);
+                                return (is_change);
                             }
                         }
                         if (abs_change[0] != INT_MAX)
                         {
-                            delta_change_abs = (double)((*curr_seq_64)[i] - (*prev_seq_64)[i]);
+                            delta_change_abs = (double) ((*curr_seq_64)[i] - (*prev_seq_64)[i]);
                             if (delta_change_abs <= abs_change[0] || delta_change_abs >= abs_change[1])
                             {
                                 is_change = true;
-                                return(is_change);
+                                return (is_change);
                             }
                         }
                     }
@@ -1473,11 +1510,11 @@ bool EventSupplier::detect_change(Attribute &attr,struct SuppliedEventData &attr
 
                 if ((attr_value.attr_val_5 != NULL) && (attr_value.attr_val_5->value._d() == ATT_SHORT))
                 {
-                	GET_SEQ(short_type,curr_seq_sh,short_att_value,prev_seq_sh,attr_value.attr_val_5);
+                    GET_SEQ(short_type, curr_seq_sh, short_att_value, prev_seq_sh, attr_value.attr_val_5);
                 }
                 else if ((attr_value.attr_val_4 != NULL) && (attr_value.attr_val_4->value._d() == ATT_SHORT))
                 {
-                	GET_SEQ(short_type,curr_seq_sh,short_att_value,prev_seq_sh,attr_value.attr_val_4);
+                    GET_SEQ(short_type, curr_seq_sh, short_att_value, prev_seq_sh, attr_value.attr_val_4);
                 }
                 else if ((the_new_any != NULL) && (ty_seq->kind() == CORBA::tk_short))
                 {
@@ -1499,51 +1536,52 @@ bool EventSupplier::detect_change(Attribute &attr,struct SuppliedEventData &attr
                         return true;
                     }
 
-					if (attr.data_type == DEV_ENUM)
-					{
-						for (i=0; i<curr_seq_sh->length(); i++)
-						{
-							if ((*curr_seq_sh)[i] != (*prev_seq_sh)[i])
-							{
-								delta_change_rel = delta_change_abs = 100.;
-								is_change = true;
-							}
-							return is_change;
-						}
-					}
-					else
-					{
-						for (i=0; i<curr_seq_sh->length(); i++)
-						{
-							if (rel_change[0] != INT_MAX)
-							{
-								if ((*prev_seq_sh)[i] != 0)
-								{
-									delta_change_rel = ((*curr_seq_sh)[i] - (*prev_seq_sh)[i])*100/(*prev_seq_sh)[i];
-								}
-								else
-								{
-									delta_change_rel = 100;
-									if ((*curr_seq_sh)[i] == (*prev_seq_sh)[i]) delta_change_rel = 0;
-								}
-								if (delta_change_rel <= rel_change[0] || delta_change_rel >= rel_change[1])
-								{
-									is_change = true;
-									return(is_change);
-								}
-							}
-							if (abs_change[0] != INT_MAX)
-							{
-								delta_change_abs = (*curr_seq_sh)[i] - (*prev_seq_sh)[i];
-								if (delta_change_abs <= abs_change[0] || delta_change_abs >= abs_change[1])
-								{
-									is_change = true;
-									return(is_change);
-								}
-							}
-						}
-						return false;
-					}
+                    if (attr.data_type == DEV_ENUM)
+                    {
+                        for (i = 0; i < curr_seq_sh->length(); i++)
+                        {
+                            if ((*curr_seq_sh)[i] != (*prev_seq_sh)[i])
+                            {
+                                delta_change_rel = delta_change_abs = 100.;
+                                is_change = true;
+                            }
+                            return is_change;
+                        }
+                    }
+                    else
+                    {
+                        for (i = 0; i < curr_seq_sh->length(); i++)
+                        {
+                            if (rel_change[0] != INT_MAX)
+                            {
+                                if ((*prev_seq_sh)[i] != 0)
+                                {
+                                    delta_change_rel =
+                                        ((*curr_seq_sh)[i] - (*prev_seq_sh)[i]) * 100 / (*prev_seq_sh)[i];
+                                }
+                                else
+                                {
+                                    delta_change_rel = 100;
+                                    if ((*curr_seq_sh)[i] == (*prev_seq_sh)[i]) delta_change_rel = 0;
+                                }
+                                if (delta_change_rel <= rel_change[0] || delta_change_rel >= rel_change[1])
+                                {
+                                    is_change = true;
+                                    return (is_change);
+                                }
+                            }
+                            if (abs_change[0] != INT_MAX)
+                            {
+                                delta_change_abs = (*curr_seq_sh)[i] - (*prev_seq_sh)[i];
+                                if (delta_change_abs <= abs_change[0] || delta_change_abs >= abs_change[1])
+                                {
+                                    is_change = true;
+                                    return (is_change);
+                                }
+                            }
+                        }
+                        return false;
+                    }
                 }
 
 //
@@ -1554,11 +1592,11 @@ bool EventSupplier::detect_change(Attribute &attr,struct SuppliedEventData &attr
 
                 if ((attr_value.attr_val_5 != NULL) && (attr_value.attr_val_5->value._d() == ATT_DOUBLE))
                 {
-                	GET_SEQ(double_type,curr_seq_db,double_att_value,prev_seq_db,attr_value.attr_val_5);
+                    GET_SEQ(double_type, curr_seq_db, double_att_value, prev_seq_db, attr_value.attr_val_5);
                 }
                 else if ((attr_value.attr_val_4 != NULL) && (attr_value.attr_val_4->value._d() == ATT_DOUBLE))
                 {
-                	GET_SEQ(double_type,curr_seq_db,double_att_value,prev_seq_db,attr_value.attr_val_4);
+                    GET_SEQ(double_type, curr_seq_db, double_att_value, prev_seq_db, attr_value.attr_val_4);
                 }
                 else if ((the_new_any != NULL) && (ty_seq->kind() == CORBA::tk_double))
                 {
@@ -1580,7 +1618,7 @@ bool EventSupplier::detect_change(Attribute &attr,struct SuppliedEventData &attr
                         force_change = true;
                         return true;
                     }
-                    for (i=0; i<curr_seq_db->length(); i++)
+                    for (i = 0; i < curr_seq_db->length(); i++)
                     {
                         if (rel_change[0] != INT_MAX)
                         {
@@ -1592,7 +1630,7 @@ bool EventSupplier::detect_change(Attribute &attr,struct SuppliedEventData &attr
 
                             if ((*prev_seq_db)[i] != 0)
                             {
-                                delta_change_rel = ((*curr_seq_db)[i] - (*prev_seq_db)[i])*100/(*prev_seq_db)[i];
+                                delta_change_rel = ((*curr_seq_db)[i] - (*prev_seq_db)[i]) * 100 / (*prev_seq_db)[i];
                             }
                             else
                             {
@@ -1603,7 +1641,7 @@ bool EventSupplier::detect_change(Attribute &attr,struct SuppliedEventData &attr
                             if (delta_change_rel <= rel_change[0] || delta_change_rel >= rel_change[1])
                             {
                                 is_change = true;
-                                return(is_change);
+                                return (is_change);
                             }
                         }
                         if (abs_change[0] != INT_MAX)
@@ -1624,7 +1662,7 @@ bool EventSupplier::detect_change(Attribute &attr,struct SuppliedEventData &attr
                             if (min_change <= abs_change[0] || max_change >= abs_change[1])
                             {
                                 is_change = true;
-                                return(is_change);
+                                return (is_change);
                             }
                         }
                     }
@@ -1639,11 +1677,11 @@ bool EventSupplier::detect_change(Attribute &attr,struct SuppliedEventData &attr
 
                 if ((attr_value.attr_val_5 != NULL) && (attr_value.attr_val_5->value._d() == ATT_STRING))
                 {
-                	GET_SEQ(string_type,curr_seq_str,string_att_value,prev_seq_str,attr_value.attr_val_5);
+                    GET_SEQ(string_type, curr_seq_str, string_att_value, prev_seq_str, attr_value.attr_val_5);
                 }
                 else if ((attr_value.attr_val_4 != NULL) && (attr_value.attr_val_4->value._d() == ATT_STRING))
                 {
-					GET_SEQ(string_type,curr_seq_str,string_att_value,prev_seq_str,attr_value.attr_val_4);
+                    GET_SEQ(string_type, curr_seq_str, string_att_value, prev_seq_str, attr_value.attr_val_4);
                 }
                 else if ((the_new_any != NULL) && (ty_seq->kind() == CORBA::tk_string))
                 {
@@ -1664,13 +1702,13 @@ bool EventSupplier::detect_change(Attribute &attr,struct SuppliedEventData &attr
                         force_change = true;
                         return true;
                     }
-                    for (i=0; i<curr_seq_str->length(); i++)
+                    for (i = 0; i < curr_seq_str->length(); i++)
                     {
-                        if (strcmp((*curr_seq_str)[i],(*prev_seq_str)[i]) != 0)
+                        if (strcmp((*curr_seq_str)[i], (*prev_seq_str)[i]) != 0)
                         {
                             delta_change_rel = delta_change_abs = 100.;
                             is_change = true;
-                            return(is_change);
+                            return (is_change);
                         }
                     }
                     return false;
@@ -1684,11 +1722,11 @@ bool EventSupplier::detect_change(Attribute &attr,struct SuppliedEventData &attr
 
                 if ((attr_value.attr_val_5 != NULL) && (attr_value.attr_val_5->value._d() == ATT_FLOAT))
                 {
-                	GET_SEQ(float_type,curr_seq_fl,float_att_value,prev_seq_fl,attr_value.attr_val_5);
+                    GET_SEQ(float_type, curr_seq_fl, float_att_value, prev_seq_fl, attr_value.attr_val_5);
                 }
                 else if ((attr_value.attr_val_4 != NULL) && (attr_value.attr_val_4->value._d() == ATT_FLOAT))
                 {
-                	GET_SEQ(float_type,curr_seq_fl,float_att_value,prev_seq_fl,attr_value.attr_val_4);
+                    GET_SEQ(float_type, curr_seq_fl, float_att_value, prev_seq_fl, attr_value.attr_val_4);
                 }
                 else if ((the_new_any != NULL) && (ty_seq->kind() == CORBA::tk_float))
                 {
@@ -1710,7 +1748,7 @@ bool EventSupplier::detect_change(Attribute &attr,struct SuppliedEventData &attr
                         return true;
                     }
 
-                    for (i=0; i<curr_seq_fl->length(); i++)
+                    for (i = 0; i < curr_seq_fl->length(); i++)
                     {
                         if (rel_change[0] != INT_MAX)
                         {
@@ -1722,7 +1760,7 @@ bool EventSupplier::detect_change(Attribute &attr,struct SuppliedEventData &attr
 
                             if ((*prev_seq_fl)[i] != 0)
                             {
-                                delta_change_rel = ((*curr_seq_fl)[i] - (*prev_seq_fl)[i])*100/(*prev_seq_fl)[i];
+                                delta_change_rel = ((*curr_seq_fl)[i] - (*prev_seq_fl)[i]) * 100 / (*prev_seq_fl)[i];
                             }
                             else
                             {
@@ -1732,7 +1770,7 @@ bool EventSupplier::detect_change(Attribute &attr,struct SuppliedEventData &attr
                             if (delta_change_rel <= rel_change[0] || delta_change_rel >= rel_change[1])
                             {
                                 is_change = true;
-                                return(is_change);
+                                return (is_change);
                             }
                         }
                         if (abs_change[0] != INT_MAX)
@@ -1753,7 +1791,7 @@ bool EventSupplier::detect_change(Attribute &attr,struct SuppliedEventData &attr
                             if (min_change <= abs_change[0] || max_change >= abs_change[1])
                             {
                                 is_change = true;
-                                return(is_change);
+                                return (is_change);
                             }
                         }
                     }
@@ -1768,11 +1806,11 @@ bool EventSupplier::detect_change(Attribute &attr,struct SuppliedEventData &attr
 
                 if ((attr_value.attr_val_5 != NULL) && (attr_value.attr_val_5->value._d() == ATT_USHORT))
                 {
-                	GET_SEQ(unsigned_short_type,curr_seq_ush,ushort_att_value,prev_seq_ush,attr_value.attr_val_5);
+                    GET_SEQ(unsigned_short_type, curr_seq_ush, ushort_att_value, prev_seq_ush, attr_value.attr_val_5);
                 }
                 else if ((attr_value.attr_val_4 != NULL) && (attr_value.attr_val_4->value._d() == ATT_USHORT))
                 {
-                	GET_SEQ(unsigned_short_type,curr_seq_ush,ushort_att_value,prev_seq_ush,attr_value.attr_val_4);
+                    GET_SEQ(unsigned_short_type, curr_seq_ush, ushort_att_value, prev_seq_ush, attr_value.attr_val_4);
                 }
                 else if ((the_new_any != NULL) && (ty_seq->kind() == CORBA::tk_ushort))
                 {
@@ -1793,13 +1831,13 @@ bool EventSupplier::detect_change(Attribute &attr,struct SuppliedEventData &attr
                         force_change = true;
                         return true;
                     }
-                    for (i=0; i<curr_seq_ush->length(); i++)
+                    for (i = 0; i < curr_seq_ush->length(); i++)
                     {
                         if (rel_change[0] != INT_MAX)
                         {
                             if ((*prev_seq_ush)[i] != 0)
                             {
-                                delta_change_rel = ((*curr_seq_ush)[i] - (*prev_seq_ush)[i])*100/(*prev_seq_ush)[i];
+                                delta_change_rel = ((*curr_seq_ush)[i] - (*prev_seq_ush)[i]) * 100 / (*prev_seq_ush)[i];
                             }
                             else
                             {
@@ -1809,7 +1847,7 @@ bool EventSupplier::detect_change(Attribute &attr,struct SuppliedEventData &attr
                             if (delta_change_rel <= rel_change[0] || delta_change_rel >= rel_change[1])
                             {
                                 is_change = true;
-                                return(is_change);
+                                return (is_change);
                             }
                         }
                         if (abs_change[0] != INT_MAX)
@@ -1818,7 +1856,7 @@ bool EventSupplier::detect_change(Attribute &attr,struct SuppliedEventData &attr
                             if (delta_change_abs <= abs_change[0] || delta_change_abs >= abs_change[1])
                             {
                                 is_change = true;
-                                return(is_change);
+                                return (is_change);
                             }
                         }
                     }
@@ -1833,11 +1871,11 @@ bool EventSupplier::detect_change(Attribute &attr,struct SuppliedEventData &attr
 
                 if ((attr_value.attr_val_5 != NULL) && (attr_value.attr_val_5->value._d() == ATT_BOOL))
                 {
-                	GET_SEQ(boolean_type,curr_seq_bo,bool_att_value,prev_seq_bo,attr_value.attr_val_5);
+                    GET_SEQ(boolean_type, curr_seq_bo, bool_att_value, prev_seq_bo, attr_value.attr_val_5);
                 }
                 else if ((attr_value.attr_val_4 != NULL) && (attr_value.attr_val_4->value._d() == ATT_BOOL))
                 {
-                	GET_SEQ(boolean_type,curr_seq_bo,bool_att_value,prev_seq_bo,attr_value.attr_val_4);
+                    GET_SEQ(boolean_type, curr_seq_bo, bool_att_value, prev_seq_bo, attr_value.attr_val_4);
                 }
                 else if ((the_new_any != NULL) && (ty_seq->kind() == CORBA::tk_boolean))
                 {
@@ -1858,13 +1896,13 @@ bool EventSupplier::detect_change(Attribute &attr,struct SuppliedEventData &attr
                         force_change = true;
                         return true;
                     }
-                    for (i=0; i<curr_seq_bo->length(); i++)
+                    for (i = 0; i < curr_seq_bo->length(); i++)
                     {
                         if ((*curr_seq_bo)[i] != (*prev_seq_bo)[i])
                         {
                             delta_change_rel = delta_change_abs = 100.;
                             is_change = true;
-                            return(is_change);
+                            return (is_change);
                         }
                     }
                     return false;
@@ -1878,11 +1916,11 @@ bool EventSupplier::detect_change(Attribute &attr,struct SuppliedEventData &attr
 
                 if ((attr_value.attr_val_5 != NULL) && (attr_value.attr_val_5->value._d() == ATT_UCHAR))
                 {
-                	GET_SEQ(char_type,curr_seq_uch,uchar_att_value,prev_seq_uch,attr_value.attr_val_5);
+                    GET_SEQ(char_type, curr_seq_uch, uchar_att_value, prev_seq_uch, attr_value.attr_val_5);
                 }
                 else if ((attr_value.attr_val_4 != NULL) && (attr_value.attr_val_4->value._d() == ATT_UCHAR))
                 {
-                	GET_SEQ(char_type,curr_seq_uch,uchar_att_value,prev_seq_uch,attr_value.attr_val_4);
+                    GET_SEQ(char_type, curr_seq_uch, uchar_att_value, prev_seq_uch, attr_value.attr_val_4);
                 }
                 else if ((the_new_any != NULL) && (ty_seq->kind() == CORBA::tk_octet))
                 {
@@ -1903,13 +1941,13 @@ bool EventSupplier::detect_change(Attribute &attr,struct SuppliedEventData &attr
                         force_change = true;
                         return true;
                     }
-                    for (i=0; i<curr_seq_uch->length(); i++)
+                    for (i = 0; i < curr_seq_uch->length(); i++)
                     {
                         if (rel_change[0] != INT_MAX)
                         {
                             if ((*prev_seq_uch)[i] != 0)
                             {
-                                delta_change_rel = ((*curr_seq_uch)[i] - (*prev_seq_uch)[i])*100/(*prev_seq_uch)[i];
+                                delta_change_rel = ((*curr_seq_uch)[i] - (*prev_seq_uch)[i]) * 100 / (*prev_seq_uch)[i];
                             }
                             else
                             {
@@ -1919,7 +1957,7 @@ bool EventSupplier::detect_change(Attribute &attr,struct SuppliedEventData &attr
                             if (delta_change_rel <= rel_change[0] || delta_change_rel >= rel_change[1])
                             {
                                 is_change = true;
-                                return(is_change);
+                                return (is_change);
                             }
                         }
                         if (abs_change[0] != INT_MAX)
@@ -1928,7 +1966,7 @@ bool EventSupplier::detect_change(Attribute &attr,struct SuppliedEventData &attr
                             if (delta_change_abs <= abs_change[0] || delta_change_abs >= abs_change[1])
                             {
                                 is_change = true;
-                                return(is_change);
+                                return (is_change);
                             }
                         }
                     }
@@ -1943,11 +1981,11 @@ bool EventSupplier::detect_change(Attribute &attr,struct SuppliedEventData &attr
 
                 if ((attr_value.attr_val_5 != NULL) && (attr_value.attr_val_5->value._d() == ATT_ULONG))
                 {
-                	GET_SEQ(unsigned_long_type,curr_seq_ulo,ulong_att_value,prev_seq_ulo,attr_value.attr_val_5);
+                    GET_SEQ(unsigned_long_type, curr_seq_ulo, ulong_att_value, prev_seq_ulo, attr_value.attr_val_5);
                 }
                 else if ((attr_value.attr_val_4 != NULL) && (attr_value.attr_val_4->value._d() == ATT_ULONG))
                 {
-                	GET_SEQ(unsigned_long_type,curr_seq_ulo,ulong_att_value,prev_seq_ulo,attr_value.attr_val_4);
+                    GET_SEQ(unsigned_long_type, curr_seq_ulo, ulong_att_value, prev_seq_ulo, attr_value.attr_val_4);
                 }
                 else if ((the_new_any != NULL) && (ty_seq->kind() == CORBA::tk_ulong))
                 {
@@ -1968,13 +2006,13 @@ bool EventSupplier::detect_change(Attribute &attr,struct SuppliedEventData &attr
                         force_change = true;
                         return true;
                     }
-                    for (i=0; i<curr_seq_ulo->length(); i++)
+                    for (i = 0; i < curr_seq_ulo->length(); i++)
                     {
                         if (rel_change[0] != INT_MAX)
                         {
                             if ((*prev_seq_ulo)[i] != 0)
                             {
-                                delta_change_rel = ((*curr_seq_ulo)[i] - (*prev_seq_ulo)[i])*100/(*prev_seq_ulo)[i];
+                                delta_change_rel = ((*curr_seq_ulo)[i] - (*prev_seq_ulo)[i]) * 100 / (*prev_seq_ulo)[i];
                             }
                             else
                             {
@@ -1984,7 +2022,7 @@ bool EventSupplier::detect_change(Attribute &attr,struct SuppliedEventData &attr
                             if (delta_change_rel <= rel_change[0] || delta_change_rel >= rel_change[1])
                             {
                                 is_change = true;
-                                return(is_change);
+                                return (is_change);
                             }
                         }
                         if (abs_change[0] != INT_MAX)
@@ -1993,7 +2031,7 @@ bool EventSupplier::detect_change(Attribute &attr,struct SuppliedEventData &attr
                             if (delta_change_abs <= abs_change[0] || delta_change_abs >= abs_change[1])
                             {
                                 is_change = true;
-                                return(is_change);
+                                return (is_change);
                             }
                         }
                     }
@@ -2008,11 +2046,11 @@ bool EventSupplier::detect_change(Attribute &attr,struct SuppliedEventData &attr
 
                 if ((attr_value.attr_val_5 != NULL) && (attr_value.attr_val_5->value._d() == ATT_ULONG64))
                 {
-                	GET_SEQ(unsigned_64_type,curr_seq_u64,ulong64_att_value,prev_seq_u64,attr_value.attr_val_5);
+                    GET_SEQ(unsigned_64_type, curr_seq_u64, ulong64_att_value, prev_seq_u64, attr_value.attr_val_5);
                 }
                 else if ((attr_value.attr_val_4 != NULL) && (attr_value.attr_val_4->value._d() == ATT_ULONG64))
                 {
-                	GET_SEQ(unsigned_64_type,curr_seq_u64,ulong64_att_value,prev_seq_u64,attr_value.attr_val_4);
+                    GET_SEQ(unsigned_64_type, curr_seq_u64, ulong64_att_value, prev_seq_u64, attr_value.attr_val_4);
                 }
                 else if ((the_new_any != NULL) && (ty_seq->kind() == CORBA::tk_ulonglong))
                 {
@@ -2034,13 +2072,14 @@ bool EventSupplier::detect_change(Attribute &attr,struct SuppliedEventData &attr
                         force_change = true;
                         return true;
                     }
-                    for (i=0; i<curr_seq_u64->length(); i++)
+                    for (i = 0; i < curr_seq_u64->length(); i++)
                     {
                         if (rel_change[0] != INT_MAX)
                         {
                             if ((*prev_seq_u64)[i] != 0)
                             {
-                                delta_change_rel = (double)(((*curr_seq_u64)[i] - (*prev_seq_u64)[i])*100/(*prev_seq_u64)[i]);
+                                delta_change_rel =
+                                    (double) (((*curr_seq_u64)[i] - (*prev_seq_u64)[i]) * 100 / (*prev_seq_u64)[i]);
                             }
                             else
                             {
@@ -2050,16 +2089,16 @@ bool EventSupplier::detect_change(Attribute &attr,struct SuppliedEventData &attr
                             if (delta_change_rel <= rel_change[0] || delta_change_rel >= rel_change[1])
                             {
                                 is_change = true;
-                                return(is_change);
+                                return (is_change);
                             }
                         }
                         if (abs_change[0] != INT_MAX)
                         {
-                            delta_change_abs = (double)((*curr_seq_u64)[i] - (*prev_seq_u64)[i]);
+                            delta_change_abs = (double) ((*curr_seq_u64)[i] - (*prev_seq_u64)[i]);
                             if (delta_change_abs <= abs_change[0] || delta_change_abs >= abs_change[1])
                             {
                                 is_change = true;
-                                return(is_change);
+                                return (is_change);
                             }
                         }
                     }
@@ -2074,11 +2113,11 @@ bool EventSupplier::detect_change(Attribute &attr,struct SuppliedEventData &attr
 
                 if ((attr_value.attr_val_5 != NULL) && (attr_value.attr_val_5->value._d() == ATT_STATE))
                 {
-                	GET_SEQ(state_type,curr_seq_state,state_att_value,prev_seq_state,attr_value.attr_val_5);
+                    GET_SEQ(state_type, curr_seq_state, state_att_value, prev_seq_state, attr_value.attr_val_5);
                 }
                 else if ((attr_value.attr_val_4 != NULL) && (attr_value.attr_val_4->value._d() == ATT_STATE))
                 {
-                	GET_SEQ(state_type,curr_seq_state,state_att_value,prev_seq_state,attr_value.attr_val_4);
+                    GET_SEQ(state_type, curr_seq_state, state_att_value, prev_seq_state, attr_value.attr_val_4);
                 }
                 else if ((the_new_any != NULL) && (ty_seq->kind() == CORBA::tk_enum))
                 {
@@ -2099,13 +2138,13 @@ bool EventSupplier::detect_change(Attribute &attr,struct SuppliedEventData &attr
                         force_change = true;
                         return true;
                     }
-                    for (i=0; i<curr_seq_state->length(); i++)
+                    for (i = 0; i < curr_seq_state->length(); i++)
                     {
                         if ((*curr_seq_state)[i] != (*prev_seq_state)[i])
                         {
                             delta_change_rel = delta_change_abs = 100.;
                             is_change = true;
-                            return(is_change);
+                            return (is_change);
                         }
                     }
                 }
@@ -2115,7 +2154,7 @@ bool EventSupplier::detect_change(Attribute &attr,struct SuppliedEventData &attr
     }
 
     cout3 << "EventSupplier::detect_change(): leaving for attribute " << attr.get_name() << endl;
-    return(is_change);
+    return (is_change);
 }
 
 
@@ -2136,35 +2175,36 @@ bool EventSupplier::detect_change(Attribute &attr,struct SuppliedEventData &attr
 //
 //-------------------------------------------------------------------------------------------------------------
 
-void EventSupplier::push_att_data_ready_event(DeviceImpl *device_impl,const string &attr_name,long data_type,DevLong ctr)
+void
+EventSupplier::push_att_data_ready_event(DeviceImpl *device_impl, const string &attr_name, long data_type, DevLong ctr)
 {
-	cout3 << "EventSupplier::push_att_data_ready_event(): called for attribute " << attr_name << endl;
+    cout3 << "EventSupplier::push_att_data_ready_event(): called for attribute " << attr_name << endl;
 
-	vector<string> filterable_names;
-	vector<double> filterable_data;
-	vector<string> filterable_names_lg;
-	vector<long> filterable_data_lg;
+    vector<string> filterable_names;
+    vector<double> filterable_data;
+    vector<string> filterable_names_lg;
+    vector<long> filterable_data_lg;
 
-	string ev_type(DATA_READY_TYPE_EVENT);
+    string ev_type(DATA_READY_TYPE_EVENT);
 
-	AttDataReady dat_ready;
-	dat_ready.name = attr_name.c_str();
-	dat_ready.data_type = (int)data_type;
-	dat_ready.ctr = ctr;
+    AttDataReady dat_ready;
+    dat_ready.name = attr_name.c_str();
+    dat_ready.data_type = (int) data_type;
+    dat_ready.ctr = ctr;
 
     SuppliedEventData ad;
-    ::memset(&ad,0,sizeof(ad));
+    ::memset(&ad, 0, sizeof(ad));
     ad.attr_dat_ready = &dat_ready;
 
-	push_event(device_impl,
-		   ev_type,
-		   filterable_names,
-		   filterable_data,
-		   filterable_names_lg,
-		   filterable_data_lg,
-	       ad,
-		   const_cast<string &>(attr_name),
-		   NULL,true);
+    push_event(device_impl,
+               ev_type,
+               filterable_names,
+               filterable_data,
+               filterable_names_lg,
+               filterable_data_lg,
+               ad,
+               const_cast<string &>(attr_name),
+               NULL, true);
 }
 
 
@@ -2185,10 +2225,13 @@ void EventSupplier::push_att_data_ready_event(DeviceImpl *device_impl,const stri
 //
 //------------------------------------------------------------------------------------------------------------------
 
-void EventSupplier::push_att_conf_events(DeviceImpl *device_impl,SuppliedEventData &attr_conf,DevFailed *except,string &attr_name)
+void EventSupplier::push_att_conf_events(DeviceImpl *device_impl,
+                                         SuppliedEventData &attr_conf,
+                                         DevFailed *except,
+                                         string &attr_name)
 {
     string event, domain_name;
-    time_t now,att_conf_subscription,attr_sub;
+    time_t now, att_conf_subscription, attr_sub;
 
     cout3 << "EventSupplier::push_att_conf_events(): called for attribute " << attr_name << endl;
 
@@ -2198,41 +2241,41 @@ void EventSupplier::push_att_conf_events(DeviceImpl *device_impl,SuppliedEventDa
 // Called for AttributeConfig_3 or AttributeConfig_5 ?
 //
 
-	bool conf5 = false;
-	int vers = 4;
+    bool conf5 = false;
+    int vers = 4;
 
-	if (attr_conf.attr_conf_5 != NULL)
-	{
-		conf5 = true;
-		vers = 5;
-	}
+    if (attr_conf.attr_conf_5 != NULL)
+    {
+        conf5 = true;
+        vers = 5;
+    }
 
 //
 // Return if there is no client or if the last client subscription is more than 10 mins ago
 //
 
     {
-    	omni_mutex_lock oml(event_mutex);
+        omni_mutex_lock oml(event_mutex);
 
-		if (conf5 == true)
-			attr_sub = attr.event_attr_conf5_subscription;
-		else
-			attr_sub = attr.event_attr_conf_subscription;
+        if (conf5 == true)
+            attr_sub = attr.event_attr_conf5_subscription;
+        else
+            attr_sub = attr.event_attr_conf_subscription;
     }
 
-	if (attr_sub == 0)
-		return;
+    if (attr_sub == 0)
+        return;
 
     now = time(NULL);
-	att_conf_subscription = now - attr_sub;
+    att_conf_subscription = now - attr_sub;
 
     cout3 << "EventSupplier::push_att_conf_events(): delta since last subscription " << att_conf_subscription << endl;
 
     if (att_conf_subscription > EVENT_RESUBSCRIBE_PERIOD)
-	{
-		attr.remove_client_lib(vers,string(EventName[ATTR_CONF_EVENT]));
-		return;
-	}
+    {
+        attr.remove_client_lib(vers, string(EventName[ATTR_CONF_EVENT]));
+        return;
+    }
 
 //
 // Push event
@@ -2244,19 +2287,19 @@ void EventSupplier::push_att_conf_events(DeviceImpl *device_impl,SuppliedEventDa
     vector<long> filterable_data_lg;
 
     string ev_type = CONF_TYPE_EVENT;
-	if (conf5 == true)
-		ev_type = EVENT_COMPAT_IDL5 + ev_type;
+    if (conf5 == true)
+        ev_type = EVENT_COMPAT_IDL5 + ev_type;
 
     push_event(device_impl,
-           ev_type,
-           filterable_names,
-           filterable_data,
-           filterable_names_lg,
-           filterable_data_lg,
-           attr_conf,
-           attr_name,
-           except,
-           true);
+               ev_type,
+               filterable_names,
+               filterable_data,
+               filterable_names_lg,
+               filterable_data_lg,
+               attr_conf,
+               attr_name,
+               except,
+               true);
 }
 
 //+--------------------------------------------------------------------------------------------------------------
@@ -2276,16 +2319,19 @@ void EventSupplier::push_att_conf_events(DeviceImpl *device_impl,SuppliedEventDa
 //
 //-------------------------------------------------------------------------------------------------------------
 
-void EventSupplier::push_dev_intr_change_event(DeviceImpl *device_impl,bool dev_start,DevCmdInfoList_2 *cmds_list,AttributeConfigList_5 *atts_list)
+void EventSupplier::push_dev_intr_change_event(DeviceImpl *device_impl,
+                                               bool dev_start,
+                                               DevCmdInfoList_2 *cmds_list,
+                                               AttributeConfigList_5 *atts_list)
 {
-	cout3 << "EventSupplier::push_dev_intr_change_event(): called for device " << device_impl->get_name() << endl;
+    cout3 << "EventSupplier::push_dev_intr_change_event(): called for device " << device_impl->get_name() << endl;
 
-	vector<string> filterable_names;
-	vector<double> filterable_data;
-	vector<string> filterable_names_lg;
-	vector<long> filterable_data_lg;
+    vector<string> filterable_names;
+    vector<double> filterable_data;
+    vector<string> filterable_names_lg;
+    vector<long> filterable_data_lg;
 
-	string ev_type(EventName[INTERFACE_CHANGE_EVENT]);
+    string ev_type(EventName[INTERFACE_CHANGE_EVENT]);
     time_t now, dev_intr_subscription;
 
 //
@@ -2293,46 +2339,46 @@ void EventSupplier::push_dev_intr_change_event(DeviceImpl *device_impl,bool dev_
 //
 
     now = time(NULL);
-	dev_intr_subscription = now - device_impl->get_event_intr_change_subscription();
+    dev_intr_subscription = now - device_impl->get_event_intr_change_subscription();
 
     cout3 << "EventSupplier::push_dev_intr_event(): delta since last subscription " << dev_intr_subscription << endl;
 
     if (dev_intr_subscription > EVENT_RESUBSCRIBE_PERIOD)
-	{
-		delete cmds_list;
-		delete atts_list;
+    {
+        delete cmds_list;
+        delete atts_list;
 
-		return;
-	}
+        return;
+    }
 
-	DevIntrChange dev_intr;
+    DevIntrChange dev_intr;
 
-	dev_intr.dev_started = dev_start;
-	dev_intr.cmds = *cmds_list;
-	dev_intr.atts = *atts_list;
+    dev_intr.dev_started = dev_start;
+    dev_intr.cmds = *cmds_list;
+    dev_intr.atts = *atts_list;
 
     SuppliedEventData ad;
-    ::memset(&ad,0,sizeof(ad));
+    ::memset(&ad, 0, sizeof(ad));
     ad.dev_intr_change = &dev_intr;
 
-	string att_name("dummy");
-	push_event(device_impl,
-		   ev_type,
-		   filterable_names,
-		   filterable_data,
-		   filterable_names_lg,
-		   filterable_data_lg,
-	       ad,
-		   att_name,
-		   NULL,
-		   true);
+    string att_name("dummy");
+    push_event(device_impl,
+               ev_type,
+               filterable_names,
+               filterable_data,
+               filterable_names_lg,
+               filterable_data_lg,
+               ad,
+               att_name,
+               NULL,
+               true);
 
 //
 // Free memory allocated for the two pointers we receive
 //
 
-	delete cmds_list;
-	delete atts_list;
+    delete cmds_list;
+    delete atts_list;
 }
 
 //+--------------------------------------------------------------------------------------------------------------
@@ -2354,81 +2400,81 @@ void EventSupplier::push_dev_intr_change_event(DeviceImpl *device_impl,bool dev_
 
 bool EventSupplier::any_dev_intr_client(DeviceImpl *device_impl)
 {
-	bool ret = false;
+    bool ret = false;
 
     time_t now = time(NULL);
-	time_t dev_intr_subscription = now - device_impl->get_event_intr_change_subscription();
+    time_t dev_intr_subscription = now - device_impl->get_event_intr_change_subscription();
 
     if (dev_intr_subscription < EVENT_RESUBSCRIBE_PERIOD)
-		ret = true;
+        ret = true;
 
-	return ret;
+    return ret;
 }
 
 void EventSupplier::convert_att_event_to_5(struct EventSupplier::SuppliedEventData &attr_value,
-										   struct EventSupplier::SuppliedEventData &sent_value,
-										   bool &need_free,Attribute &attr)
+                                           struct EventSupplier::SuppliedEventData &sent_value,
+                                           bool &need_free, Attribute &attr)
 {
-	if (attr_value.attr_val_3 != Tango_nullptr)
-	{
-		AttributeValue_5 *tmp_attr_val_5 = new AttributeValue_5();
-		attr.AttributeValue_3_2_AttributeValue_5(attr_value.attr_val_3,tmp_attr_val_5);
-		sent_value.attr_val_5 = tmp_attr_val_5;
-		need_free = true;
-	}
-	else if (attr_value.attr_val_4 != Tango_nullptr)
-	{
-		AttributeValue_5 *tmp_attr_val_5 = new AttributeValue_5();
-		attr.AttributeValue_4_2_AttributeValue_5(attr_value.attr_val_4,tmp_attr_val_5);
-		sent_value.attr_val_5 = tmp_attr_val_5;
-		need_free = true;
-	}
-	else
-		sent_value.attr_val_5 = attr_value.attr_val_5;
+    if (attr_value.attr_val_3 != Tango_nullptr)
+    {
+        AttributeValue_5 *tmp_attr_val_5 = new AttributeValue_5();
+        attr.AttributeValue_3_2_AttributeValue_5(attr_value.attr_val_3, tmp_attr_val_5);
+        sent_value.attr_val_5 = tmp_attr_val_5;
+        need_free = true;
+    }
+    else if (attr_value.attr_val_4 != Tango_nullptr)
+    {
+        AttributeValue_5 *tmp_attr_val_5 = new AttributeValue_5();
+        attr.AttributeValue_4_2_AttributeValue_5(attr_value.attr_val_4, tmp_attr_val_5);
+        sent_value.attr_val_5 = tmp_attr_val_5;
+        need_free = true;
+    }
+    else
+        sent_value.attr_val_5 = attr_value.attr_val_5;
 }
 
 void EventSupplier::convert_att_event_to_4(struct EventSupplier::SuppliedEventData &attr_value,
-										   struct EventSupplier::SuppliedEventData &sent_value,
-										   bool &need_free,Attribute &attr)
+                                           struct EventSupplier::SuppliedEventData &sent_value,
+                                           bool &need_free, Attribute &attr)
 {
-	if (attr_value.attr_val_3 != Tango_nullptr)
-	{
-		AttributeValue_4 *tmp_attr_val_4 = new AttributeValue_4();
-		attr.AttributeValue_3_2_AttributeValue_4(attr_value.attr_val_3,tmp_attr_val_4);
-		sent_value.attr_val_4 = tmp_attr_val_4;
-		need_free = true;
-	}
-	else if (attr_value.attr_val_5 != Tango_nullptr)
-	{
-		AttributeValue_4 *tmp_attr_val_4 = new AttributeValue_4();
-		attr.AttributeValue_5_2_AttributeValue_4(attr_value.attr_val_5,tmp_attr_val_4);
-		sent_value.attr_val_4 = tmp_attr_val_4;
-		need_free = true;
-	}
-	else
-		sent_value.attr_val_4 = attr_value.attr_val_4;
+    if (attr_value.attr_val_3 != Tango_nullptr)
+    {
+        AttributeValue_4 *tmp_attr_val_4 = new AttributeValue_4();
+        attr.AttributeValue_3_2_AttributeValue_4(attr_value.attr_val_3, tmp_attr_val_4);
+        sent_value.attr_val_4 = tmp_attr_val_4;
+        need_free = true;
+    }
+    else if (attr_value.attr_val_5 != Tango_nullptr)
+    {
+        AttributeValue_4 *tmp_attr_val_4 = new AttributeValue_4();
+        attr.AttributeValue_5_2_AttributeValue_4(attr_value.attr_val_5, tmp_attr_val_4);
+        sent_value.attr_val_4 = tmp_attr_val_4;
+        need_free = true;
+    }
+    else
+        sent_value.attr_val_4 = attr_value.attr_val_4;
 }
 
 void EventSupplier::convert_att_event_to_3(struct EventSupplier::SuppliedEventData &attr_value,
-										   struct EventSupplier::SuppliedEventData &sent_value,
-										   bool &need_free,Attribute &attr)
+                                           struct EventSupplier::SuppliedEventData &sent_value,
+                                           bool &need_free, Attribute &attr)
 {
-	if (attr_value.attr_val_4 != Tango_nullptr)
-	{
-		AttributeValue_3 *tmp_attr_val_3 = new AttributeValue_3();
-		attr.AttributeValue_4_2_AttributeValue_3(attr_value.attr_val_4,tmp_attr_val_3);
-		sent_value.attr_val_3 = tmp_attr_val_3;
-		need_free = true;
-	}
-	else if (attr_value.attr_val_5 != Tango_nullptr)
-	{
-		AttributeValue_3 *tmp_attr_val_3 = new AttributeValue_3();
-		attr.AttributeValue_5_2_AttributeValue_3(attr_value.attr_val_5,tmp_attr_val_3);
-		sent_value.attr_val_3 = tmp_attr_val_3;
-		need_free = true;
-	}
-	else
-		sent_value.attr_val_3 = attr_value.attr_val_3;
+    if (attr_value.attr_val_4 != Tango_nullptr)
+    {
+        AttributeValue_3 *tmp_attr_val_3 = new AttributeValue_3();
+        attr.AttributeValue_4_2_AttributeValue_3(attr_value.attr_val_4, tmp_attr_val_3);
+        sent_value.attr_val_3 = tmp_attr_val_3;
+        need_free = true;
+    }
+    else if (attr_value.attr_val_5 != Tango_nullptr)
+    {
+        AttributeValue_3 *tmp_attr_val_3 = new AttributeValue_3();
+        attr.AttributeValue_5_2_AttributeValue_3(attr_value.attr_val_5, tmp_attr_val_3);
+        sent_value.attr_val_3 = tmp_attr_val_3;
+        need_free = true;
+    }
+    else
+        sent_value.attr_val_3 = attr_value.attr_val_3;
 }
 
 } /* End of Tango namespace */

--- a/cppapi/server/eventsupplier.cpp
+++ b/cppapi/server/eventsupplier.cpp
@@ -334,7 +334,7 @@ bool EventSupplier::detect_and_push_change_event(DeviceImpl *device_impl, struct
 // if no attribute of this name is registered with change then insert the current value
 //
 
-    if (!attr.prev_change_event.inited)
+    if (attr.prev_change_event.inited == false)
     {
         if (except != NULL)
         {
@@ -1011,13 +1011,17 @@ bool EventSupplier::detect_and_push_periodic_event(DeviceImpl *device_impl,
     else
     {
 #ifdef _TG_WINDOWS_
-        double tmp = (double)eve_period * DELTA_PERIODIC;
-        double int_part,eve_round;
-        double frac = modf(tmp,&int_part);
+        double tmp = (double) eve_period * DELTA_PERIODIC;
+        double int_part, eve_round;
+        double frac = modf(tmp, &int_part);
         if (frac >= 0.5)
+        {
             eve_round = ceil(tmp);
+        }
         else
+        {
             eve_round = floor(tmp);
+        }
 #else
         double eve_round = round((double) eve_period * DELTA_PERIODIC);
 #endif
@@ -1334,7 +1338,7 @@ bool EventSupplier::detect_change(Attribute &attr, struct SuppliedEventData &att
 
     TangoMonitor &mon1 = dev->get_att_conf_monitor();
     mon1.get_monitor();
-    if (!archive)
+    if (not archive)
     {
         rel_change[0] = attr.rel_change[0];
         rel_change[1] = attr.rel_change[1];

--- a/cppapi/server/eventsupplier.cpp
+++ b/cppapi/server/eventsupplier.cpp
@@ -74,7 +74,9 @@ EventSupplier::EventSupplier(Util *tg)
     {
         fqdn_prefix = "tango://";
         if (Util::_UseDb == false || Util::_FileDb == true)
+        {
             fqdn_prefix = fqdn_prefix + tg->get_host_name() + ':' + tg->get_svr_port_num() + '/';
+        }
         else
         {
             Database *db = tg->get_database();
@@ -150,17 +152,23 @@ SendEventType EventSupplier::detect_and_push_events(DeviceImpl *device_impl, str
         {
             case 5:
                 if (change5_subscription >= EVENT_RESUBSCRIBE_PERIOD)
+                {
                     attr.remove_client_lib(5, string(EventName[CHANGE_EVENT]));
+                }
                 break;
 
             case 4:
                 if (change4_subscription >= EVENT_RESUBSCRIBE_PERIOD)
+                {
                     attr.remove_client_lib(4, string(EventName[CHANGE_EVENT]));
+                }
                 break;
 
             default:
                 if (change3_subscription >= EVENT_RESUBSCRIBE_PERIOD)
+                {
                     attr.remove_client_lib(3, string(EventName[CHANGE_EVENT]));
+                }
                 break;
         }
 
@@ -169,7 +177,9 @@ SendEventType EventSupplier::detect_and_push_events(DeviceImpl *device_impl, str
     if (client_libs.empty() == false)
     {
         if (detect_and_push_change_event(device_impl, attr_value, attr, attr_name, except) == true)
+        {
             ret.change = true;
+        }
     }
 
 //
@@ -186,17 +196,23 @@ SendEventType EventSupplier::detect_and_push_events(DeviceImpl *device_impl, str
         {
             case 5:
                 if (periodic5_subscription >= EVENT_RESUBSCRIBE_PERIOD)
+                {
                     attr.remove_client_lib(5, string(EventName[PERIODIC_EVENT]));
+                }
                 break;
 
             case 4:
                 if (periodic4_subscription >= EVENT_RESUBSCRIBE_PERIOD)
+                {
                     attr.remove_client_lib(4, string(EventName[PERIODIC_EVENT]));
+                }
                 break;
 
             default:
                 if (periodic3_subscription >= EVENT_RESUBSCRIBE_PERIOD)
+                {
                     attr.remove_client_lib(3, string(EventName[PERIODIC_EVENT]));
+                }
                 break;
         }
 
@@ -205,7 +221,9 @@ SendEventType EventSupplier::detect_and_push_events(DeviceImpl *device_impl, str
     if (client_libs.empty() == false)
     {
         if (detect_and_push_periodic_event(device_impl, attr_value, attr, attr_name, except, time_bef_attr) == true)
+        {
             ret.periodic = true;
+        }
     }
 
 //
@@ -222,17 +240,23 @@ SendEventType EventSupplier::detect_and_push_events(DeviceImpl *device_impl, str
         {
             case 5:
                 if (archive5_subscription >= EVENT_RESUBSCRIBE_PERIOD)
+                {
                     attr.remove_client_lib(5, string(EventName[ARCHIVE_EVENT]));
+                }
                 break;
 
             case 4:
                 if (archive4_subscription >= EVENT_RESUBSCRIBE_PERIOD)
+                {
                     attr.remove_client_lib(4, string(EventName[ARCHIVE_EVENT]));
+                }
                 break;
 
             default:
                 if (archive3_subscription >= EVENT_RESUBSCRIBE_PERIOD)
+                {
                     attr.remove_client_lib(3, string(EventName[ARCHIVE_EVENT]));
+                }
                 break;
         }
 
@@ -241,7 +265,9 @@ SendEventType EventSupplier::detect_and_push_events(DeviceImpl *device_impl, str
     if (client_libs.empty() == false)
     {
         if (detect_and_push_archive_event(device_impl, attr_value, attr, attr_name, except, time_bef_attr) == true)
+        {
             ret.archive = true;
+        }
     }
 
     return ret;
@@ -282,13 +308,21 @@ bool EventSupplier::detect_and_push_change_event(DeviceImpl *device_impl, struct
     Tango::AttrQuality the_quality;
 
     if (attr_value.attr_val_5 != NULL)
+    {
         the_quality = attr_value.attr_val_5->quality;
+    }
     else if (attr_value.attr_val_4 != NULL)
+    {
         the_quality = attr_value.attr_val_4->quality;
+    }
     else if (attr_value.attr_val_3 != NULL)
+    {
         the_quality = attr_value.attr_val_3->quality;
+    }
     else
+    {
         the_quality = attr_value.attr_val->quality;
+    }
 
 //
 // get the mutex to synchronize the sending of events
@@ -310,20 +344,30 @@ bool EventSupplier::detect_and_push_change_event(DeviceImpl *device_impl, struct
         else
         {
             if (attr_value.attr_val_5 != NULL)
+            {
                 attr.prev_change_event.value_4 = attr_value.attr_val_5->value;
+            }
             else if (attr_value.attr_val_4 != NULL)
+            {
                 attr.prev_change_event.value_4 = attr_value.attr_val_4->value;
+            }
             else if (attr_value.attr_val_3 != NULL)
+            {
                 attr.prev_change_event.value = attr_value.attr_val_3->value;
+            }
             else
+            {
                 attr.prev_change_event.value = attr_value.attr_val->value;
+            }
 
             attr.prev_change_event.quality = the_quality;
             attr.prev_change_event.err = false;
         }
         attr.prev_change_event.inited = true;
         if (user_push == true)
+        {
             is_change = true;
+        }
     }
     else
     {
@@ -369,13 +413,21 @@ bool EventSupplier::detect_and_push_change_event(DeviceImpl *device_impl, struct
         else
         {
             if (attr_value.attr_val_5 != NULL)
+            {
                 attr.prev_change_event.value_4 = attr_value.attr_val_5->value;
+            }
             else if (attr_value.attr_val_4 != NULL)
+            {
                 attr.prev_change_event.value_4 = attr_value.attr_val_4->value;
+            }
             else if (attr_value.attr_val_3 != NULL)
+            {
                 attr.prev_change_event.value = attr_value.attr_val_3->value;
+            }
             else
+            {
                 attr.prev_change_event.value = attr_value.attr_val->value;
+            }
             attr.prev_change_event.quality = the_quality;
             attr.prev_change_event.err = false;
         }
@@ -392,15 +444,23 @@ bool EventSupplier::detect_and_push_change_event(DeviceImpl *device_impl, struct
 
         filterable_names.push_back("forced_event");
         if (force_change == true)
+        {
             filterable_data.push_back((double) 1.0);
+        }
         else
+        {
             filterable_data.push_back((double) 0.0);
+        }
 
         filterable_names.push_back("quality");
         if (quality_change == true)
+        {
             filterable_data.push_back((double) 1.0);
+        }
         else
+        {
             filterable_data.push_back((double) 0.0);
+        }
 
         vector<int> &client_libs = attr.get_client_lib(CHANGE_EVENT);
         vector<int>::iterator ite;
@@ -453,16 +513,26 @@ bool EventSupplier::detect_and_push_change_event(DeviceImpl *device_impl, struct
             if (need_free == true)
             {
                 if (sent_value.attr_val_5 != NULL)
+                {
                     delete sent_value.attr_val_5;
+                }
                 else if (sent_value.attr_val_4 != NULL)
+                {
                     delete sent_value.attr_val_4;
+                }
                 else if (sent_value.attr_val_3 != NULL)
+                {
                     delete sent_value.attr_val_3;
+                }
                 else
+                {
                     delete sent_value.attr_val;
+                }
             }
             if (name_changed == true)
+            {
                 ev_name = EventName[CHANGE_EVENT];
+            }
         }
         ret = true;
 
@@ -515,13 +585,21 @@ bool EventSupplier::detect_and_push_archive_event(DeviceImpl *device_impl,
     Tango::AttrQuality the_quality;
 
     if (attr_value.attr_val_5 != NULL)
+    {
         the_quality = attr_value.attr_val_5->quality;
+    }
     else if (attr_value.attr_val_4 != NULL)
+    {
         the_quality = attr_value.attr_val_4->quality;
+    }
     else if (attr_value.attr_val_3 != NULL)
+    {
         the_quality = attr_value.attr_val_3->quality;
+    }
     else
+    {
         the_quality = attr_value.attr_val->quality;
+    }
 
     struct timeval now;
     if (time_bef_attr == NULL)
@@ -552,9 +630,13 @@ bool EventSupplier::detect_and_push_archive_event(DeviceImpl *device_impl,
 //
 
     if (time_bef_attr != NULL)
+    {
         now_ms = (double) time_bef_attr->tv_sec * 1000. + (double) time_bef_attr->tv_usec / 1000.;
+    }
     else
+    {
         now_ms = (double) now.tv_sec * 1000. + (double) now.tv_usec / 1000.;
+    }
     ms_since_last_periodic = now_ms - attr.archive_last_periodic;
 
     int arch_period;
@@ -618,13 +700,21 @@ bool EventSupplier::detect_and_push_archive_event(DeviceImpl *device_impl,
         else
         {
             if (attr_value.attr_val_5 != NULL)
+            {
                 attr.prev_archive_event.value_4 = attr_value.attr_val_5->value;
+            }
             else if (attr_value.attr_val_4 != NULL)
+            {
                 attr.prev_archive_event.value_4 = attr_value.attr_val_4->value;
+            }
             else if (attr_value.attr_val_3 != NULL)
+            {
                 attr.prev_archive_event.value = attr_value.attr_val_3->value;
+            }
             else
+            {
                 attr.prev_archive_event.value = attr_value.attr_val->value;
+            }
 
             attr.prev_archive_event.quality = the_quality;
             attr.prev_archive_event.err = false;
@@ -633,7 +723,9 @@ bool EventSupplier::detect_and_push_archive_event(DeviceImpl *device_impl,
         attr.archive_last_event = now_ms;
         attr.prev_archive_event.inited = true;
         if (user_push == true)
+        {
             is_change = true;
+        }
     }
     else
     {
@@ -683,13 +775,21 @@ bool EventSupplier::detect_and_push_archive_event(DeviceImpl *device_impl,
         else
         {
             if (attr_value.attr_val_5 != NULL)
+            {
                 attr.prev_archive_event.value_4 = attr_value.attr_val_5->value;
+            }
             else if (attr_value.attr_val_4 != NULL)
+            {
                 attr.prev_archive_event.value_4 = attr_value.attr_val_4->value;
+            }
             else if (attr_value.attr_val_3 != NULL)
+            {
                 attr.prev_archive_event.value = attr_value.attr_val_3->value;
+            }
             else
+            {
                 attr.prev_archive_event.value = attr_value.attr_val->value;
+            }
             attr.prev_archive_event.quality = the_quality;
             attr.prev_archive_event.err = false;
         }
@@ -716,15 +816,23 @@ bool EventSupplier::detect_and_push_archive_event(DeviceImpl *device_impl,
         filterable_data.push_back(delta_change_abs);
         filterable_names.push_back("forced_event");
         if (force_change == true)
+        {
             filterable_data.push_back((double) 1.0);
+        }
         else
+        {
             filterable_data.push_back((double) 0.0);
+        }
 
         filterable_names.push_back("quality");
         if (quality_change == true)
+        {
             filterable_data.push_back((double) 1.0);
+        }
         else
+        {
             filterable_data.push_back((double) 0.0);
+        }
 
         filterable_names.push_back("delta_event");
         filterable_data.push_back(now_ms - attr.archive_last_event);
@@ -781,16 +889,26 @@ bool EventSupplier::detect_and_push_archive_event(DeviceImpl *device_impl,
             if (need_free == true)
             {
                 if (sent_value.attr_val_5 != NULL)
+                {
                     delete sent_value.attr_val_5;
+                }
                 else if (sent_value.attr_val_4 != NULL)
+                {
                     delete sent_value.attr_val_4;
+                }
                 else if (sent_value.attr_val_3 != NULL)
+                {
                     delete sent_value.attr_val_3;
+                }
                 else
+                {
                     delete sent_value.attr_val;
+                }
             }
             if (name_changed == true)
+            {
                 ev_name = EventName[ARCHIVE_EVENT];
+            }
         }
 
         ret = true;
@@ -853,9 +971,13 @@ bool EventSupplier::detect_and_push_periodic_event(DeviceImpl *device_impl,
 //
 
     if (time_bef_attr != NULL)
+    {
         now_ms = (double) time_bef_attr->tv_sec * 1000. + (double) time_bef_attr->tv_usec / 1000.;
+    }
     else
+    {
         now_ms = (double) now.tv_sec * 1000. + (double) now.tv_usec / 1000.;
+    }
 
 //
 // get the mutex to synchronize the sending of events
@@ -977,16 +1099,26 @@ bool EventSupplier::detect_and_push_periodic_event(DeviceImpl *device_impl,
             if (need_free == true)
             {
                 if (sent_value.attr_val_5 != NULL)
+                {
                     delete sent_value.attr_val_5;
+                }
                 else if (sent_value.attr_val_4 != NULL)
+                {
                     delete sent_value.attr_val_4;
+                }
                 else if (sent_value.attr_val_3 != NULL)
+                {
                     delete sent_value.attr_val_3;
+                }
                 else
+                {
                     delete sent_value.attr_val;
+                }
             }
             if (name_changed == true)
+            {
                 ev_name = EventName[PERIODIC_EVENT];
+            }
         }
         ret = true;
     }
@@ -1030,9 +1162,13 @@ bool EventSupplier::detect_change(Attribute &attr, struct SuppliedEventData &att
     const CORBA::Any *the_new_any = NULL;
 
     if (attr_value.attr_val_5 != NULL)
+    {
         the_new_quality = attr_value.attr_val_5->quality;
+    }
     else if (attr_value.attr_val_4 != NULL)
+    {
         the_new_quality = attr_value.attr_val_4->quality;
+    }
     else if (attr_value.attr_val_3 != NULL)
     {
         the_new_quality = attr_value.attr_val_3->quality;
@@ -1202,7 +1338,9 @@ bool EventSupplier::detect_change(Attribute &attr, struct SuppliedEventData &att
         abs_change[1] = attr.abs_change[1];
         inited = attr.prev_change_event.inited;
         if ((attr.prev_change_event.quality != Tango::ATTR_INVALID) && (the_new_quality != Tango::ATTR_INVALID))
+        {
             enable_check = true;
+        }
     }
     else
     {
@@ -1212,7 +1350,9 @@ bool EventSupplier::detect_change(Attribute &attr, struct SuppliedEventData &att
         abs_change[1] = attr.archive_abs_change[1];
         inited = attr.prev_archive_event.inited;
         if ((attr.prev_archive_event.quality != Tango::ATTR_INVALID) && (the_new_quality != Tango::ATTR_INVALID))
+        {
             enable_check = true;
+        }
     }
     mon1.rel_monitor();
 
@@ -1224,7 +1364,9 @@ bool EventSupplier::detect_change(Attribute &attr, struct SuppliedEventData &att
             unsigned int i;
 
             if (the_new_any != NULL)
+            {
                 ty = the_new_any->type();
+            }
 
 //
 // First, analyse the DevEncoded data type
@@ -1239,9 +1381,13 @@ bool EventSupplier::detect_change(Attribute &attr, struct SuppliedEventData &att
 
                 const Tango::DevVarEncodedArray *un_seq;
                 if (attr_value.attr_val_5 != NULL)
+                {
                     un_seq = &(attr_value.attr_val_5->value.encoded_att_value());
+                }
                 else
+                {
                     un_seq = &(attr_value.attr_val_4->value.encoded_att_value());
+                }
 
                 curr_seq_str_nb = strlen((*un_seq)[0].encoded_format.in());
                 curr_seq_nb = (*un_seq)[0].encoded_data.length();
@@ -1293,7 +1439,9 @@ bool EventSupplier::detect_change(Attribute &attr, struct SuppliedEventData &att
                             {
                                 delta_change_rel = 100;
                                 if ((*curr_data_ptr)[i] == (*prev_data_ptr)[i])
+                                {
                                     delta_change_rel = 0;
+                                }
                             }
                             if (delta_change_rel <= rel_change[0] || delta_change_rel >= rel_change[1])
                             {
@@ -1327,27 +1475,39 @@ bool EventSupplier::detect_change(Attribute &attr, struct SuppliedEventData &att
                     dev_state_type = true;
                     curr_sta = attr_value.attr_val_5->value.dev_state_att();
                     if (archive == true)
+                    {
                         prev_sta = attr.prev_archive_event.value_4.dev_state_att();
+                    }
                     else
+                    {
                         prev_sta = attr.prev_change_event.value_4.dev_state_att();
+                    }
                 }
                 else if ((attr_value.attr_val_4 != NULL) && (attr_value.attr_val_4->value._d() == DEVICE_STATE))
                 {
                     dev_state_type = true;
                     curr_sta = attr_value.attr_val_4->value.dev_state_att();
                     if (archive == true)
+                    {
                         prev_sta = attr.prev_archive_event.value_4.dev_state_att();
+                    }
                     else
+                    {
                         prev_sta = attr.prev_change_event.value_4.dev_state_att();
+                    }
                 }
                 else if ((the_new_any != NULL) && (ty->kind() == CORBA::tk_enum))
                 {
                     dev_state_type = true;
                     *the_new_any >>= curr_sta;
                     if (archive == true)
+                    {
                         attr.prev_archive_event.value >>= prev_sta;
+                    }
                     else
+                    {
                         attr.prev_change_event.value >>= prev_sta;
+                    }
 
                 }
 
@@ -1389,9 +1549,13 @@ bool EventSupplier::detect_change(Attribute &attr, struct SuppliedEventData &att
                     long_type = true;
                     *the_new_any >>= curr_seq_lo;
                     if (archive == true)
+                    {
                         attr.prev_archive_event.value >>= prev_seq_lo;
+                    }
                     else
+                    {
                         attr.prev_change_event.value >>= prev_seq_lo;
+                    }
                 }
 
                 if (long_type == true)
@@ -1414,7 +1578,8 @@ bool EventSupplier::detect_change(Attribute &attr, struct SuppliedEventData &att
                             else
                             {
                                 delta_change_rel = 100;
-                                if ((*curr_seq_lo)[i] == (*prev_seq_lo)[i]) delta_change_rel = 0;
+                                if ((*curr_seq_lo)[i] == (*prev_seq_lo)[i])
+                                { delta_change_rel = 0; }
                             }
 
                             if (delta_change_rel <= rel_change[0] || delta_change_rel >= rel_change[1])
@@ -1455,9 +1620,13 @@ bool EventSupplier::detect_change(Attribute &attr, struct SuppliedEventData &att
                     long_long_type = true;
                     *the_new_any >>= curr_seq_64;
                     if (archive == true)
+                    {
                         attr.prev_archive_event.value >>= prev_seq_64;
+                    }
                     else
+                    {
                         attr.prev_change_event.value >>= prev_seq_64;
+                    }
                 }
 
                 if (long_long_type == true)
@@ -1481,7 +1650,8 @@ bool EventSupplier::detect_change(Attribute &attr, struct SuppliedEventData &att
                             else
                             {
                                 delta_change_rel = 100;
-                                if ((*curr_seq_64)[i] == (*prev_seq_64)[i]) delta_change_rel = 0;
+                                if ((*curr_seq_64)[i] == (*prev_seq_64)[i])
+                                { delta_change_rel = 0; }
                             }
                             if (delta_change_rel <= rel_change[0] || delta_change_rel >= rel_change[1])
                             {
@@ -1521,9 +1691,13 @@ bool EventSupplier::detect_change(Attribute &attr, struct SuppliedEventData &att
                     short_type = true;
                     *the_new_any >>= curr_seq_sh;
                     if (archive == true)
+                    {
                         attr.prev_archive_event.value >>= prev_seq_sh;
+                    }
                     else
+                    {
                         attr.prev_change_event.value >>= prev_seq_sh;
+                    }
                 }
 
                 if (short_type == true)
@@ -1562,7 +1736,8 @@ bool EventSupplier::detect_change(Attribute &attr, struct SuppliedEventData &att
                                 else
                                 {
                                     delta_change_rel = 100;
-                                    if ((*curr_seq_sh)[i] == (*prev_seq_sh)[i]) delta_change_rel = 0;
+                                    if ((*curr_seq_sh)[i] == (*prev_seq_sh)[i])
+                                    { delta_change_rel = 0; }
                                 }
                                 if (delta_change_rel <= rel_change[0] || delta_change_rel >= rel_change[1])
                                 {
@@ -1603,9 +1778,13 @@ bool EventSupplier::detect_change(Attribute &attr, struct SuppliedEventData &att
                     double_type = true;
                     *the_new_any >>= curr_seq_db;
                     if (archive == true)
+                    {
                         attr.prev_archive_event.value >>= prev_seq_db;
+                    }
                     else
+                    {
                         attr.prev_change_event.value >>= prev_seq_db;
+                    }
                 }
 
                 if (double_type == true)
@@ -1635,7 +1814,8 @@ bool EventSupplier::detect_change(Attribute &attr, struct SuppliedEventData &att
                             else
                             {
                                 delta_change_rel = 100;
-                                if ((*curr_seq_db)[i] == (*prev_seq_db)[i]) delta_change_rel = 0;
+                                if ((*curr_seq_db)[i] == (*prev_seq_db)[i])
+                                { delta_change_rel = 0; }
                             }
 
                             if (delta_change_rel <= rel_change[0] || delta_change_rel >= rel_change[1])
@@ -1688,9 +1868,13 @@ bool EventSupplier::detect_change(Attribute &attr, struct SuppliedEventData &att
                     string_type = true;
                     *the_new_any >>= curr_seq_str;
                     if (archive == true)
+                    {
                         attr.prev_archive_event.value >>= prev_seq_str;
+                    }
                     else
+                    {
                         attr.prev_change_event.value >>= prev_seq_str;
+                    }
                 }
 
                 if (string_type == true)
@@ -1733,9 +1917,13 @@ bool EventSupplier::detect_change(Attribute &attr, struct SuppliedEventData &att
                     float_type = true;
                     *the_new_any >>= curr_seq_fl;
                     if (archive == true)
+                    {
                         attr.prev_archive_event.value >>= prev_seq_fl;
+                    }
                     else
+                    {
                         attr.prev_change_event.value >>= prev_seq_fl;
+                    }
                 }
 
                 if (float_type == true)
@@ -1765,7 +1953,8 @@ bool EventSupplier::detect_change(Attribute &attr, struct SuppliedEventData &att
                             else
                             {
                                 delta_change_rel = 100;
-                                if ((*curr_seq_fl)[i] == (*prev_seq_fl)[i]) delta_change_rel = 0;
+                                if ((*curr_seq_fl)[i] == (*prev_seq_fl)[i])
+                                { delta_change_rel = 0; }
                             }
                             if (delta_change_rel <= rel_change[0] || delta_change_rel >= rel_change[1])
                             {
@@ -1817,9 +2006,13 @@ bool EventSupplier::detect_change(Attribute &attr, struct SuppliedEventData &att
                     unsigned_short_type = true;
                     *the_new_any >>= curr_seq_ush;
                     if (archive == true)
+                    {
                         attr.prev_archive_event.value >>= prev_seq_ush;
+                    }
                     else
+                    {
                         attr.prev_change_event.value >>= prev_seq_ush;
+                    }
                 }
 
                 if (unsigned_short_type == true)
@@ -1842,7 +2035,8 @@ bool EventSupplier::detect_change(Attribute &attr, struct SuppliedEventData &att
                             else
                             {
                                 delta_change_rel = 100;
-                                if ((*curr_seq_ush)[i] == (*prev_seq_ush)[i]) delta_change_rel = 0;
+                                if ((*curr_seq_ush)[i] == (*prev_seq_ush)[i])
+                                { delta_change_rel = 0; }
                             }
                             if (delta_change_rel <= rel_change[0] || delta_change_rel >= rel_change[1])
                             {
@@ -1882,9 +2076,13 @@ bool EventSupplier::detect_change(Attribute &attr, struct SuppliedEventData &att
                     boolean_type = true;
                     *the_new_any >>= curr_seq_bo;
                     if (archive == true)
+                    {
                         attr.prev_archive_event.value >>= prev_seq_bo;
+                    }
                     else
+                    {
                         attr.prev_change_event.value >>= prev_seq_bo;
+                    }
                 }
 
                 if (boolean_type == true)
@@ -1927,9 +2125,13 @@ bool EventSupplier::detect_change(Attribute &attr, struct SuppliedEventData &att
                     char_type = true;
                     *the_new_any >>= curr_seq_uch;
                     if (archive == true)
+                    {
                         attr.prev_archive_event.value >>= prev_seq_uch;
+                    }
                     else
+                    {
                         attr.prev_change_event.value >>= prev_seq_uch;
+                    }
                 }
 
                 if (char_type == true)
@@ -1952,7 +2154,8 @@ bool EventSupplier::detect_change(Attribute &attr, struct SuppliedEventData &att
                             else
                             {
                                 delta_change_rel = 100;
-                                if ((*curr_seq_uch)[i] == (*prev_seq_uch)[i]) delta_change_rel = 0;
+                                if ((*curr_seq_uch)[i] == (*prev_seq_uch)[i])
+                                { delta_change_rel = 0; }
                             }
                             if (delta_change_rel <= rel_change[0] || delta_change_rel >= rel_change[1])
                             {
@@ -1992,9 +2195,13 @@ bool EventSupplier::detect_change(Attribute &attr, struct SuppliedEventData &att
                     unsigned_long_type = true;
                     *the_new_any >>= curr_seq_ulo;
                     if (archive == true)
+                    {
                         attr.prev_archive_event.value >>= prev_seq_ulo;
+                    }
                     else
+                    {
                         attr.prev_change_event.value >>= prev_seq_ulo;
+                    }
                 }
 
                 if (unsigned_long_type == true)
@@ -2017,7 +2224,8 @@ bool EventSupplier::detect_change(Attribute &attr, struct SuppliedEventData &att
                             else
                             {
                                 delta_change_rel = 100;
-                                if ((*curr_seq_ulo)[i] == (*prev_seq_ulo)[i]) delta_change_rel = 0;
+                                if ((*curr_seq_ulo)[i] == (*prev_seq_ulo)[i])
+                                { delta_change_rel = 0; }
                             }
                             if (delta_change_rel <= rel_change[0] || delta_change_rel >= rel_change[1])
                             {
@@ -2057,9 +2265,13 @@ bool EventSupplier::detect_change(Attribute &attr, struct SuppliedEventData &att
                     unsigned_64_type = true;
                     *the_new_any >>= curr_seq_u64;
                     if (archive == true)
+                    {
                         attr.prev_archive_event.value >>= prev_seq_u64;
+                    }
                     else
+                    {
                         attr.prev_change_event.value >>= prev_seq_u64;
+                    }
 
                 }
 
@@ -2084,7 +2296,8 @@ bool EventSupplier::detect_change(Attribute &attr, struct SuppliedEventData &att
                             else
                             {
                                 delta_change_rel = 100;
-                                if ((*curr_seq_u64)[i] == (*prev_seq_u64)[i]) delta_change_rel = 0;
+                                if ((*curr_seq_u64)[i] == (*prev_seq_u64)[i])
+                                { delta_change_rel = 0; }
                             }
                             if (delta_change_rel <= rel_change[0] || delta_change_rel >= rel_change[1])
                             {
@@ -2124,9 +2337,13 @@ bool EventSupplier::detect_change(Attribute &attr, struct SuppliedEventData &att
                     state_type = true;
                     *the_new_any >>= curr_seq_state;
                     if (archive == true)
+                    {
                         attr.prev_archive_event.value >>= prev_seq_state;
+                    }
                     else
+                    {
                         attr.prev_change_event.value >>= prev_seq_state;
+                    }
                 }
 
                 if (state_type == true)
@@ -2258,13 +2475,19 @@ void EventSupplier::push_att_conf_events(DeviceImpl *device_impl,
         omni_mutex_lock oml(event_mutex);
 
         if (conf5 == true)
+        {
             attr_sub = attr.event_attr_conf5_subscription;
+        }
         else
+        {
             attr_sub = attr.event_attr_conf_subscription;
+        }
     }
 
     if (attr_sub == 0)
+    {
         return;
+    }
 
     now = time(NULL);
     att_conf_subscription = now - attr_sub;
@@ -2288,7 +2511,9 @@ void EventSupplier::push_att_conf_events(DeviceImpl *device_impl,
 
     string ev_type = CONF_TYPE_EVENT;
     if (conf5 == true)
+    {
         ev_type = EVENT_COMPAT_IDL5 + ev_type;
+    }
 
     push_event(device_impl,
                ev_type,
@@ -2406,7 +2631,9 @@ bool EventSupplier::any_dev_intr_client(DeviceImpl *device_impl)
     time_t dev_intr_subscription = now - device_impl->get_event_intr_change_subscription();
 
     if (dev_intr_subscription < EVENT_RESUBSCRIBE_PERIOD)
+    {
         ret = true;
+    }
 
     return ret;
 }
@@ -2430,7 +2657,9 @@ void EventSupplier::convert_att_event_to_5(struct EventSupplier::SuppliedEventDa
         need_free = true;
     }
     else
+    {
         sent_value.attr_val_5 = attr_value.attr_val_5;
+    }
 }
 
 void EventSupplier::convert_att_event_to_4(struct EventSupplier::SuppliedEventData &attr_value,
@@ -2452,7 +2681,9 @@ void EventSupplier::convert_att_event_to_4(struct EventSupplier::SuppliedEventDa
         need_free = true;
     }
     else
+    {
         sent_value.attr_val_4 = attr_value.attr_val_4;
+    }
 }
 
 void EventSupplier::convert_att_event_to_3(struct EventSupplier::SuppliedEventData &attr_value,
@@ -2474,7 +2705,9 @@ void EventSupplier::convert_att_event_to_3(struct EventSupplier::SuppliedEventDa
         need_free = true;
     }
     else
+    {
         sent_value.attr_val_3 = attr_value.attr_val_3;
+    }
 }
 
 } /* End of Tango namespace */

--- a/cppapi/server/fwdattribute.tpp
+++ b/cppapi/server/fwdattribute.tpp
@@ -51,32 +51,32 @@ namespace Tango
 //--------------------------------------------------------------------------------------------------------------------
 
 template<typename T>
-void FwdAttribute::set_local_attribute(DeviceAttribute &da,T* &seq_ptr)
+void FwdAttribute::set_local_attribute(DeviceAttribute &da, T *&seq_ptr)
 {
-	qual = da.get_quality();
+    qual = da.get_quality();
 
-	TimeVal local_tv = da.get_date();
+    TimeVal local_tv = da.get_date();
 #ifdef _TG_WINDOWS_
-	tv.time = local_tv.tv_sec;
-	tv.millitm = local_tv.tv_usec / 1000;
+    tv.time = local_tv.tv_sec;
+    tv.millitm = local_tv.tv_usec / 1000;
 #else
-	tv.tv_sec = local_tv.tv_sec;
-	tv.tv_usec = local_tv.tv_usec;
+    tv.tv_sec = local_tv.tv_sec;
+    tv.tv_usec = local_tv.tv_usec;
 #endif
 
-	da >> seq_ptr;
+    da >> seq_ptr;
 
-	if (writable == READ_WRITE || writable == READ_WITH_WRITE)
-	{
-		set_write_value(seq_ptr->get_buffer() + da.get_nb_read(),da.get_written_dim_x(),da.get_written_dim_y());
-	}
+    if (writable == READ_WRITE || writable == READ_WITH_WRITE)
+    {
+        set_write_value(seq_ptr->get_buffer() + da.get_nb_read(), da.get_written_dim_x(), da.get_written_dim_y());
+    }
 
     if (seq_ptr->release() == true)
-        set_value_date_quality(seq_ptr->get_buffer(true),tv,qual,da.get_dim_x(),da.get_dim_y(),true);
+        set_value_date_quality(seq_ptr->get_buffer(true), tv, qual, da.get_dim_x(), da.get_dim_y(), true);
     else
-        set_value_date_quality(seq_ptr->get_buffer(),tv,qual,da.get_dim_x(),da.get_dim_y());
+        set_value_date_quality(seq_ptr->get_buffer(), tv, qual, da.get_dim_x(), da.get_dim_y());
 
-	delete seq_ptr;
+    delete seq_ptr;
 }
 
 //--------------------------------------------------------------------------------------------------------------------
@@ -97,16 +97,16 @@ void FwdAttribute::set_local_attribute(DeviceAttribute &da,T* &seq_ptr)
 //
 //--------------------------------------------------------------------------------------------------------------------
 
-template<typename T,typename V>
-void FwdAttribute::propagate_writen_data(DeviceAttribute &da,WAttribute &attr,T *&ptr,V *&seq_ptr)
+template<typename T, typename V>
+void FwdAttribute::propagate_writen_data(DeviceAttribute &da, WAttribute &attr, T *&ptr, V *&seq_ptr)
 {
-	attr.get_write_value(const_cast<const T* &>(ptr));
-	int data_length = attr.get_write_value_length();
-	long w_dim_x = attr.get_w_dim_x();
-	long w_dim_y = attr.get_w_dim_y();
+    attr.get_write_value(const_cast<const T *&>(ptr));
+    int data_length = attr.get_write_value_length();
+    long w_dim_x = attr.get_w_dim_x();
+    long w_dim_y = attr.get_w_dim_y();
 
-	seq_ptr = new V(data_length,data_length,ptr,false);
-	da.insert(seq_ptr,w_dim_x,w_dim_y);
+    seq_ptr = new V(data_length, data_length, ptr, false);
+    da.insert(seq_ptr, w_dim_x, w_dim_y);
 }
 
 //--------------------------------------------------------------------------------------------------------------------
@@ -129,216 +129,216 @@ void FwdAttribute::propagate_writen_data(DeviceAttribute &da,WAttribute &attr,T 
 template<typename T>
 bool FwdAttribute::new_att_conf_base(const T &conf)
 {
-	if (string(conf.name.in()) != name)
-		return true;
+    if (string(conf.name.in()) != name)
+        return true;
 
-	if (conf.writable != writable)
-		return true;
+    if (conf.writable != writable)
+        return true;
 
-	if (conf.data_format != data_format)
-		return true;
+    if (conf.data_format != data_format)
+        return true;
 
-	if (conf.data_type != data_type)
-		return true;
+    if (conf.data_type != data_type)
+        return true;
 
-	if (string(conf.description.in()) != description)
-		return true;
+    if (string(conf.description.in()) != description)
+        return true;
 
-	if (string(conf.unit.in()) != unit)
-		return true;
+    if (string(conf.unit.in()) != unit)
+        return true;
 
-	if (string(conf.standard_unit.in()) != standard_unit)
-		return true;
+    if (string(conf.standard_unit.in()) != standard_unit)
+        return true;
 
-	if (string(conf.display_unit.in()) != display_unit)
-		return true;
+    if (string(conf.display_unit.in()) != display_unit)
+        return true;
 
-	if (string(conf.format.in()) != format)
-		return true;
+    if (string(conf.format.in()) != format)
+        return true;
 
-	if (string(conf.min_value.in()) != min_value_str)
-		return true;
+    if (string(conf.min_value.in()) != min_value_str)
+        return true;
 
-	if (string(conf.max_value.in()) != max_value_str)
-		return true;
+    if (string(conf.max_value.in()) != max_value_str)
+        return true;
 
-	if (conf.level != disp_level)
-		return true;
+    if (conf.level != disp_level)
+        return true;
 
-	if (conf.writable_attr_name.in() != writable_attr_name)
-		return true;
+    if (conf.writable_attr_name.in() != writable_attr_name)
+        return true;
 
-	if (string(conf.att_alarm.min_alarm.in()) != min_alarm_str)
-		return true;
+    if (string(conf.att_alarm.min_alarm.in()) != min_alarm_str)
+        return true;
 
-	if (string(conf.att_alarm.max_alarm.in()) != max_alarm_str)
-		return true;
+    if (string(conf.att_alarm.max_alarm.in()) != max_alarm_str)
+        return true;
 
-	if (string(conf.att_alarm.min_warning.in()) != min_warning_str)
-		return true;
+    if (string(conf.att_alarm.min_warning.in()) != min_warning_str)
+        return true;
 
-	if (string(conf.att_alarm.max_warning.in()) != max_warning_str)
-		return true;
+    if (string(conf.att_alarm.max_warning.in()) != max_warning_str)
+        return true;
 
-	string tmp_prop(conf.att_alarm.delta_t);
-	if (tmp_prop == AlrmValueNotSpec)
-	{
-		if (delta_t_str != "0")
-			return true;
-	}
-	else
-	{
-		if (tmp_prop != delta_t_str)
-			return true;
-	}
+    string tmp_prop(conf.att_alarm.delta_t);
+    if (tmp_prop == AlrmValueNotSpec)
+    {
+        if (delta_t_str != "0")
+            return true;
+    }
+    else
+    {
+        if (tmp_prop != delta_t_str)
+            return true;
+    }
 
-	tmp_prop = conf.att_alarm.delta_val;
-	if (tmp_prop == AlrmValueNotSpec)
-	{
-		if (delta_val_str != AlrmValueNotSpec)
-			return true;
-	}
-	else
-	{
-		if (tmp_prop != delta_val_str)
-			return true;
-	}
+    tmp_prop = conf.att_alarm.delta_val;
+    if (tmp_prop == AlrmValueNotSpec)
+    {
+        if (delta_val_str != AlrmValueNotSpec)
+            return true;
+    }
+    else
+    {
+        if (tmp_prop != delta_val_str)
+            return true;
+    }
 
-	double tmp_array[2];
+    double tmp_array[2];
 
 //
 // rel_change
 //
 
-	tmp_prop = conf.event_prop.ch_event.rel_change;
-	if (tmp_prop == AlrmValueNotSpec)
-	{
-		if (rel_change[0] != INT_MAX || rel_change[1] != INT_MAX)
-			return true;
-	}
-	else
-	{
-		if (rel_change[0] == INT_MAX && rel_change[1] == INT_MAX)
-			return true;
-		else
-		{
-			convert_event_prop(tmp_prop,tmp_array);
-			if (tmp_array[0] != rel_change[0] || tmp_array[1] != rel_change[1])
-				return true;
-		}
-	}
+    tmp_prop = conf.event_prop.ch_event.rel_change;
+    if (tmp_prop == AlrmValueNotSpec)
+    {
+        if (rel_change[0] != INT_MAX || rel_change[1] != INT_MAX)
+            return true;
+    }
+    else
+    {
+        if (rel_change[0] == INT_MAX && rel_change[1] == INT_MAX)
+            return true;
+        else
+        {
+            convert_event_prop(tmp_prop, tmp_array);
+            if (tmp_array[0] != rel_change[0] || tmp_array[1] != rel_change[1])
+                return true;
+        }
+    }
 
 //
 // abs_change
 //
 
-	tmp_prop = conf.event_prop.ch_event.abs_change;
-	if (tmp_prop == AlrmValueNotSpec)
-	{
-		if (abs_change[0] != INT_MAX || abs_change[1] != INT_MAX)
-			return true;
-	}
-	else
-	{
-		if (abs_change[0] == INT_MAX && abs_change[1] == INT_MAX)
-			return true;
-		else
-		{
-			convert_event_prop(tmp_prop,tmp_array);
-			if (tmp_array[0] != abs_change[0] || tmp_array[1] != abs_change[1])
-				return true;
-		}
-	}
+    tmp_prop = conf.event_prop.ch_event.abs_change;
+    if (tmp_prop == AlrmValueNotSpec)
+    {
+        if (abs_change[0] != INT_MAX || abs_change[1] != INT_MAX)
+            return true;
+    }
+    else
+    {
+        if (abs_change[0] == INT_MAX && abs_change[1] == INT_MAX)
+            return true;
+        else
+        {
+            convert_event_prop(tmp_prop, tmp_array);
+            if (tmp_array[0] != abs_change[0] || tmp_array[1] != abs_change[1])
+                return true;
+        }
+    }
 
 //
 // archive rel_change
 //
 
-	tmp_prop = conf.event_prop.arch_event.rel_change;
-	if (tmp_prop == AlrmValueNotSpec)
-	{
-		if (archive_rel_change[0] != INT_MAX || archive_rel_change[1] != INT_MAX)
-			return true;
-	}
-	else
-	{
-		if (archive_rel_change[0] == INT_MAX && archive_rel_change[1] == INT_MAX)
-			return true;
-		else
-		{
-			convert_event_prop(tmp_prop,tmp_array);
-			if (tmp_array[0] != archive_rel_change[0] || tmp_array[1] != archive_rel_change[1])
-				return true;
-		}
-	}
+    tmp_prop = conf.event_prop.arch_event.rel_change;
+    if (tmp_prop == AlrmValueNotSpec)
+    {
+        if (archive_rel_change[0] != INT_MAX || archive_rel_change[1] != INT_MAX)
+            return true;
+    }
+    else
+    {
+        if (archive_rel_change[0] == INT_MAX && archive_rel_change[1] == INT_MAX)
+            return true;
+        else
+        {
+            convert_event_prop(tmp_prop, tmp_array);
+            if (tmp_array[0] != archive_rel_change[0] || tmp_array[1] != archive_rel_change[1])
+                return true;
+        }
+    }
 
 //
 // archive abs_change
 //
 
-	tmp_prop = conf.event_prop.arch_event.abs_change;
-	if (tmp_prop == AlrmValueNotSpec)
-	{
-		if (archive_abs_change[0] != INT_MAX || archive_abs_change[1] != INT_MAX)
-			return true;
-	}
-	else
-	{
-		if (archive_abs_change[0] == INT_MAX && archive_abs_change[1] == INT_MAX)
-			return true;
-		else
-		{
-			convert_event_prop(tmp_prop,tmp_array);
-			if (tmp_array[0] != archive_abs_change[0] || tmp_array[1] != archive_abs_change[1])
-				return true;
-		}
-	}
+    tmp_prop = conf.event_prop.arch_event.abs_change;
+    if (tmp_prop == AlrmValueNotSpec)
+    {
+        if (archive_abs_change[0] != INT_MAX || archive_abs_change[1] != INT_MAX)
+            return true;
+    }
+    else
+    {
+        if (archive_abs_change[0] == INT_MAX && archive_abs_change[1] == INT_MAX)
+            return true;
+        else
+        {
+            convert_event_prop(tmp_prop, tmp_array);
+            if (tmp_array[0] != archive_abs_change[0] || tmp_array[1] != archive_abs_change[1])
+                return true;
+        }
+    }
 
 //
 // event period
 //
 
-	tmp_prop = conf.event_prop.per_event.period;
-	if (tmp_prop == AlrmValueNotSpec)
-	{
-		if (event_period != DEFAULT_EVENT_PERIOD)
-			return true;
-	}
-	else
-	{
-		stringstream ss;
-		int tmp_per;
+    tmp_prop = conf.event_prop.per_event.period;
+    if (tmp_prop == AlrmValueNotSpec)
+    {
+        if (event_period != DEFAULT_EVENT_PERIOD)
+            return true;
+    }
+    else
+    {
+        stringstream ss;
+        int tmp_per;
 
-		ss << tmp_prop;
-		ss >> tmp_per;
+        ss << tmp_prop;
+        ss >> tmp_per;
 
-		if (tmp_per != event_period)
-			return true;
-	}
+        if (tmp_per != event_period)
+            return true;
+    }
 
 //
 // archive event period
 //
 
-	tmp_prop = conf.event_prop.arch_event.period;
-	if (tmp_prop == AlrmValueNotSpec)
-	{
-		if (archive_period != INT_MAX)
-			return true;
-	}
-	else
-	{
-		stringstream ss;
-		int tmp_per;
+    tmp_prop = conf.event_prop.arch_event.period;
+    if (tmp_prop == AlrmValueNotSpec)
+    {
+        if (archive_period != INT_MAX)
+            return true;
+    }
+    else
+    {
+        stringstream ss;
+        int tmp_per;
 
-		ss << tmp_prop;
-		ss >> tmp_per;
+        ss << tmp_prop;
+        ss >> tmp_per;
 
-		if  (tmp_per != archive_period)
-			return true;
-	}
+        if (tmp_per != archive_period)
+            return true;
+    }
 
-	return false;
+    return false;
 }
 
 } // End of Tango namespace

--- a/cppapi/server/w_attribute.cpp
+++ b/cppapi/server/w_attribute.cpp
@@ -3019,7 +3019,7 @@ bool WAttribute::check_rds_alarm()
                         if (Tango_isnan(float_array_val[0]) || Tango_isnan(tmp_fl[0]))
                         {
                             // send an alarm if only read or set value are NAN
-                            if (!(Tango_isnan(float_array_val[0]) && Tango_isnan(tmp_fl[0])))
+                            if (not(Tango_isnan(float_array_val[0]) && Tango_isnan(tmp_fl[0])))
                             {
                                 quality = Tango::ATTR_ALARM;
                                 alarm.set(rds);

--- a/cppapi/server/w_attribute.cpp
+++ b/cppapi/server/w_attribute.cpp
@@ -76,85 +76,85 @@ namespace Tango
 
 
 WAttribute::WAttribute(vector<AttrProperty> &prop_list,
-		       Attr &tmp_attr,string &dev_name,long idx)
-:Attribute(prop_list,tmp_attr,dev_name,idx),
-long_ptr(NULL),double_ptr(NULL),str_ptr(NULL),float_ptr(NULL),
-boolean_ptr(NULL),ushort_ptr(NULL),uchar_ptr(NULL),encoded_ptr(NULL),
-string_allocated(false),memorized(false),memorized_init(false),w_ext(new WAttributeExt),
-long64_ptr(NULL),ulong_ptr(NULL),ulong64_ptr(NULL),state_ptr(NULL),uswv(false),mem_write_failed(false)
+                       Attr &tmp_attr, string &dev_name, long idx)
+    : Attribute(prop_list, tmp_attr, dev_name, idx),
+      long_ptr(NULL), double_ptr(NULL), str_ptr(NULL), float_ptr(NULL),
+      boolean_ptr(NULL), ushort_ptr(NULL), uchar_ptr(NULL), encoded_ptr(NULL),
+      string_allocated(false), memorized(false), memorized_init(false), w_ext(new WAttributeExt),
+      long64_ptr(NULL), ulong_ptr(NULL), ulong64_ptr(NULL), state_ptr(NULL), uswv(false), mem_write_failed(false)
 {
 
 //
 // Init some data
 //
 
-	short_val = old_short_val = 0;
-	long_val = old_long_val = 0;
-	double_val = old_double_val = 0.0;
-	float_val = old_float_val = 0.0;
-	boolean_val = old_boolean_val = true;
-	ushort_val = old_ushort_val = 0;
-	uchar_val = old_uchar_val = 0;
-	long64_val = old_long64_val = 0;
-	ulong_val = old_ulong_val = 0;
-	ulong64_val = old_ulong64_val = 0;
-	dev_state_val = old_dev_state_val = Tango::UNKNOWN;
-	str_val = CORBA::string_dup("Not initialised");
-	old_str_val = CORBA::string_dup("Not initialised");
-	encoded_val.encoded_data.length(0);
-	encoded_val.encoded_format = CORBA::string_dup("Not initialised");
-	old_encoded_val.encoded_data.length(0);
-	old_encoded_val.encoded_format = CORBA::string_dup("Not initialised");
+    short_val = old_short_val = 0;
+    long_val = old_long_val = 0;
+    double_val = old_double_val = 0.0;
+    float_val = old_float_val = 0.0;
+    boolean_val = old_boolean_val = true;
+    ushort_val = old_ushort_val = 0;
+    uchar_val = old_uchar_val = 0;
+    long64_val = old_long64_val = 0;
+    ulong_val = old_ulong_val = 0;
+    ulong64_val = old_ulong64_val = 0;
+    dev_state_val = old_dev_state_val = Tango::UNKNOWN;
+    str_val = CORBA::string_dup("Not initialised");
+    old_str_val = CORBA::string_dup("Not initialised");
+    encoded_val.encoded_data.length(0);
+    encoded_val.encoded_format = CORBA::string_dup("Not initialised");
+    old_encoded_val.encoded_data.length(0);
+    old_encoded_val.encoded_format = CORBA::string_dup("Not initialised");
 
-	short_array_val.length(1);
-	short_array_val[0] = 0;
-	long_array_val.length(1);
-	long_array_val[0] = 0;
-	double_array_val.length(1);
-	double_array_val[0] = 0.0;
-	str_array_val.length(1);
-	str_array_val[0] = CORBA::string_dup("Not initialised");
-	float_array_val.length(1);
-	float_array_val[0] = 0.0;
-	boolean_array_val.length(1);
-	boolean_array_val[0] = true;
-	ushort_array_val.length(1);
-	ushort_array_val[0] = 0;
-	uchar_array_val.length(1);
-	uchar_array_val[0] = 0;
-	long64_array_val.length(1);
-	long64_array_val[0] = 0;
-	ulong_array_val.length(1);
-	ulong_array_val[0] = 0;
-	ulong64_array_val.length(1);
-	ulong64_array_val[0] = 0;
-	state_array_val.length(1);
-	state_array_val[0] = Tango::UNKNOWN;
+    short_array_val.length(1);
+    short_array_val[0] = 0;
+    long_array_val.length(1);
+    long_array_val[0] = 0;
+    double_array_val.length(1);
+    double_array_val[0] = 0.0;
+    str_array_val.length(1);
+    str_array_val[0] = CORBA::string_dup("Not initialised");
+    float_array_val.length(1);
+    float_array_val[0] = 0.0;
+    boolean_array_val.length(1);
+    boolean_array_val[0] = true;
+    ushort_array_val.length(1);
+    ushort_array_val[0] = 0;
+    uchar_array_val.length(1);
+    uchar_array_val[0] = 0;
+    long64_array_val.length(1);
+    long64_array_val[0] = 0;
+    ulong_array_val.length(1);
+    ulong_array_val[0] = 0;
+    ulong64_array_val.length(1);
+    ulong64_array_val[0] = 0;
+    state_array_val.length(1);
+    state_array_val[0] = Tango::UNKNOWN;
 
 
-	short_ptr = &short_val;
-	w_dim_x = 1;
-	w_dim_y = 0;
-	write_date.tv_sec = write_date.tv_usec = 0;
+    short_ptr = &short_val;
+    w_dim_x = 1;
+    w_dim_y = 0;
+    write_date.tv_sec = write_date.tv_usec = 0;
 
 //
 // Init memorized field and eventually get the memorized value
 //
 
-	set_memorized(tmp_attr.get_memorized());
-	set_memorized_init(tmp_attr.get_memorized_init());
+    set_memorized(tmp_attr.get_memorized());
+    set_memorized_init(tmp_attr.get_memorized_init());
 
-	if (is_memorized() == true)
-	{
-		try
-		{
-			mem_value = get_attr_value(prop_list,MemAttrPropName);
-		}
-		catch (Tango::DevFailed &)
-		{
-			mem_value = MemNotUsed;
-		}
-	}
+    if (is_memorized() == true)
+    {
+        try
+        {
+            mem_value = get_attr_value(prop_list, MemAttrPropName);
+        }
+        catch (Tango::DevFailed &)
+        {
+            mem_value = MemNotUsed;
+        }
+    }
 }
 
 //+-------------------------------------------------------------------------
@@ -168,10 +168,10 @@ long64_ptr(NULL),ulong_ptr(NULL),ulong64_ptr(NULL),state_ptr(NULL),uswv(false),m
 WAttribute::~WAttribute()
 {
 #ifndef HAS_UNIQUE_PTR
-	delete w_ext;
+    delete w_ext;
 #endif
-	CORBA::string_free(str_val);
-	CORBA::string_free(old_str_val);
+    CORBA::string_free(str_val);
+    CORBA::string_free(old_str_val);
 //	CORBA::string_free(encoded_val.encoded_format);
 //	CORBA::string_free(old_encoded_val.encoded_format);
 }
@@ -191,97 +191,97 @@ WAttribute::~WAttribute()
 
 void WAttribute::set_rvalue()
 {
-	switch(data_type)
-	{
-	case Tango::DEV_SHORT:
-	case Tango::DEV_ENUM:
-		if (data_format == Tango::SCALAR)
-			set_value(&short_val,1,0,false);
-		else
-			set_value(const_cast<DevShort *>(short_array_val.get_buffer()),w_dim_x,w_dim_y,false);
-		break;
+    switch (data_type)
+    {
+        case Tango::DEV_SHORT:
+        case Tango::DEV_ENUM:
+            if (data_format == Tango::SCALAR)
+                set_value(&short_val, 1, 0, false);
+            else
+                set_value(const_cast<DevShort *>(short_array_val.get_buffer()), w_dim_x, w_dim_y, false);
+            break;
 
-	case Tango::DEV_LONG:
-		if (data_format == Tango::SCALAR)
-			set_value(&long_val,1,0,false);
-		else
-			set_value(const_cast<DevLong *>(long_array_val.get_buffer()),w_dim_x,w_dim_y,false);
-		break;
+        case Tango::DEV_LONG:
+            if (data_format == Tango::SCALAR)
+                set_value(&long_val, 1, 0, false);
+            else
+                set_value(const_cast<DevLong *>(long_array_val.get_buffer()), w_dim_x, w_dim_y, false);
+            break;
 
-	case Tango::DEV_LONG64:
-		if (data_format == Tango::SCALAR)
-			set_value(&long64_val,1,0,false);
-		else
-			set_value(const_cast<DevLong64 *>(long64_array_val.get_buffer()),w_dim_x,w_dim_y,false);
-		break;
+        case Tango::DEV_LONG64:
+            if (data_format == Tango::SCALAR)
+                set_value(&long64_val, 1, 0, false);
+            else
+                set_value(const_cast<DevLong64 *>(long64_array_val.get_buffer()), w_dim_x, w_dim_y, false);
+            break;
 
-	case Tango::DEV_DOUBLE:
-		if (data_format == Tango::SCALAR)
-			set_value(&double_val,1,0,false);
-		else
-			set_value(const_cast<DevDouble *>(double_array_val.get_buffer()),w_dim_x,w_dim_y,false);
-		break;
+        case Tango::DEV_DOUBLE:
+            if (data_format == Tango::SCALAR)
+                set_value(&double_val, 1, 0, false);
+            else
+                set_value(const_cast<DevDouble *>(double_array_val.get_buffer()), w_dim_x, w_dim_y, false);
+            break;
 
-	case Tango::DEV_STRING:
-		if (data_format == Tango::SCALAR)
-			set_value(&str_val,1,0,false);
-		else
-			set_value(const_cast<DevString *>(str_array_val.get_buffer()),w_dim_x,w_dim_y,false);
-		break;
+        case Tango::DEV_STRING:
+            if (data_format == Tango::SCALAR)
+                set_value(&str_val, 1, 0, false);
+            else
+                set_value(const_cast<DevString *>(str_array_val.get_buffer()), w_dim_x, w_dim_y, false);
+            break;
 
-	case Tango::DEV_FLOAT:
-		if (data_format == Tango::SCALAR)
-			set_value(&float_val,1,0,false);
-		else
-			set_value(const_cast<DevFloat *>(float_array_val.get_buffer()),w_dim_x,w_dim_y,false);
-		break;
+        case Tango::DEV_FLOAT:
+            if (data_format == Tango::SCALAR)
+                set_value(&float_val, 1, 0, false);
+            else
+                set_value(const_cast<DevFloat *>(float_array_val.get_buffer()), w_dim_x, w_dim_y, false);
+            break;
 
-	case Tango::DEV_BOOLEAN:
-		if (data_format == Tango::SCALAR)
-			set_value(&boolean_val,1,0,false);
-		else
-			set_value(const_cast<DevBoolean *>(boolean_array_val.get_buffer()),w_dim_x,w_dim_y,false);
-		break;
+        case Tango::DEV_BOOLEAN:
+            if (data_format == Tango::SCALAR)
+                set_value(&boolean_val, 1, 0, false);
+            else
+                set_value(const_cast<DevBoolean *>(boolean_array_val.get_buffer()), w_dim_x, w_dim_y, false);
+            break;
 
-	case Tango::DEV_USHORT:
-		if (data_format == Tango::SCALAR)
-			set_value(&ushort_val,1,0,false);
-		else
-			set_value(const_cast<DevUShort *>(ushort_array_val.get_buffer()),w_dim_x,w_dim_y,false);
-		break;
+        case Tango::DEV_USHORT:
+            if (data_format == Tango::SCALAR)
+                set_value(&ushort_val, 1, 0, false);
+            else
+                set_value(const_cast<DevUShort *>(ushort_array_val.get_buffer()), w_dim_x, w_dim_y, false);
+            break;
 
-	case Tango::DEV_UCHAR:
-		if (data_format == Tango::SCALAR)
-			set_value(&uchar_val,1,0,false);
-		else
-			set_value(const_cast<DevUChar *>(uchar_array_val.get_buffer()),w_dim_x,w_dim_y,false);
-		break;
+        case Tango::DEV_UCHAR:
+            if (data_format == Tango::SCALAR)
+                set_value(&uchar_val, 1, 0, false);
+            else
+                set_value(const_cast<DevUChar *>(uchar_array_val.get_buffer()), w_dim_x, w_dim_y, false);
+            break;
 
-	case Tango::DEV_ULONG:
-		if (data_format == Tango::SCALAR)
-			set_value(&ulong_val,1,0,false);
-		else
-			set_value(const_cast<DevULong *>(ulong_array_val.get_buffer()),w_dim_x,w_dim_y,false);
-		break;
+        case Tango::DEV_ULONG:
+            if (data_format == Tango::SCALAR)
+                set_value(&ulong_val, 1, 0, false);
+            else
+                set_value(const_cast<DevULong *>(ulong_array_val.get_buffer()), w_dim_x, w_dim_y, false);
+            break;
 
-	case Tango::DEV_ULONG64:
-		if (data_format == Tango::SCALAR)
-			set_value(&ulong64_val,1,0,false);
-		else
-			set_value(const_cast<DevULong64 *>(ulong64_array_val.get_buffer()),w_dim_x,w_dim_y,false);
-		break;
+        case Tango::DEV_ULONG64:
+            if (data_format == Tango::SCALAR)
+                set_value(&ulong64_val, 1, 0, false);
+            else
+                set_value(const_cast<DevULong64 *>(ulong64_array_val.get_buffer()), w_dim_x, w_dim_y, false);
+            break;
 
-	case Tango::DEV_STATE:
-		if (data_format == Tango::SCALAR)
-			set_value(&dev_state_val,1,0,false);
-		else
-			set_value(const_cast<DevState *>(state_array_val.get_buffer()),w_dim_x,w_dim_y,false);
-		break;
+        case Tango::DEV_STATE:
+            if (data_format == Tango::SCALAR)
+                set_value(&dev_state_val, 1, 0, false);
+            else
+                set_value(const_cast<DevState *>(state_array_val.get_buffer()), w_dim_x, w_dim_y, false);
+            break;
 
-	case Tango::DEV_ENCODED:
-		set_value(&encoded_val,1,0,false);
-		break;
-	}
+        case Tango::DEV_ENCODED:
+            set_value(&encoded_val, 1, 0, false);
+            break;
+    }
 }
 
 //+-------------------------------------------------------------------------
@@ -295,10 +295,10 @@ void WAttribute::set_rvalue()
 //
 //--------------------------------------------------------------------------
 
-void WAttribute::check_written_value(const CORBA::Any &any,unsigned long x,unsigned long y)
+void WAttribute::check_written_value(const CORBA::Any &any, unsigned long x, unsigned long y)
 {
-	CORBA::ULong nb_data;
-	unsigned long i;
+    CORBA::ULong nb_data;
+    unsigned long i;
 
 //
 // If the server is in its starting phase, gives a NULL ptr
@@ -310,839 +310,851 @@ void WAttribute::check_written_value(const CORBA::Any &any,unsigned long x,unsig
     if (tg->is_svr_starting() == false && tg->is_device_restarting(d_name) == false)
         mon_ptr = &(get_att_device()->get_att_conf_monitor());
 
-	switch (data_type)
-	{
-	case Tango::DEV_SHORT :
-	case Tango::DEV_ENUM :
+    switch (data_type)
+    {
+        case Tango::DEV_SHORT :
+        case Tango::DEV_ENUM :
         {
 
 //
 // Check data type inside the any and data number
 //
 
-		const Tango::DevVarShortArray *sh_ptr;
-		if ((any >>= sh_ptr) == false)
-		{
-			TangoSys_OMemStream o;
+            const Tango::DevVarShortArray *sh_ptr;
+            if ((any >>= sh_ptr) == false)
+            {
+                TangoSys_OMemStream o;
 
-			o << "Incompatible attribute type, expected type is : Tango::DevVarShortArray (even for single value)" << ends;
-			Except::throw_exception((const char *)API_IncompatibleAttrDataType,
-					      o.str(),
-					      (const char *)"WAttribute::check_written_value()");
-		}
-		nb_data = sh_ptr->length();
-		check_length(nb_data,x,y);
+                o << "Incompatible attribute type, expected type is : Tango::DevVarShortArray (even for single value)"
+                  << ends;
+                Except::throw_exception((const char *) API_IncompatibleAttrDataType,
+                                        o.str(),
+                                        (const char *) "WAttribute::check_written_value()");
+            }
+            nb_data = sh_ptr->length();
+            check_length(nb_data, x, y);
 
 //
 // Check the incoming value against min or max_value if needed
 //
 
-        {
-            AutoTangoMonitor sync1(mon_ptr);
-            if (check_min_value == true)
             {
-                for (i = 0;i < nb_data;i++)
+                AutoTangoMonitor sync1(mon_ptr);
+                if (check_min_value == true)
                 {
-                    if ((*sh_ptr)[i] < min_value.sh)
+                    for (i = 0; i < nb_data; i++)
                     {
-                        TangoSys_OMemStream o;
+                        if ((*sh_ptr)[i] < min_value.sh)
+                        {
+                            TangoSys_OMemStream o;
 
-                        o << "Set value for attribute " << name;
-                        o << " is below the minimum authorized (at least element " << i << ")" << ends;
-                        Except::throw_exception((const char *)API_WAttrOutsideLimit,
-                                    o.str(),
-                                    (const char *)"WAttribute::check_written_value()");
+                            o << "Set value for attribute " << name;
+                            o << " is below the minimum authorized (at least element " << i << ")" << ends;
+                            Except::throw_exception((const char *) API_WAttrOutsideLimit,
+                                                    o.str(),
+                                                    (const char *) "WAttribute::check_written_value()");
+                        }
+                    }
+                }
+                if (check_max_value == true)
+                {
+                    for (i = 0; i < nb_data; i++)
+                    {
+                        if ((*sh_ptr)[i] > max_value.sh)
+                        {
+                            TangoSys_OMemStream o;
+
+                            o << "Set value for attribute " << name;
+                            o << " is above the maximum authorized (at least element " << i << ")" << ends;
+                            Except::throw_exception((const char *) API_WAttrOutsideLimit,
+                                                    o.str(),
+                                                    (const char *) "WAttribute::check_written_value()");
+                        }
                     }
                 }
             }
-            if (check_max_value == true)
-            {
-                for (i = 0;i < nb_data;i++)
-                {
-                    if ((*sh_ptr)[i] > max_value.sh)
-                    {
-                        TangoSys_OMemStream o;
 
-                        o << "Set value for attribute " << name;
-                        o << " is above the maximum authorized (at least element " << i << ")" << ends;
-                        Except::throw_exception((const char *)API_WAttrOutsideLimit,
-                                     o.str(),
-                                    (const char *)"WAttribute::check_written_value()");
-                    }
-                }
+            short_ptr = sh_ptr->get_buffer();
+            if (data_format == Tango::SCALAR)
+            {
+                old_short_val = short_val;
+                short_val = (*sh_ptr)[0];
+                w_dim_x = 1;
+                w_dim_y = 0;
+            }
+            else
+            {
+                w_dim_x = x;
+                w_dim_y = y;
             }
         }
+            break;
 
-		short_ptr = sh_ptr->get_buffer();
-		if (data_format == Tango::SCALAR)
-		{
-			old_short_val = short_val;
-			short_val = (*sh_ptr)[0];
-			w_dim_x = 1;
-			w_dim_y = 0;
-		}
-		else
-		{
-			w_dim_x = x;
-			w_dim_y = y;
-		}
-        }
-		break;
-
-	case Tango::DEV_LONG :
+        case Tango::DEV_LONG :
         {
 
 //
 // Check data type inside the any
 //
 
-		const Tango::DevVarLongArray *lg_ptr;
-		if ((any >>= lg_ptr) == false)
-		{
-			TangoSys_OMemStream o;
+            const Tango::DevVarLongArray *lg_ptr;
+            if ((any >>= lg_ptr) == false)
+            {
+                TangoSys_OMemStream o;
 
-			o << "Incompatible attribute type, expected type is : Tango::DevVarLongArray (even for single value)" << ends;
-			Except::throw_exception((const char *)API_IncompatibleAttrDataType,
-					      o.str(),
-					      (const char *)"WAttribute::check_written_value()");
-		}
-		nb_data = lg_ptr->length();
-		check_length(nb_data,x,y);
+                o << "Incompatible attribute type, expected type is : Tango::DevVarLongArray (even for single value)"
+                  << ends;
+                Except::throw_exception((const char *) API_IncompatibleAttrDataType,
+                                        o.str(),
+                                        (const char *) "WAttribute::check_written_value()");
+            }
+            nb_data = lg_ptr->length();
+            check_length(nb_data, x, y);
 
 //
 // Check the incoming value
 //
 
-        {
-            AutoTangoMonitor sync1(mon_ptr);
-            if (check_min_value == true)
             {
-                for (i = 0;i < nb_data;i++)
+                AutoTangoMonitor sync1(mon_ptr);
+                if (check_min_value == true)
                 {
-                    if ((*lg_ptr)[i] < min_value.lg)
+                    for (i = 0; i < nb_data; i++)
                     {
-                        TangoSys_OMemStream o;
+                        if ((*lg_ptr)[i] < min_value.lg)
+                        {
+                            TangoSys_OMemStream o;
 
-                        o << "Set value for attribute " << name;
-                        o << " is below the minimum authorized (at least element " << i << ")" << ends;
-                        Except::throw_exception((const char *)API_WAttrOutsideLimit,
-                                  o.str(),
-                                  (const char *)"WAttribute::check_written_value()");
+                            o << "Set value for attribute " << name;
+                            o << " is below the minimum authorized (at least element " << i << ")" << ends;
+                            Except::throw_exception((const char *) API_WAttrOutsideLimit,
+                                                    o.str(),
+                                                    (const char *) "WAttribute::check_written_value()");
+                        }
+                    }
+                }
+                if (check_max_value == true)
+                {
+                    for (i = 0; i < nb_data; i++)
+                    {
+                        if ((*lg_ptr)[i] > max_value.lg)
+                        {
+                            TangoSys_OMemStream o;
+
+                            o << "Set value for attribute " << name;
+                            o << " is above the maximum authorized (at least element " << i << ")" << ends;
+                            Except::throw_exception((const char *) API_WAttrOutsideLimit,
+                                                    o.str(),
+                                                    (const char *) "WAttribute::check_written_value()");
+                        }
                     }
                 }
             }
-            if (check_max_value == true)
-            {
-                for (i = 0;i < nb_data;i++)
-                {
-                    if ((*lg_ptr)[i] > max_value.lg)
-                    {
-                        TangoSys_OMemStream o;
 
-                        o << "Set value for attribute " << name;
-                        o << " is above the maximum authorized (at least element " << i << ")" << ends;
-                        Except::throw_exception((const char *)API_WAttrOutsideLimit,
-                                  o.str(),
-                                  (const char *)"WAttribute::check_written_value()");
-                    }
-                }
+            long_ptr = lg_ptr->get_buffer();
+            if (data_format == Tango::SCALAR)
+            {
+                old_long_val = long_val;
+                long_val = (*lg_ptr)[0];
+                w_dim_x = 1;
+                w_dim_y = 0;
+            }
+            else
+            {
+                w_dim_x = x;
+                w_dim_y = y;
             }
         }
-
-		long_ptr = lg_ptr->get_buffer();
-		if (data_format == Tango::SCALAR)
-		{
-			old_long_val = long_val;
-			long_val = (*lg_ptr)[0];
-			w_dim_x = 1;
-			w_dim_y = 0;
-		}
-		else
-		{
-			w_dim_x = x;
-			w_dim_y = y;
-		}
-        }
-		break;
+            break;
 
 
-	case Tango::DEV_LONG64 :
+        case Tango::DEV_LONG64 :
         {
 
 //
 // Check data type inside the any
 //
 
-		const Tango::DevVarLong64Array *lg64_ptr;
-		if ((any >>= lg64_ptr) == false)
-		{
-			TangoSys_OMemStream o;
+            const Tango::DevVarLong64Array *lg64_ptr;
+            if ((any >>= lg64_ptr) == false)
+            {
+                TangoSys_OMemStream o;
 
-			o << "Incompatible attribute type, expected type is : Tango::DevVarLong64Array (even for single value)" << ends;
-			Except::throw_exception((const char *)API_IncompatibleAttrDataType,
-					      o.str(),
-					      (const char *)"WAttribute::check_written_value()");
-		}
-		nb_data = lg64_ptr->length();
-		check_length(nb_data,x,y);
+                o << "Incompatible attribute type, expected type is : Tango::DevVarLong64Array (even for single value)"
+                  << ends;
+                Except::throw_exception((const char *) API_IncompatibleAttrDataType,
+                                        o.str(),
+                                        (const char *) "WAttribute::check_written_value()");
+            }
+            nb_data = lg64_ptr->length();
+            check_length(nb_data, x, y);
 
 //
 // Check the incoming value
 //
 
-        {
-            AutoTangoMonitor sync1(mon_ptr);
-            if (check_min_value == true)
             {
-                for (i = 0;i < nb_data;i++)
+                AutoTangoMonitor sync1(mon_ptr);
+                if (check_min_value == true)
                 {
-                    if ((*lg64_ptr)[i] < min_value.lg64)
+                    for (i = 0; i < nb_data; i++)
                     {
-                        TangoSys_OMemStream o;
+                        if ((*lg64_ptr)[i] < min_value.lg64)
+                        {
+                            TangoSys_OMemStream o;
 
-                        o << "Set value for attribute " << name;
-                        o << " is below the minimum authorized (at least element " << i << ")" << ends;
-                        Except::throw_exception((const char *)API_WAttrOutsideLimit,
-                                  o.str(),
-                                  (const char *)"WAttribute::check_written_value()");
+                            o << "Set value for attribute " << name;
+                            o << " is below the minimum authorized (at least element " << i << ")" << ends;
+                            Except::throw_exception((const char *) API_WAttrOutsideLimit,
+                                                    o.str(),
+                                                    (const char *) "WAttribute::check_written_value()");
+                        }
+                    }
+                }
+                if (check_max_value == true)
+                {
+                    for (i = 0; i < nb_data; i++)
+                    {
+                        if ((*lg64_ptr)[i] > max_value.lg64)
+                        {
+                            TangoSys_OMemStream o;
+
+                            o << "Set value for attribute " << name;
+                            o << " is above the maximum authorized (at least element " << i << ")" << ends;
+                            Except::throw_exception((const char *) API_WAttrOutsideLimit,
+                                                    o.str(),
+                                                    (const char *) "WAttribute::check_written_value()");
+                        }
                     }
                 }
             }
-            if (check_max_value == true)
-            {
-                for (i = 0;i < nb_data;i++)
-                {
-                    if ((*lg64_ptr)[i] > max_value.lg64)
-                    {
-                        TangoSys_OMemStream o;
 
-                        o << "Set value for attribute " << name;
-                        o << " is above the maximum authorized (at least element " << i << ")" << ends;
-                        Except::throw_exception((const char *)API_WAttrOutsideLimit,
-                                  o.str(),
-                                  (const char *)"WAttribute::check_written_value()");
-                    }
-                }
+            long64_ptr = lg64_ptr->get_buffer();
+            if (data_format == Tango::SCALAR)
+            {
+                old_long64_val = long64_val;
+                long64_val = (*lg64_ptr)[0];
+                w_dim_x = 1;
+                w_dim_y = 0;
+            }
+            else
+            {
+                w_dim_x = x;
+                w_dim_y = y;
             }
         }
+            break;
 
-		long64_ptr = lg64_ptr->get_buffer();
-		if (data_format == Tango::SCALAR)
-		{
-			old_long64_val = long64_val;
-			long64_val = (*lg64_ptr)[0];
-			w_dim_x = 1;
-			w_dim_y = 0;
-		}
-		else
-		{
-			w_dim_x = x;
-			w_dim_y = y;
-		}
-        }
-		break;
-
-	case Tango::DEV_DOUBLE :
+        case Tango::DEV_DOUBLE :
         {
 
 //
 // Check data type inside the any
 //
 
-		const Tango::DevVarDoubleArray *db_ptr;
-		if ((any >>= db_ptr) == false)
-		{
-			TangoSys_OMemStream o;
+            const Tango::DevVarDoubleArray *db_ptr;
+            if ((any >>= db_ptr) == false)
+            {
+                TangoSys_OMemStream o;
 
-			o << "Incompatible attribute type, expected type is : Tango::DevVarDoubleArray (even for single value)" << ends;
-			Except::throw_exception((const char *)API_IncompatibleAttrDataType,
-					      o.str(),
-					      (const char *)"WAttribute::check_written_value()");
-		}
-		nb_data = db_ptr->length();
-		check_length(nb_data,x,y);
+                o << "Incompatible attribute type, expected type is : Tango::DevVarDoubleArray (even for single value)"
+                  << ends;
+                Except::throw_exception((const char *) API_IncompatibleAttrDataType,
+                                        o.str(),
+                                        (const char *) "WAttribute::check_written_value()");
+            }
+            nb_data = db_ptr->length();
+            check_length(nb_data, x, y);
 
 //
 // Check the incoming value
 // First check for NaN, INF
 //
 
-        {
-            AutoTangoMonitor sync1(mon_ptr);
-            for (i = 0;i < nb_data;i++)
             {
-                if (tg->is_wattr_nan_allowed() == false)
+                AutoTangoMonitor sync1(mon_ptr);
+                for (i = 0; i < nb_data; i++)
                 {
+                    if (tg->is_wattr_nan_allowed() == false)
+                    {
 #ifdef _TG_WINDOWS_
-                    if (_finite((*db_ptr)[i]) == 0)
+                        if (_finite((*db_ptr)[i]) == 0)
 #else
-                    if (isfinite((*db_ptr)[i]) == 0)
+                        if (isfinite((*db_ptr)[i]) == 0)
 #endif
-                    {
-                        TangoSys_OMemStream o;
+                        {
+                            TangoSys_OMemStream o;
 
-                        o << "Set value for attribute " << name;
-                        o << " is a NaN or INF value (at least element " << i << ")" << ends;
-                        Except::throw_exception((const char *)API_WAttrOutsideLimit,
-                                  o.str(),
-                                  (const char *)"WAttribute::check_written_value()");
+                            o << "Set value for attribute " << name;
+                            o << " is a NaN or INF value (at least element " << i << ")" << ends;
+                            Except::throw_exception((const char *) API_WAttrOutsideLimit,
+                                                    o.str(),
+                                                    (const char *) "WAttribute::check_written_value()");
+                        }
                     }
-                }
 
-                if (check_min_value == true)
-                {
-                    if ((*db_ptr)[i] < min_value.db)
+                    if (check_min_value == true)
                     {
-                        TangoSys_OMemStream o;
+                        if ((*db_ptr)[i] < min_value.db)
+                        {
+                            TangoSys_OMemStream o;
 
-                        o << "Set value for attribute " << name;
-                        o << " is below the minimum authorized (at least element " << i << ")" << ends;
-                        Except::throw_exception((const char *)API_WAttrOutsideLimit,
-                                  o.str(),
-                                  (const char *)"WAttribute::check_written_value()");
+                            o << "Set value for attribute " << name;
+                            o << " is below the minimum authorized (at least element " << i << ")" << ends;
+                            Except::throw_exception((const char *) API_WAttrOutsideLimit,
+                                                    o.str(),
+                                                    (const char *) "WAttribute::check_written_value()");
+                        }
                     }
-                }
 
-                if (check_max_value == true)
-                {
-                    if ((*db_ptr)[i] > max_value.db)
+                    if (check_max_value == true)
                     {
-                        TangoSys_OMemStream o;
+                        if ((*db_ptr)[i] > max_value.db)
+                        {
+                            TangoSys_OMemStream o;
 
-                        o << "Set value for attribute " << name;
-                        o << " is above the maximum authorized (at least element " << i << ")" << ends;
-                        Except::throw_exception((const char *)API_WAttrOutsideLimit,
-                                  o.str(),
-                                  (const char *)"WAttribute::check_written_value()");
+                            o << "Set value for attribute " << name;
+                            o << " is above the maximum authorized (at least element " << i << ")" << ends;
+                            Except::throw_exception((const char *) API_WAttrOutsideLimit,
+                                                    o.str(),
+                                                    (const char *) "WAttribute::check_written_value()");
+                        }
                     }
                 }
             }
-        }
 
-		double_ptr = db_ptr->get_buffer();
-		if (data_format == Tango::SCALAR)
-		{
-			old_double_val = double_val;
-			double_val = (*db_ptr)[0];
-			w_dim_x = 1;
-			w_dim_y = 0;
-		}
-		else
-		{
-			w_dim_x = x;
-			w_dim_y = y;
-		}
+            double_ptr = db_ptr->get_buffer();
+            if (data_format == Tango::SCALAR)
+            {
+                old_double_val = double_val;
+                double_val = (*db_ptr)[0];
+                w_dim_x = 1;
+                w_dim_y = 0;
+            }
+            else
+            {
+                w_dim_x = x;
+                w_dim_y = y;
+            }
         }
-		break;
+            break;
 
-	case Tango::DEV_STRING :
+        case Tango::DEV_STRING :
 
 //
 // Check data type inside the any
 //
 
-		const Tango::DevVarStringArray *string_ptr;
-		if ((any >>= string_ptr) == false)
-		{
-			TangoSys_OMemStream o;
+            const Tango::DevVarStringArray *string_ptr;
+            if ((any >>= string_ptr) == false)
+            {
+                TangoSys_OMemStream o;
 
-			o << "Incompatible attribute type, expected type is : Tango::DevVarStringArray (even for single value)" << ends;
-			Except::throw_exception((const char *)API_IncompatibleAttrDataType,
-					      o.str(),
-					      (const char *)"WAttribute::check_written_value()");
-		}
-		nb_data = string_ptr->length();
-		check_length(nb_data,x,y);
+                o << "Incompatible attribute type, expected type is : Tango::DevVarStringArray (even for single value)"
+                  << ends;
+                Except::throw_exception((const char *) API_IncompatibleAttrDataType,
+                                        o.str(),
+                                        (const char *) "WAttribute::check_written_value()");
+            }
+            nb_data = string_ptr->length();
+            check_length(nb_data, x, y);
 
-		str_ptr = string_ptr->get_buffer();
+            str_ptr = string_ptr->get_buffer();
 
-		if (data_format == Tango::SCALAR)
-		{
-			CORBA::string_free(old_str_val);
-			old_str_val = CORBA::string_dup(str_val);
-			CORBA::string_free(str_val);
+            if (data_format == Tango::SCALAR)
+            {
+                CORBA::string_free(old_str_val);
+                old_str_val = CORBA::string_dup(str_val);
+                CORBA::string_free(str_val);
 
-			str_val = CORBA::string_dup((*string_ptr)[0]);
-			w_dim_x = 1;
-			w_dim_y = 0;
-		}
-		else
-		{
-			w_dim_x = x;
-			w_dim_y = y;
-		}
-		break;
+                str_val = CORBA::string_dup((*string_ptr)[0]);
+                w_dim_x = 1;
+                w_dim_y = 0;
+            }
+            else
+            {
+                w_dim_x = x;
+                w_dim_y = y;
+            }
+            break;
 
-	case Tango::DEV_FLOAT :
+        case Tango::DEV_FLOAT :
         {
 
 //
 // Check data type inside the any
 //
 
-		const Tango::DevVarFloatArray *fl_ptr;
-		if ((any >>= fl_ptr) == false)
-		{
-			TangoSys_OMemStream o;
+            const Tango::DevVarFloatArray *fl_ptr;
+            if ((any >>= fl_ptr) == false)
+            {
+                TangoSys_OMemStream o;
 
-			o << "Incompatible attribute type, expected type is : Tango::DevVarFloatArray (even for single value)" << ends;
-			Except::throw_exception((const char *)API_IncompatibleAttrDataType,
-					      o.str(),
-					      (const char *)"WAttribute::check_written_value()");
-		}
-		nb_data = fl_ptr->length();
-		check_length(nb_data,x,y);
+                o << "Incompatible attribute type, expected type is : Tango::DevVarFloatArray (even for single value)"
+                  << ends;
+                Except::throw_exception((const char *) API_IncompatibleAttrDataType,
+                                        o.str(),
+                                        (const char *) "WAttribute::check_written_value()");
+            }
+            nb_data = fl_ptr->length();
+            check_length(nb_data, x, y);
 
 //
 // Check the incoming value
 // First check for NaN, INF
 //
 
-        {
-            AutoTangoMonitor sync1(mon_ptr);
-            for (i = 0;i < nb_data;i++)
             {
-                if (tg->is_wattr_nan_allowed() == false)
+                AutoTangoMonitor sync1(mon_ptr);
+                for (i = 0; i < nb_data; i++)
                 {
-#ifdef _TG_WINDOWS_
-                    if (_finite((*fl_ptr)[i]) == 0)
-#else
-                    if (isfinite((*fl_ptr)[i]) == 0)
-#endif
+                    if (tg->is_wattr_nan_allowed() == false)
                     {
-                        TangoSys_OMemStream o;
+#ifdef _TG_WINDOWS_
+                        if (_finite((*fl_ptr)[i]) == 0)
+#else
+                        if (isfinite((*fl_ptr)[i]) == 0)
+#endif
+                        {
+                            TangoSys_OMemStream o;
 
-                        o << "Set value for attribute " << name;
-                        o << " is a NaN or INF value (at least element " << i << ")" << ends;
-                        Except::throw_exception((const char *)API_WAttrOutsideLimit,
-                                  o.str(),
-                                  (const char *)"WAttribute::check_written_value()");
+                            o << "Set value for attribute " << name;
+                            o << " is a NaN or INF value (at least element " << i << ")" << ends;
+                            Except::throw_exception((const char *) API_WAttrOutsideLimit,
+                                                    o.str(),
+                                                    (const char *) "WAttribute::check_written_value()");
+                        }
+                    }
+
+                    if (check_min_value == true)
+                    {
+                        if ((*fl_ptr)[i] < min_value.fl)
+                        {
+                            TangoSys_OMemStream o;
+
+                            o << "Set value for attribute " << name;
+                            o << " is below the minimum authorized (at least element " << i << ")" << ends;
+                            Except::throw_exception((const char *) API_WAttrOutsideLimit,
+                                                    o.str(),
+                                                    (const char *) "WAttribute::check_written_value()");
+                        }
+                    }
+
+                    if (check_max_value == true)
+                    {
+                        if ((*fl_ptr)[i] > max_value.fl)
+                        {
+                            TangoSys_OMemStream o;
+
+                            o << "Set value for attribute " << name;
+                            o << " is above the maximum authorized (at least element " << i << ")" << ends;
+                            Except::throw_exception((const char *) API_WAttrOutsideLimit,
+                                                    o.str(),
+                                                    (const char *) "WAttribute::check_written_value()");
+                        }
                     }
                 }
+            }
 
+            float_ptr = fl_ptr->get_buffer();
+            if (data_format == Tango::SCALAR)
+            {
+                old_float_val = float_val;
+                float_val = (*fl_ptr)[0];
+                w_dim_x = 1;
+                w_dim_y = 0;
+            }
+            else
+            {
+                w_dim_x = x;
+                w_dim_y = y;
+            }
+        }
+            break;
+
+        case Tango::DEV_USHORT :
+        {
+
+//
+// Check data type inside the any
+//
+
+            const Tango::DevVarUShortArray *ush_ptr;
+            if ((any >>= ush_ptr) == false)
+            {
+                TangoSys_OMemStream o;
+
+                o << "Incompatible attribute type, expected type is : Tango::DevVarUShortArray (even for single value)"
+                  << ends;
+                Except::throw_exception((const char *) API_IncompatibleAttrDataType,
+                                        o.str(),
+                                        (const char *) "WAttribute::check_written_value()");
+            }
+            nb_data = ush_ptr->length();
+            check_length(nb_data, x, y);
+
+//
+// Check the incoming value
+//
+
+            {
+                AutoTangoMonitor sync1(mon_ptr);
                 if (check_min_value == true)
                 {
-                    if ((*fl_ptr)[i] < min_value.fl)
+                    for (i = 0; i < nb_data; i++)
                     {
-                        TangoSys_OMemStream o;
+                        if ((*ush_ptr)[i] < min_value.ush)
+                        {
+                            TangoSys_OMemStream o;
 
-                        o << "Set value for attribute " << name;
-                        o << " is below the minimum authorized (at least element " << i << ")" << ends;
-                        Except::throw_exception((const char *)API_WAttrOutsideLimit,
-                                  o.str(),
-                                  (const char *)"WAttribute::check_written_value()");
+                            o << "Set value for attribute " << name;
+                            o << " is below the minimum authorized (at least element " << i << ")" << ends;
+                            Except::throw_exception((const char *) API_WAttrOutsideLimit,
+                                                    o.str(),
+                                                    (const char *) "WAttribute::check_written_value()");
+                        }
                     }
                 }
-
                 if (check_max_value == true)
                 {
-                    if ((*fl_ptr)[i] > max_value.fl)
+                    for (i = 0; i < nb_data; i++)
                     {
-                        TangoSys_OMemStream o;
+                        if ((*ush_ptr)[i] > max_value.ush)
+                        {
+                            TangoSys_OMemStream o;
 
-                        o << "Set value for attribute " << name;
-                        o << " is above the maximum authorized (at least element " << i << ")" << ends;
-                        Except::throw_exception((const char *)API_WAttrOutsideLimit,
-                                  o.str(),
-                                  (const char *)"WAttribute::check_written_value()");
+                            o << "Set value for attribute " << name;
+                            o << " is above the maximum authorized (at least element " << i << ")" << ends;
+                            Except::throw_exception((const char *) API_WAttrOutsideLimit,
+                                                    o.str(),
+                                                    (const char *) "WAttribute::check_written_value()");
+                        }
                     }
                 }
             }
-        }
 
-		float_ptr = fl_ptr->get_buffer();
-		if (data_format == Tango::SCALAR)
-		{
-			old_float_val = float_val;
-			float_val = (*fl_ptr)[0];
-			w_dim_x = 1;
-			w_dim_y = 0;
-		}
-		else
-		{
-			w_dim_x = x;
-			w_dim_y = y;
-		}
+            ushort_ptr = ush_ptr->get_buffer();
+            if (data_format == Tango::SCALAR)
+            {
+                old_ushort_val = ushort_val;
+                ushort_val = (*ush_ptr)[0];
+                w_dim_x = 1;
+                w_dim_y = 0;
+            }
+            else
+            {
+                w_dim_x = x;
+                w_dim_y = y;
+            }
         }
-		break;
+            break;
 
-	case Tango::DEV_USHORT :
+        case Tango::DEV_UCHAR :
         {
 
 //
 // Check data type inside the any
 //
 
-		const Tango::DevVarUShortArray *ush_ptr;
-		if ((any >>= ush_ptr) == false)
-		{
-			TangoSys_OMemStream o;
+            const Tango::DevVarCharArray *uch_ptr;
+            if ((any >>= uch_ptr) == false)
+            {
+                TangoSys_OMemStream o;
 
-			o << "Incompatible attribute type, expected type is : Tango::DevVarUShortArray (even for single value)" << ends;
-			Except::throw_exception((const char *)API_IncompatibleAttrDataType,
-					      o.str(),
-					      (const char *)"WAttribute::check_written_value()");
-		}
-		nb_data = ush_ptr->length();
-		check_length(nb_data,x,y);
+                o << "Incompatible attribute type, expected type is : Tango::DevVarCharArray (even for single value)"
+                  << ends;
+                Except::throw_exception((const char *) API_IncompatibleAttrDataType,
+                                        o.str(),
+                                        (const char *) "WAttribute::check_written_value()");
+            }
+            nb_data = uch_ptr->length();
+            check_length(nb_data, x, y);
 
 //
 // Check the incoming value
 //
 
-        {
-            AutoTangoMonitor sync1(mon_ptr);
-            if (check_min_value == true)
             {
-                for (i = 0;i < nb_data;i++)
+                AutoTangoMonitor sync1(mon_ptr);
+                if (check_min_value == true)
                 {
-                    if ((*ush_ptr)[i] < min_value.ush)
+                    for (i = 0; i < nb_data; i++)
                     {
-                        TangoSys_OMemStream o;
+                        if ((*uch_ptr)[i] < min_value.uch)
+                        {
+                            TangoSys_OMemStream o;
 
-                        o << "Set value for attribute " << name;
-                        o << " is below the minimum authorized (at least element " << i << ")" << ends;
-                        Except::throw_exception((const char *)API_WAttrOutsideLimit,
-                                  o.str(),
-                                  (const char *)"WAttribute::check_written_value()");
+                            o << "Set value for attribute " << name;
+                            o << " is below the minimum authorized (at least element " << i << ")" << ends;
+                            Except::throw_exception((const char *) API_WAttrOutsideLimit,
+                                                    o.str(),
+                                                    (const char *) "WAttribute::check_written_value()");
+                        }
+                    }
+                }
+                if (check_max_value == true)
+                {
+                    for (i = 0; i < nb_data; i++)
+                    {
+                        if ((*uch_ptr)[i] > max_value.uch)
+                        {
+                            TangoSys_OMemStream o;
+
+                            o << "Set value for attribute " << name;
+                            o << " is above the maximum authorized (at least element " << i << ")" << ends;
+                            Except::throw_exception((const char *) API_WAttrOutsideLimit,
+                                                    o.str(),
+                                                    (const char *) "WAttribute::check_written_value()");
+                        }
                     }
                 }
             }
-            if (check_max_value == true)
-            {
-                for (i = 0;i < nb_data;i++)
-                {
-                    if ((*ush_ptr)[i] > max_value.ush)
-                    {
-                        TangoSys_OMemStream o;
 
-                        o << "Set value for attribute " << name;
-                        o << " is above the maximum authorized (at least element " << i << ")" << ends;
-                        Except::throw_exception((const char *)API_WAttrOutsideLimit,
-                                  o.str(),
-                                  (const char *)"WAttribute::check_written_value()");
-                    }
-                }
+            uchar_ptr = uch_ptr->get_buffer();
+            if (data_format == Tango::SCALAR)
+            {
+                old_uchar_val = uchar_val;
+                uchar_val = (*uch_ptr)[0];
+                w_dim_x = 1;
+                w_dim_y = 0;
+            }
+            else
+            {
+                w_dim_x = x;
+                w_dim_y = y;
             }
         }
+            break;
 
-		ushort_ptr = ush_ptr->get_buffer();
-		if (data_format == Tango::SCALAR)
-		{
-			old_ushort_val = ushort_val;
-			ushort_val = (*ush_ptr)[0];
-			w_dim_x = 1;
-			w_dim_y = 0;
-		}
-		else
-		{
-			w_dim_x = x;
-			w_dim_y = y;
-		}
-        }
-		break;
-
-	case Tango::DEV_UCHAR :
+        case Tango::DEV_ULONG :
         {
-
 //
 // Check data type inside the any
 //
 
-		const Tango::DevVarCharArray *uch_ptr;
-		if ((any >>= uch_ptr) == false)
-		{
-			TangoSys_OMemStream o;
+            const Tango::DevVarULongArray *ulo_ptr;
+            if ((any >>= ulo_ptr) == false)
+            {
+                TangoSys_OMemStream o;
 
-			o << "Incompatible attribute type, expected type is : Tango::DevVarCharArray (even for single value)" << ends;
-			Except::throw_exception((const char *)API_IncompatibleAttrDataType,
-					      o.str(),
-					      (const char *)"WAttribute::check_written_value()");
-		}
-		nb_data = uch_ptr->length();
-		check_length(nb_data,x,y);
+                o << "Incompatible attribute type, expected type is : Tango::DevVarULongArray (even for single value)"
+                  << ends;
+                Except::throw_exception((const char *) API_IncompatibleAttrDataType,
+                                        o.str(),
+                                        (const char *) "WAttribute::check_written_value()");
+            }
+            nb_data = ulo_ptr->length();
+            check_length(nb_data, x, y);
 
 //
 // Check the incoming value
 //
 
-        {
-            AutoTangoMonitor sync1(mon_ptr);
-            if (check_min_value == true)
             {
-                for (i = 0;i < nb_data;i++)
+                AutoTangoMonitor sync1(mon_ptr);
+                if (check_min_value == true)
                 {
-                    if ((*uch_ptr)[i] < min_value.uch)
+                    for (i = 0; i < nb_data; i++)
                     {
-                        TangoSys_OMemStream o;
+                        if ((*ulo_ptr)[i] < min_value.ulg)
+                        {
+                            TangoSys_OMemStream o;
 
-                        o << "Set value for attribute " << name;
-                        o << " is below the minimum authorized (at least element " << i << ")" << ends;
-                        Except::throw_exception((const char *)API_WAttrOutsideLimit,
-                                  o.str(),
-                                  (const char *)"WAttribute::check_written_value()");
+                            o << "Set value for attribute " << name;
+                            o << " is below the minimum authorized (at least element " << i << ")" << ends;
+                            Except::throw_exception((const char *) API_WAttrOutsideLimit,
+                                                    o.str(),
+                                                    (const char *) "WAttribute::check_written_value()");
+                        }
+                    }
+                }
+                if (check_max_value == true)
+                {
+                    for (i = 0; i < nb_data; i++)
+                    {
+                        if ((*ulo_ptr)[i] > max_value.ulg)
+                        {
+                            TangoSys_OMemStream o;
+
+                            o << "Set value for attribute " << name;
+                            o << " is above the maximum authorized (at least element " << i << ")" << ends;
+                            Except::throw_exception((const char *) API_WAttrOutsideLimit,
+                                                    o.str(),
+                                                    (const char *) "WAttribute::check_written_value()");
+                        }
                     }
                 }
             }
-            if (check_max_value == true)
-            {
-                for (i = 0;i < nb_data;i++)
-                {
-                    if ((*uch_ptr)[i] > max_value.uch)
-                    {
-                        TangoSys_OMemStream o;
 
-                        o << "Set value for attribute " << name;
-                        o << " is above the maximum authorized (at least element " << i << ")" << ends;
-                        Except::throw_exception((const char *)API_WAttrOutsideLimit,
-                                  o.str(),
-                                  (const char *)"WAttribute::check_written_value()");
-                    }
-                }
+            ulong_ptr = ulo_ptr->get_buffer();
+            if (data_format == Tango::SCALAR)
+            {
+                old_ulong_val = ulong_val;
+                ulong_val = (*ulo_ptr)[0];
+                w_dim_x = 1;
+                w_dim_y = 0;
+            }
+            else
+            {
+                w_dim_x = x;
+                w_dim_y = y;
             }
         }
+            break;
 
-		uchar_ptr = uch_ptr->get_buffer();
-		if (data_format == Tango::SCALAR)
-		{
-			old_uchar_val = uchar_val;
-			uchar_val = (*uch_ptr)[0];
-			w_dim_x = 1;
-			w_dim_y = 0;
-		}
-		else
-		{
-			w_dim_x = x;
-			w_dim_y = y;
-		}
-        }
-		break;
-
-	case Tango::DEV_ULONG :
+        case Tango::DEV_ULONG64 :
         {
 //
 // Check data type inside the any
 //
 
-		const Tango::DevVarULongArray *ulo_ptr;
-		if ((any >>= ulo_ptr) == false)
-		{
-			TangoSys_OMemStream o;
+            const Tango::DevVarULong64Array *ulg64_ptr;
+            if ((any >>= ulg64_ptr) == false)
+            {
+                TangoSys_OMemStream o;
 
-			o << "Incompatible attribute type, expected type is : Tango::DevVarULongArray (even for single value)" << ends;
-			Except::throw_exception((const char *)API_IncompatibleAttrDataType,
-					      o.str(),
-					      (const char *)"WAttribute::check_written_value()");
-		}
-		nb_data = ulo_ptr->length();
-		check_length(nb_data,x,y);
+                o << "Incompatible attribute type, expected type is : Tango::DevVarULong64Array (even for single value)"
+                  << ends;
+                Except::throw_exception((const char *) API_IncompatibleAttrDataType,
+                                        o.str(),
+                                        (const char *) "WAttribute::check_written_value()");
+            }
+            nb_data = ulg64_ptr->length();
+            check_length(nb_data, x, y);
 
 //
 // Check the incoming value
 //
 
-        {
-            AutoTangoMonitor sync1(mon_ptr);
-            if (check_min_value == true)
             {
-                for (i = 0;i < nb_data;i++)
+                AutoTangoMonitor sync1(mon_ptr);
+                if (check_min_value == true)
                 {
-                    if ((*ulo_ptr)[i] < min_value.ulg)
+                    for (i = 0; i < nb_data; i++)
                     {
-                        TangoSys_OMemStream o;
+                        if ((*ulg64_ptr)[i] < min_value.ulg64)
+                        {
+                            TangoSys_OMemStream o;
 
-                        o << "Set value for attribute " << name;
-                        o << " is below the minimum authorized (at least element " << i << ")" << ends;
-                        Except::throw_exception((const char *)API_WAttrOutsideLimit,
-                                  o.str(),
-                                  (const char *)"WAttribute::check_written_value()");
+                            o << "Set value for attribute " << name;
+                            o << " is below the minimum authorized (at least element " << i << ")" << ends;
+                            Except::throw_exception((const char *) API_WAttrOutsideLimit,
+                                                    o.str(),
+                                                    (const char *) "WAttribute::check_written_value()");
+                        }
+                    }
+                }
+                if (check_max_value == true)
+                {
+                    for (i = 0; i < nb_data; i++)
+                    {
+                        if ((*ulg64_ptr)[i] > max_value.ulg64)
+                        {
+                            TangoSys_OMemStream o;
+
+                            o << "Set value for attribute " << name;
+                            o << " is above the maximum authorized (at least element " << i << ")" << ends;
+                            Except::throw_exception((const char *) API_WAttrOutsideLimit,
+                                                    o.str(),
+                                                    (const char *) "WAttribute::check_written_value()");
+                        }
                     }
                 }
             }
-            if (check_max_value == true)
-            {
-                for (i = 0;i < nb_data;i++)
-                {
-                    if ((*ulo_ptr)[i] > max_value.ulg)
-                    {
-                        TangoSys_OMemStream o;
 
-                        o << "Set value for attribute " << name;
-                        o << " is above the maximum authorized (at least element " << i << ")" << ends;
-                        Except::throw_exception((const char *)API_WAttrOutsideLimit,
-                                  o.str(),
-                                  (const char *)"WAttribute::check_written_value()");
-                    }
-                }
+            ulong64_ptr = ulg64_ptr->get_buffer();
+            if (data_format == Tango::SCALAR)
+            {
+                old_ulong64_val = ulong64_val;
+                ulong64_val = (*ulg64_ptr)[0];
+                w_dim_x = 1;
+                w_dim_y = 0;
+            }
+            else
+            {
+                w_dim_x = x;
+                w_dim_y = y;
             }
         }
+            break;
 
-		ulong_ptr = ulo_ptr->get_buffer();
-		if (data_format == Tango::SCALAR)
-		{
-			old_ulong_val = ulong_val;
-			ulong_val = (*ulo_ptr)[0];
-			w_dim_x = 1;
-			w_dim_y = 0;
-		}
-		else
-		{
-			w_dim_x = x;
-			w_dim_y = y;
-		}
-        }
-		break;
-
-	case Tango::DEV_ULONG64 :
-        {
-//
-// Check data type inside the any
-//
-
-		const Tango::DevVarULong64Array *ulg64_ptr;
-		if ((any >>= ulg64_ptr) == false)
-		{
-			TangoSys_OMemStream o;
-
-			o << "Incompatible attribute type, expected type is : Tango::DevVarULong64Array (even for single value)" << ends;
-			Except::throw_exception((const char *)API_IncompatibleAttrDataType,
-					      o.str(),
-					      (const char *)"WAttribute::check_written_value()");
-		}
-		nb_data = ulg64_ptr->length();
-		check_length(nb_data,x,y);
-
-//
-// Check the incoming value
-//
-
-        {
-            AutoTangoMonitor sync1(mon_ptr);
-            if (check_min_value == true)
-            {
-                for (i = 0;i < nb_data;i++)
-                {
-                    if ((*ulg64_ptr)[i] < min_value.ulg64)
-                    {
-                        TangoSys_OMemStream o;
-
-                        o << "Set value for attribute " << name;
-                        o << " is below the minimum authorized (at least element " << i << ")" << ends;
-                        Except::throw_exception((const char *)API_WAttrOutsideLimit,
-                                  o.str(),
-                                  (const char *)"WAttribute::check_written_value()");
-                    }
-                }
-            }
-            if (check_max_value == true)
-            {
-                for (i = 0;i < nb_data;i++)
-                {
-                    if ((*ulg64_ptr)[i] > max_value.ulg64)
-                    {
-                        TangoSys_OMemStream o;
-
-                        o << "Set value for attribute " << name;
-                        o << " is above the maximum authorized (at least element " << i << ")" << ends;
-                        Except::throw_exception((const char *)API_WAttrOutsideLimit,
-                                  o.str(),
-                                  (const char *)"WAttribute::check_written_value()");
-                    }
-                }
-            }
-        }
-
-		ulong64_ptr = ulg64_ptr->get_buffer();
-		if (data_format == Tango::SCALAR)
-		{
-			old_ulong64_val = ulong64_val;
-			ulong64_val = (*ulg64_ptr)[0];
-			w_dim_x = 1;
-			w_dim_y = 0;
-		}
-		else
-		{
-			w_dim_x = x;
-			w_dim_y = y;
-		}
-        }
-		break;
-
-	case Tango::DEV_BOOLEAN :
+        case Tango::DEV_BOOLEAN :
 
 //
 // Check data type inside the any
 //
 
-		const Tango::DevVarBooleanArray *boo_ptr;
-		if ((any >>= boo_ptr) == false)
-		{
-			TangoSys_OMemStream o;
+            const Tango::DevVarBooleanArray *boo_ptr;
+            if ((any >>= boo_ptr) == false)
+            {
+                TangoSys_OMemStream o;
 
-			o << "Incompatible attribute type, expected type is : Tango::DevVarBooleanArray (even for single value)" << ends;
-			Except::throw_exception((const char *)API_IncompatibleAttrDataType,
-					      o.str(),
-					      (const char *)"WAttribute::check_written_value()");
-		}
-		nb_data = boo_ptr->length();
-		check_length(nb_data,x,y);
+                o << "Incompatible attribute type, expected type is : Tango::DevVarBooleanArray (even for single value)"
+                  << ends;
+                Except::throw_exception((const char *) API_IncompatibleAttrDataType,
+                                        o.str(),
+                                        (const char *) "WAttribute::check_written_value()");
+            }
+            nb_data = boo_ptr->length();
+            check_length(nb_data, x, y);
 
-		boolean_ptr = boo_ptr->get_buffer();
-		if (data_format == Tango::SCALAR)
-		{
-			old_boolean_val = boolean_val;
-			boolean_val = (*boo_ptr)[0];
-			w_dim_x = 1;
-			w_dim_y = 0;
-		}
-		else
-		{
-			w_dim_x = x;
-			w_dim_y = y;
-		}
-		break;
+            boolean_ptr = boo_ptr->get_buffer();
+            if (data_format == Tango::SCALAR)
+            {
+                old_boolean_val = boolean_val;
+                boolean_val = (*boo_ptr)[0];
+                w_dim_x = 1;
+                w_dim_y = 0;
+            }
+            else
+            {
+                w_dim_x = x;
+                w_dim_y = y;
+            }
+            break;
 
-	case Tango::DEV_STATE :
+        case Tango::DEV_STATE :
         {
 //
 // Check data type inside the any
 //
 
-		const Tango::DevVarStateArray *sta_ptr;
-		if ((any >>= sta_ptr) == false)
-		{
-			TangoSys_OMemStream o;
+            const Tango::DevVarStateArray *sta_ptr;
+            if ((any >>= sta_ptr) == false)
+            {
+                TangoSys_OMemStream o;
 
-			o << "Incompatible attribute type, expected type is : Tango::DevVarStateArray (even for single value)" << ends;
-			Except::throw_exception((const char *)API_IncompatibleAttrDataType,
-					      o.str(),
-					      (const char *)"WAttribute::check_written_value()");
-		}
-		nb_data = sta_ptr->length();
-		check_length(nb_data,x,y);
+                o << "Incompatible attribute type, expected type is : Tango::DevVarStateArray (even for single value)"
+                  << ends;
+                Except::throw_exception((const char *) API_IncompatibleAttrDataType,
+                                        o.str(),
+                                        (const char *) "WAttribute::check_written_value()");
+            }
+            nb_data = sta_ptr->length();
+            check_length(nb_data, x, y);
 
-		state_ptr = sta_ptr->get_buffer();
-		if (data_format == Tango::SCALAR)
-		{
-			old_dev_state_val = dev_state_val;
-			dev_state_val = (*sta_ptr)[0];
-			w_dim_x = 1;
-			w_dim_y = 0;
-		}
-		else
-		{
-			w_dim_x = x;
-			w_dim_y = y;
-		}
+            state_ptr = sta_ptr->get_buffer();
+            if (data_format == Tango::SCALAR)
+            {
+                old_dev_state_val = dev_state_val;
+                dev_state_val = (*sta_ptr)[0];
+                w_dim_x = 1;
+                w_dim_y = 0;
+            }
+            else
+            {
+                w_dim_x = x;
+                w_dim_y = y;
+            }
         }
-		break;
-	}
+            break;
+    }
 }
 
-void WAttribute::check_written_value(const Tango::AttrValUnion &att_union,unsigned long x,unsigned long y)
+void WAttribute::check_written_value(const Tango::AttrValUnion &att_union, unsigned long x, unsigned long y)
 {
-	unsigned int nb_data;
-	unsigned int i;
+    unsigned int nb_data;
+    unsigned int i;
 
 //
 // If the server is in its starting phase, gives a NULL ptr
@@ -1154,29 +1166,30 @@ void WAttribute::check_written_value(const Tango::AttrValUnion &att_union,unsign
     if (tg->is_svr_starting() == false && tg->is_device_restarting(d_name) == false)
         mon_ptr = &(get_att_device()->get_att_conf_monitor());
 
-	switch (data_type)
-	{
-	case Tango::DEV_SHORT :
-	case Tango::DEV_ENUM :
-		{
+    switch (data_type)
+    {
+        case Tango::DEV_SHORT :
+        case Tango::DEV_ENUM :
+        {
 
 //
 // Check data type inside the union and data number
 //
 
-			if (att_union._d() != ATT_SHORT)
-			{
-				TangoSys_OMemStream o;
+            if (att_union._d() != ATT_SHORT)
+            {
+                TangoSys_OMemStream o;
 
-				o << "Incompatible attribute type, expected type is : Tango::DevVarShortArray (even for single value)" << ends;
-				Except::throw_exception((const char *)API_IncompatibleAttrDataType,
-					    	  o.str(),
-					    	  (const char *)"WAttribute::check_written_value()");
-			}
+                o << "Incompatible attribute type, expected type is : Tango::DevVarShortArray (even for single value)"
+                  << ends;
+                Except::throw_exception((const char *) API_IncompatibleAttrDataType,
+                                        o.str(),
+                                        (const char *) "WAttribute::check_written_value()");
+            }
 
-			const Tango::DevVarShortArray &sh_seq = att_union.short_att_value();
-			nb_data = sh_seq.length();
-            check_length(nb_data,x,y);
+            const Tango::DevVarShortArray &sh_seq = att_union.short_att_value();
+            nb_data = sh_seq.length();
+            check_length(nb_data, x, y);
 
 
 //
@@ -1185,63 +1198,65 @@ void WAttribute::check_written_value(const Tango::AttrValUnion &att_union,unsign
 
             {
                 AutoTangoMonitor sync1(mon_ptr);
-                check_min_max(nb_data,sh_seq,min_value.sh,max_value.sh);
+                check_min_max(nb_data, sh_seq, min_value.sh, max_value.sh);
             }
 
-			short_ptr = sh_seq.get_buffer();
-			if (data_format == Tango::SCALAR)
-			{
-				old_short_val = short_val;
-				short_val = sh_seq[0];
-				w_dim_x = 1;
-				w_dim_y = 0;
-			}
-			else
-			{
-				w_dim_x = x;
-				w_dim_y = y;
-			}
+            short_ptr = sh_seq.get_buffer();
+            if (data_format == Tango::SCALAR)
+            {
+                old_short_val = short_val;
+                short_val = sh_seq[0];
+                w_dim_x = 1;
+                w_dim_y = 0;
+            }
+            else
+            {
+                w_dim_x = x;
+                w_dim_y = y;
+            }
 
 //
 // If the attribute is enumerated, check the input value compared to the enum labels
 //
 
-			if (get_data_type() == DEV_ENUM)
-			{
-				int max_val = enum_labels.size() - 1;
-				for (i = 0;i < nb_data;i++)
-				{
-					if (sh_seq[i] < 0 || sh_seq[i] > max_val)
-					{
-						stringstream ss;
-						ss << "Set value for attribute " << name;
-						ss << " is negative or above the maximun authorized (" << max_val << ") for at least element " << i;
+            if (get_data_type() == DEV_ENUM)
+            {
+                int max_val = enum_labels.size() - 1;
+                for (i = 0; i < nb_data; i++)
+                {
+                    if (sh_seq[i] < 0 || sh_seq[i] > max_val)
+                    {
+                        stringstream ss;
+                        ss << "Set value for attribute " << name;
+                        ss << " is negative or above the maximun authorized (" << max_val << ") for at least element "
+                           << i;
 
-						Except::throw_exception(API_WAttrOutsideLimit,ss.str(),"WAttribute::check_written_value()");
-					}
-				}
-			}
-		}
-		break;
+                        Except::throw_exception(API_WAttrOutsideLimit, ss.str(), "WAttribute::check_written_value()");
+                    }
+                }
+            }
+        }
+            break;
 
-	case Tango::DEV_LONG :
-		{
+        case Tango::DEV_LONG :
+        {
 //
 // Check data type inside the union
 //
 
-			if (att_union._d() != ATT_LONG)
-			{
-				TangoSys_OMemStream o;
+            if (att_union._d() != ATT_LONG)
+            {
+                TangoSys_OMemStream o;
 
-				o << "Incompatible attribute type, expected type is : Tango::DevVarLongArray (even for single value)" << ends;
-				Except::throw_exception((const char *)API_IncompatibleAttrDataType,
-					    	  o.str(),
-					    	  (const char *)"WAttribute::check_written_value()");
-			}
-			const Tango::DevVarLongArray &lg_seq = att_union.long_att_value();
-			nb_data = lg_seq.length();
-			check_length(nb_data,x,y);
+                o << "Incompatible attribute type, expected type is : Tango::DevVarLongArray (even for single value)"
+                  << ends;
+                Except::throw_exception((const char *) API_IncompatibleAttrDataType,
+                                        o.str(),
+                                        (const char *) "WAttribute::check_written_value()");
+            }
+            const Tango::DevVarLongArray &lg_seq = att_union.long_att_value();
+            nb_data = lg_seq.length();
+            check_length(nb_data, x, y);
 
 //
 // Check the incoming value
@@ -1249,44 +1264,45 @@ void WAttribute::check_written_value(const Tango::AttrValUnion &att_union,unsign
 
             {
                 AutoTangoMonitor sync1(mon_ptr);
-                check_min_max(nb_data,lg_seq,min_value.lg,max_value.lg);
+                check_min_max(nb_data, lg_seq, min_value.lg, max_value.lg);
             }
 
-			long_ptr = lg_seq.get_buffer();
-			if (data_format == Tango::SCALAR)
-			{
-				old_long_val = long_val;
-				long_val = lg_seq[0];
-				w_dim_x = 1;
-				w_dim_y = 0;
-			}
-			else
-			{
-				w_dim_x = x;
-				w_dim_y = y;
-			}
-		}
-		break;
+            long_ptr = lg_seq.get_buffer();
+            if (data_format == Tango::SCALAR)
+            {
+                old_long_val = long_val;
+                long_val = lg_seq[0];
+                w_dim_x = 1;
+                w_dim_y = 0;
+            }
+            else
+            {
+                w_dim_x = x;
+                w_dim_y = y;
+            }
+        }
+            break;
 
 
-	case Tango::DEV_LONG64 :
-		{
+        case Tango::DEV_LONG64 :
+        {
 //
 // Check data type inside the union
 //
 
-			if (att_union._d() != ATT_LONG64)
-			{
-				TangoSys_OMemStream o;
+            if (att_union._d() != ATT_LONG64)
+            {
+                TangoSys_OMemStream o;
 
-				o << "Incompatible attribute type, expected type is : Tango::DevVarLong64Array (even for single value)" << ends;
-				Except::throw_exception((const char *)API_IncompatibleAttrDataType,
-					    	  o.str(),
-					    	  (const char *)"WAttribute::check_written_value()");
-			}
-			const Tango::DevVarLong64Array &lg64_seq = att_union.long64_att_value();
-			nb_data = lg64_seq.length();
-			check_length(nb_data,x,y);
+                o << "Incompatible attribute type, expected type is : Tango::DevVarLong64Array (even for single value)"
+                  << ends;
+                Except::throw_exception((const char *) API_IncompatibleAttrDataType,
+                                        o.str(),
+                                        (const char *) "WAttribute::check_written_value()");
+            }
+            const Tango::DevVarLong64Array &lg64_seq = att_union.long64_att_value();
+            nb_data = lg64_seq.length();
+            check_length(nb_data, x, y);
 
 //
 // Check the incoming value
@@ -1294,43 +1310,44 @@ void WAttribute::check_written_value(const Tango::AttrValUnion &att_union,unsign
 
             {
                 AutoTangoMonitor sync1(mon_ptr);
-                check_min_max(nb_data,lg64_seq,min_value.lg64,max_value.lg64);
+                check_min_max(nb_data, lg64_seq, min_value.lg64, max_value.lg64);
             }
 
-			long64_ptr = lg64_seq.get_buffer();
-			if (data_format == Tango::SCALAR)
-			{
-				old_long64_val = long64_val;
-				long64_val = lg64_seq[0];
-				w_dim_x = 1;
-				w_dim_y = 0;
-			}
-			else
-			{
-				w_dim_x = x;
-				w_dim_y = y;
-			}
-		}
-		break;
+            long64_ptr = lg64_seq.get_buffer();
+            if (data_format == Tango::SCALAR)
+            {
+                old_long64_val = long64_val;
+                long64_val = lg64_seq[0];
+                w_dim_x = 1;
+                w_dim_y = 0;
+            }
+            else
+            {
+                w_dim_x = x;
+                w_dim_y = y;
+            }
+        }
+            break;
 
-	case Tango::DEV_DOUBLE :
-		{
+        case Tango::DEV_DOUBLE :
+        {
 //
 // Check data type inside the union
 //
 
-			if (att_union._d() != ATT_DOUBLE)
-			{
-				TangoSys_OMemStream o;
+            if (att_union._d() != ATT_DOUBLE)
+            {
+                TangoSys_OMemStream o;
 
-				o << "Incompatible attribute type, expected type is : Tango::DevVarDoubleArray (even for single value)" << ends;
-				Except::throw_exception((const char *)API_IncompatibleAttrDataType,
-					    	  o.str(),
-					    	  (const char *)"WAttribute::check_written_value()");
-			}
-			const Tango::DevVarDoubleArray &db_seq = att_union.double_att_value();
-			nb_data = db_seq.length();
-			check_length(nb_data,x,y);
+                o << "Incompatible attribute type, expected type is : Tango::DevVarDoubleArray (even for single value)"
+                  << ends;
+                Except::throw_exception((const char *) API_IncompatibleAttrDataType,
+                                        o.str(),
+                                        (const char *) "WAttribute::check_written_value()");
+            }
+            const Tango::DevVarDoubleArray &db_seq = att_union.double_att_value();
+            nb_data = db_seq.length();
+            check_length(nb_data, x, y);
 
 //
 // Check the incoming value
@@ -1339,7 +1356,7 @@ void WAttribute::check_written_value(const Tango::AttrValUnion &att_union,unsign
 
             {
                 AutoTangoMonitor sync1(mon_ptr);
-                for (i = 0;i < nb_data;i++)
+                for (i = 0; i < nb_data; i++)
                 {
                     if (tg->is_wattr_nan_allowed() == false)
                     {
@@ -1353,9 +1370,9 @@ void WAttribute::check_written_value(const Tango::AttrValUnion &att_union,unsign
 
                             o << "Set value for attribute " << name;
                             o << " is a NaN or INF value (at least element " << i << ")" << ends;
-                            Except::throw_exception((const char *)API_WAttrOutsideLimit,
-                                      o.str(),
-                                      (const char *)"WAttribute::check_written_value()");
+                            Except::throw_exception((const char *) API_WAttrOutsideLimit,
+                                                    o.str(),
+                                                    (const char *) "WAttribute::check_written_value()");
                         }
                     }
 
@@ -1367,9 +1384,9 @@ void WAttribute::check_written_value(const Tango::AttrValUnion &att_union,unsign
 
                             o << "Set value for attribute " << name;
                             o << " is below the minimum authorized (at least element " << i << ")" << ends;
-                            Except::throw_exception((const char *)API_WAttrOutsideLimit,
-                                      o.str(),
-                                      (const char *)"WAttribute::check_written_value()");
+                            Except::throw_exception((const char *) API_WAttrOutsideLimit,
+                                                    o.str(),
+                                                    (const char *) "WAttribute::check_written_value()");
                         }
                     }
 
@@ -1381,87 +1398,89 @@ void WAttribute::check_written_value(const Tango::AttrValUnion &att_union,unsign
 
                             o << "Set value for attribute " << name;
                             o << " is above the maximum authorized (at least element " << i << ")" << ends;
-                            Except::throw_exception((const char *)API_WAttrOutsideLimit,
-                                      o.str(),
-                                      (const char *)"WAttribute::check_written_value()");
+                            Except::throw_exception((const char *) API_WAttrOutsideLimit,
+                                                    o.str(),
+                                                    (const char *) "WAttribute::check_written_value()");
                         }
                     }
                 }
             }
 
-			double_ptr = db_seq.get_buffer();
-			if (data_format == Tango::SCALAR)
-			{
-				old_double_val = double_val;
-				double_val = db_seq[0];
-				w_dim_x = 1;
-				w_dim_y = 0;
-			}
-			else
-			{
-				w_dim_x = x;
-				w_dim_y = y;
-			}
-		}
-		break;
+            double_ptr = db_seq.get_buffer();
+            if (data_format == Tango::SCALAR)
+            {
+                old_double_val = double_val;
+                double_val = db_seq[0];
+                w_dim_x = 1;
+                w_dim_y = 0;
+            }
+            else
+            {
+                w_dim_x = x;
+                w_dim_y = y;
+            }
+        }
+            break;
 
-	case Tango::DEV_STRING :
-		{
+        case Tango::DEV_STRING :
+        {
 //
 // Check data type inside the union
 //
 
-			if (att_union._d() != ATT_STRING)
-			{
-				TangoSys_OMemStream o;
+            if (att_union._d() != ATT_STRING)
+            {
+                TangoSys_OMemStream o;
 
-				o << "Incompatible attribute type, expected type is : Tango::DevVarStringArray (even for single value)" << ends;
-				Except::throw_exception((const char *)API_IncompatibleAttrDataType,
-					    	  o.str(),
-					    	  (const char *)"WAttribute::check_written_value()");
-			}
-			const Tango::DevVarStringArray &string_seq = att_union.string_att_value();
-			nb_data = string_seq.length();
-			check_length(nb_data,x,y);
+                o << "Incompatible attribute type, expected type is : Tango::DevVarStringArray (even for single value)"
+                  << ends;
+                Except::throw_exception((const char *) API_IncompatibleAttrDataType,
+                                        o.str(),
+                                        (const char *) "WAttribute::check_written_value()");
+            }
+            const Tango::DevVarStringArray &string_seq = att_union.string_att_value();
+            nb_data = string_seq.length();
+            check_length(nb_data, x, y);
 
-			str_ptr = string_seq.get_buffer();
+            str_ptr = string_seq.get_buffer();
 
-			if (data_format == Tango::SCALAR)
-			{
-				CORBA::string_free(old_str_val);
-				old_str_val = CORBA::string_dup(str_val);
-				CORBA::string_free(str_val);
+            if (data_format == Tango::SCALAR)
+            {
+                CORBA::string_free(old_str_val);
+                old_str_val = CORBA::string_dup(str_val);
+                CORBA::string_free(str_val);
 
-				str_val = CORBA::string_dup(string_seq[0]);
-				w_dim_x = 1;
-				w_dim_y = 0;
-			}
-			else
-			{
-				w_dim_x = x;
-				w_dim_y = y;
-			}
-		}
-		break;
+                str_val = CORBA::string_dup(string_seq[0]);
+                w_dim_x = 1;
+                w_dim_y = 0;
+            }
+            else
+            {
+                w_dim_x = x;
+                w_dim_y = y;
+            }
+        }
+            break;
 
-	case Tango::DEV_FLOAT :
-		{
+        case Tango::DEV_FLOAT :
+        {
 //
 // Check data type inside the union
 //
 
-			if (att_union._d() != ATT_FLOAT)
-			{
-				TangoSys_OMemStream o;
+            if (att_union._d() != ATT_FLOAT)
+            {
+                TangoSys_OMemStream o;
 
-				o << "Incompatible attribute type, expected type is : Tango::DevVarFloatArray (even for single value)" << ends;
-				Except::throw_exception((const char *)API_IncompatibleAttrDataType,
-					    	  o.str(),
-					    	  (const char *)"WAttribute::check_written_value()");
-			}
-			const Tango::DevVarFloatArray &fl_seq = att_union.float_att_value();
-			nb_data = fl_seq.length();
-			check_length(nb_data,x,y);
+                o << "Incompatible attribute type, expected type is : Tango::DevVarFloatArray (even for single value)"
+                  << ends;
+                Except::throw_exception((const char *) API_IncompatibleAttrDataType,
+                                        o.str(),
+                                        (const char *) "WAttribute::check_written_value()");
+            }
+            const Tango::DevVarFloatArray &fl_seq = att_union.float_att_value();
+            nb_data = fl_seq.length();
+            check_length(nb_data, x, y);
 
 //
 // Check the incoming value
@@ -1470,7 +1489,7 @@ void WAttribute::check_written_value(const Tango::AttrValUnion &att_union,unsign
 
             {
                 AutoTangoMonitor sync1(mon_ptr);
-                for (i = 0;i < nb_data;i++)
+                for (i = 0; i < nb_data; i++)
                 {
                     if (tg->is_wattr_nan_allowed() == false)
                     {
@@ -1484,9 +1503,9 @@ void WAttribute::check_written_value(const Tango::AttrValUnion &att_union,unsign
 
                             o << "Set value for attribute " << name;
                             o << " is a NaN or INF value (at least element " << i << ")" << ends;
-                            Except::throw_exception((const char *)API_WAttrOutsideLimit,
-                                      o.str(),
-                                      (const char *)"WAttribute::check_written_value()");
+                            Except::throw_exception((const char *) API_WAttrOutsideLimit,
+                                                    o.str(),
+                                                    (const char *) "WAttribute::check_written_value()");
                         }
                     }
 
@@ -1498,9 +1517,9 @@ void WAttribute::check_written_value(const Tango::AttrValUnion &att_union,unsign
 
                             o << "Set value for attribute " << name;
                             o << " is below the minimum authorized (at least element " << i << ")" << ends;
-                            Except::throw_exception((const char *)API_WAttrOutsideLimit,
-                                      o.str(),
-                                      (const char *)"WAttribute::check_written_value()");
+                            Except::throw_exception((const char *) API_WAttrOutsideLimit,
+                                                    o.str(),
+                                                    (const char *) "WAttribute::check_written_value()");
                         }
                     }
 
@@ -1512,48 +1531,49 @@ void WAttribute::check_written_value(const Tango::AttrValUnion &att_union,unsign
 
                             o << "Set value for attribute " << name;
                             o << " is above the maximum authorized (at least element " << i << ")" << ends;
-                            Except::throw_exception((const char *)API_WAttrOutsideLimit,
-                                      o.str(),
-                                      (const char *)"WAttribute::check_written_value()");
+                            Except::throw_exception((const char *) API_WAttrOutsideLimit,
+                                                    o.str(),
+                                                    (const char *) "WAttribute::check_written_value()");
                         }
                     }
                 }
             }
 
-			float_ptr = fl_seq.get_buffer();
-			if (data_format == Tango::SCALAR)
-			{
-				old_float_val = float_val;
-				float_val = fl_seq[0];
-				w_dim_x = 1;
-				w_dim_y = 0;
-			}
-			else
-			{
-				w_dim_x = x;
-				w_dim_y = y;
-			}
-		}
-		break;
+            float_ptr = fl_seq.get_buffer();
+            if (data_format == Tango::SCALAR)
+            {
+                old_float_val = float_val;
+                float_val = fl_seq[0];
+                w_dim_x = 1;
+                w_dim_y = 0;
+            }
+            else
+            {
+                w_dim_x = x;
+                w_dim_y = y;
+            }
+        }
+            break;
 
-	case Tango::DEV_USHORT :
-		{
+        case Tango::DEV_USHORT :
+        {
 //
 // Check data type inside the union
 //
 
-			if (att_union._d() != ATT_USHORT)
-			{
-				TangoSys_OMemStream o;
+            if (att_union._d() != ATT_USHORT)
+            {
+                TangoSys_OMemStream o;
 
-				o << "Incompatible attribute type, expected type is : Tango::DevVarUShortArray (even for single value)" << ends;
-				Except::throw_exception((const char *)API_IncompatibleAttrDataType,
-					    	  o.str(),
-					    	  (const char *)"WAttribute::check_written_value()");
-			}
-			const Tango::DevVarUShortArray &ush_seq = att_union.ushort_att_value();
-			nb_data = ush_seq.length();
-			check_length(nb_data,x,y);
+                o << "Incompatible attribute type, expected type is : Tango::DevVarUShortArray (even for single value)"
+                  << ends;
+                Except::throw_exception((const char *) API_IncompatibleAttrDataType,
+                                        o.str(),
+                                        (const char *) "WAttribute::check_written_value()");
+            }
+            const Tango::DevVarUShortArray &ush_seq = att_union.ushort_att_value();
+            nb_data = ush_seq.length();
+            check_length(nb_data, x, y);
 
 //
 // Check the incoming value
@@ -1561,43 +1581,44 @@ void WAttribute::check_written_value(const Tango::AttrValUnion &att_union,unsign
 
             {
                 AutoTangoMonitor sync1(mon_ptr);
-                check_min_max(nb_data,ush_seq,min_value.ush,max_value.ush);
+                check_min_max(nb_data, ush_seq, min_value.ush, max_value.ush);
             }
 
-			ushort_ptr = ush_seq.get_buffer();
-			if (data_format == Tango::SCALAR)
-			{
-				old_ushort_val = ushort_val;
-				ushort_val = ush_seq[0];
-				w_dim_x = 1;
-				w_dim_y = 0;
-			}
-			else
-			{
-				w_dim_x = x;
-				w_dim_y = y;
-			}
-		}
-		break;
+            ushort_ptr = ush_seq.get_buffer();
+            if (data_format == Tango::SCALAR)
+            {
+                old_ushort_val = ushort_val;
+                ushort_val = ush_seq[0];
+                w_dim_x = 1;
+                w_dim_y = 0;
+            }
+            else
+            {
+                w_dim_x = x;
+                w_dim_y = y;
+            }
+        }
+            break;
 
-	case Tango::DEV_UCHAR :
-		{
+        case Tango::DEV_UCHAR :
+        {
 //
 // Check data type inside the union
 //
 
-			if (att_union._d() != ATT_UCHAR)
-			{
-				TangoSys_OMemStream o;
+            if (att_union._d() != ATT_UCHAR)
+            {
+                TangoSys_OMemStream o;
 
-				o << "Incompatible attribute type, expected type is : Tango::DevVarCharArray (even for single value)" << ends;
-				Except::throw_exception((const char *)API_IncompatibleAttrDataType,
-					    	  o.str(),
-					    	  (const char *)"WAttribute::check_written_value()");
-			}
-			const Tango::DevVarCharArray &uch_seq = att_union.uchar_att_value();
-			nb_data = uch_seq.length();
-			check_length(nb_data,x,y);
+                o << "Incompatible attribute type, expected type is : Tango::DevVarCharArray (even for single value)"
+                  << ends;
+                Except::throw_exception((const char *) API_IncompatibleAttrDataType,
+                                        o.str(),
+                                        (const char *) "WAttribute::check_written_value()");
+            }
+            const Tango::DevVarCharArray &uch_seq = att_union.uchar_att_value();
+            nb_data = uch_seq.length();
+            check_length(nb_data, x, y);
 
 //
 // Check the incoming value
@@ -1605,43 +1626,44 @@ void WAttribute::check_written_value(const Tango::AttrValUnion &att_union,unsign
 
             {
                 AutoTangoMonitor sync1(mon_ptr);
-                check_min_max(nb_data,uch_seq,min_value.uch,max_value.uch);
+                check_min_max(nb_data, uch_seq, min_value.uch, max_value.uch);
             }
 
-			uchar_ptr = uch_seq.get_buffer();
-			if (data_format == Tango::SCALAR)
-			{
-				old_uchar_val = uchar_val;
-				uchar_val = uch_seq[0];
-				w_dim_x = 1;
-				w_dim_y = 0;
-			}
-			else
-			{
-				w_dim_x = x;
-				w_dim_y = y;
-			}
-		}
-		break;
+            uchar_ptr = uch_seq.get_buffer();
+            if (data_format == Tango::SCALAR)
+            {
+                old_uchar_val = uchar_val;
+                uchar_val = uch_seq[0];
+                w_dim_x = 1;
+                w_dim_y = 0;
+            }
+            else
+            {
+                w_dim_x = x;
+                w_dim_y = y;
+            }
+        }
+            break;
 
-	case Tango::DEV_ULONG :
-		{
+        case Tango::DEV_ULONG :
+        {
 //
 // Check data type inside the union
 //
 
-			if (att_union._d() != ATT_ULONG)
-			{
-				TangoSys_OMemStream o;
+            if (att_union._d() != ATT_ULONG)
+            {
+                TangoSys_OMemStream o;
 
-				o << "Incompatible attribute type, expected type is : Tango::DevVarULongArray (even for single value)" << ends;
-				Except::throw_exception((const char *)API_IncompatibleAttrDataType,
-					    	  o.str(),
-					    	  (const char *)"WAttribute::check_written_value()");
-			}
-			const Tango::DevVarULongArray &ulo_seq = att_union.ulong_att_value();
-			nb_data = ulo_seq.length();
-			check_length(nb_data,x,y);
+                o << "Incompatible attribute type, expected type is : Tango::DevVarULongArray (even for single value)"
+                  << ends;
+                Except::throw_exception((const char *) API_IncompatibleAttrDataType,
+                                        o.str(),
+                                        (const char *) "WAttribute::check_written_value()");
+            }
+            const Tango::DevVarULongArray &ulo_seq = att_union.ulong_att_value();
+            nb_data = ulo_seq.length();
+            check_length(nb_data, x, y);
 
 //
 // Check the incoming value
@@ -1649,43 +1671,44 @@ void WAttribute::check_written_value(const Tango::AttrValUnion &att_union,unsign
 
             {
                 AutoTangoMonitor sync1(mon_ptr);
-                check_min_max(nb_data,ulo_seq,min_value.ulg,max_value.ulg);
+                check_min_max(nb_data, ulo_seq, min_value.ulg, max_value.ulg);
             }
 
-			ulong_ptr = ulo_seq.get_buffer();
-			if (data_format == Tango::SCALAR)
-			{
-				old_ulong_val = ulong_val;
-				ulong_val = ulo_seq[0];
-				w_dim_x = 1;
-				w_dim_y = 0;
-			}
-			else
-			{
-				w_dim_x = x;
-				w_dim_y = y;
-			}
-		}
-		break;
+            ulong_ptr = ulo_seq.get_buffer();
+            if (data_format == Tango::SCALAR)
+            {
+                old_ulong_val = ulong_val;
+                ulong_val = ulo_seq[0];
+                w_dim_x = 1;
+                w_dim_y = 0;
+            }
+            else
+            {
+                w_dim_x = x;
+                w_dim_y = y;
+            }
+        }
+            break;
 
-	case Tango::DEV_ULONG64 :
-		{
+        case Tango::DEV_ULONG64 :
+        {
 //
 // Check data type inside the union
 //
 
-			if (att_union._d() != ATT_ULONG64)
-			{
-				TangoSys_OMemStream o;
+            if (att_union._d() != ATT_ULONG64)
+            {
+                TangoSys_OMemStream o;
 
-				o << "Incompatible attribute type, expected type is : Tango::DevVarULong64Array (even for single value)" << ends;
-				Except::throw_exception((const char *)API_IncompatibleAttrDataType,
-					    	  o.str(),
-					    	  (const char *)"WAttribute::check_written_value()");
-			}
-			const Tango::DevVarULong64Array &ulo64_seq = att_union.ulong64_att_value();
-			nb_data = ulo64_seq.length();
-			check_length(nb_data,x,y);
+                o << "Incompatible attribute type, expected type is : Tango::DevVarULong64Array (even for single value)"
+                  << ends;
+                Except::throw_exception((const char *) API_IncompatibleAttrDataType,
+                                        o.str(),
+                                        (const char *) "WAttribute::check_written_value()");
+            }
+            const Tango::DevVarULong64Array &ulo64_seq = att_union.ulong64_att_value();
+            nb_data = ulo64_seq.length();
+            check_length(nb_data, x, y);
 
 //
 // Check the incoming value
@@ -1693,116 +1716,119 @@ void WAttribute::check_written_value(const Tango::AttrValUnion &att_union,unsign
 
             {
                 AutoTangoMonitor sync1(mon_ptr);
-                check_min_max(nb_data,ulo64_seq,min_value.ulg64,max_value.ulg64);
+                check_min_max(nb_data, ulo64_seq, min_value.ulg64, max_value.ulg64);
             }
 
-			ulong64_ptr = ulo64_seq.get_buffer();
-			if (data_format == Tango::SCALAR)
-			{
-				old_ulong64_val = ulong64_val;
-				ulong64_val = ulo64_seq[0];
-				w_dim_x = 1;
-				w_dim_y = 0;
-			}
-			else
-			{
-				w_dim_x = x;
-				w_dim_y = y;
-			}
-		}
-		break;
+            ulong64_ptr = ulo64_seq.get_buffer();
+            if (data_format == Tango::SCALAR)
+            {
+                old_ulong64_val = ulong64_val;
+                ulong64_val = ulo64_seq[0];
+                w_dim_x = 1;
+                w_dim_y = 0;
+            }
+            else
+            {
+                w_dim_x = x;
+                w_dim_y = y;
+            }
+        }
+            break;
 
-	case Tango::DEV_STATE :
-		{
+        case Tango::DEV_STATE :
+        {
 //
 // Check data type inside the union
 //
 
-			if (att_union._d() != ATT_STATE)
-			{
-				TangoSys_OMemStream o;
+            if (att_union._d() != ATT_STATE)
+            {
+                TangoSys_OMemStream o;
 
-				o << "Incompatible attribute type, expected type is : Tango::DevVarStateArray (even for single value)" << ends;
-				Except::throw_exception((const char *)API_IncompatibleAttrDataType,
-					    	  o.str(),
-					    	  (const char *)"WAttribute::check_written_value()");
-			}
-			const Tango::DevVarStateArray &sta_seq = att_union.state_att_value();
-			nb_data = sta_seq.length();
-            check_length(nb_data,x,y);
+                o << "Incompatible attribute type, expected type is : Tango::DevVarStateArray (even for single value)"
+                  << ends;
+                Except::throw_exception((const char *) API_IncompatibleAttrDataType,
+                                        o.str(),
+                                        (const char *) "WAttribute::check_written_value()");
+            }
+            const Tango::DevVarStateArray &sta_seq = att_union.state_att_value();
+            nb_data = sta_seq.length();
+            check_length(nb_data, x, y);
 
 //
 // Check the incoming value
 //
 
-            check_min_max(nb_data,sta_seq,min_value.d_sta,max_value.d_sta);
+            check_min_max(nb_data, sta_seq, min_value.d_sta, max_value.d_sta);
 
-			state_ptr = sta_seq.get_buffer();
-			if (data_format == Tango::SCALAR)
-			{
-				old_dev_state_val = dev_state_val;
-				dev_state_val = sta_seq[0];
-				w_dim_x = 1;
-				w_dim_y = 0;
-			}
-			else
-			{
-				w_dim_x = x;
-				w_dim_y = y;
-			}
-		}
-		break;
+            state_ptr = sta_seq.get_buffer();
+            if (data_format == Tango::SCALAR)
+            {
+                old_dev_state_val = dev_state_val;
+                dev_state_val = sta_seq[0];
+                w_dim_x = 1;
+                w_dim_y = 0;
+            }
+            else
+            {
+                w_dim_x = x;
+                w_dim_y = y;
+            }
+        }
+            break;
 
-	case Tango::DEV_BOOLEAN :
-		{
+        case Tango::DEV_BOOLEAN :
+        {
 //
 // Check data type inside the union
 //
 
-			if (att_union._d() != ATT_BOOL)
-			{
-				TangoSys_OMemStream o;
+            if (att_union._d() != ATT_BOOL)
+            {
+                TangoSys_OMemStream o;
 
-				o << "Incompatible attribute type, expected type is : Tango::DevVarBooleanArray (even for single value)" << ends;
-				Except::throw_exception((const char *)API_IncompatibleAttrDataType,
-					    	  o.str(),
-					    	  (const char *)"WAttribute::check_written_value()");
-			}
-			const Tango::DevVarBooleanArray &boo_seq = att_union.bool_att_value();
-			nb_data = boo_seq.length();
-			check_length(nb_data,x,y);
+                o << "Incompatible attribute type, expected type is : Tango::DevVarBooleanArray (even for single value)"
+                  << ends;
+                Except::throw_exception((const char *) API_IncompatibleAttrDataType,
+                                        o.str(),
+                                        (const char *) "WAttribute::check_written_value()");
+            }
+            const Tango::DevVarBooleanArray &boo_seq = att_union.bool_att_value();
+            nb_data = boo_seq.length();
+            check_length(nb_data, x, y);
 
-			boolean_ptr = boo_seq.get_buffer();
-			if (data_format == Tango::SCALAR)
-			{
-				old_boolean_val = boolean_val;
-				boolean_val = boo_seq[0];
-				w_dim_x = 1;
-				w_dim_y = 0;
-			}
-			else
-			{
-				w_dim_x = x;
-				w_dim_y = y;
-			}
-		}
-		break;
+            boolean_ptr = boo_seq.get_buffer();
+            if (data_format == Tango::SCALAR)
+            {
+                old_boolean_val = boolean_val;
+                boolean_val = boo_seq[0];
+                w_dim_x = 1;
+                w_dim_y = 0;
+            }
+            else
+            {
+                w_dim_x = x;
+                w_dim_y = y;
+            }
+        }
+            break;
 
-	case Tango::DEV_ENCODED :
-		{
-			if (att_union._d() != ATT_ENCODED)
-			{
-				TangoSys_OMemStream o;
+        case Tango::DEV_ENCODED :
+        {
+            if (att_union._d() != ATT_ENCODED)
+            {
+                TangoSys_OMemStream o;
 
-				o << "Incompatible attribute type, expected type is : Tango::DevVarEncodedArray (even for single value)" << ends;
-				Except::throw_exception((const char *)API_IncompatibleAttrDataType,
-					    	  o.str(),
-					    	  (const char *)"WAttribute::check_written_value()");
-			}
+                o << "Incompatible attribute type, expected type is : Tango::DevVarEncodedArray (even for single value)"
+                  << ends;
+                Except::throw_exception((const char *) API_IncompatibleAttrDataType,
+                                        o.str(),
+                                        (const char *) "WAttribute::check_written_value()");
+            }
 
-			const Tango::DevVarEncodedArray &enc_seq = att_union.encoded_att_value();
-			nb_data = enc_seq.length();
-			check_length(nb_data,x,y);
+            const Tango::DevVarEncodedArray &enc_seq = att_union.encoded_att_value();
+            nb_data = enc_seq.length();
+            check_length(nb_data, x, y);
 
 //
 // Check the incoming value against min or max_value if needed
@@ -1813,10 +1839,10 @@ void WAttribute::check_written_value(const Tango::AttrValUnion &att_union,unsign
                 unsigned int j;
                 if (check_min_value == true)
                 {
-                    for (i = 0;i < nb_data;i++)
+                    for (i = 0; i < nb_data; i++)
                     {
                         CORBA::ULong nb_data_elt = enc_seq[i].encoded_data.length();
-                        for (j = 0;j < nb_data_elt;j++)
+                        for (j = 0; j < nb_data_elt; j++)
                         {
                             if (enc_seq[i].encoded_data[j] < min_value.uch)
                             {
@@ -1824,19 +1850,19 @@ void WAttribute::check_written_value(const Tango::AttrValUnion &att_union,unsign
 
                                 o << "Set value for attribute " << name;
                                 o << " is below the minimum authorized (at least element " << i << ")" << ends;
-                                Except::throw_exception((const char *)API_WAttrOutsideLimit,
-                                            o.str(),
-                                            (const char *)"WAttribute::check_written_value()");
+                                Except::throw_exception((const char *) API_WAttrOutsideLimit,
+                                                        o.str(),
+                                                        (const char *) "WAttribute::check_written_value()");
                             }
                         }
                     }
                 }
                 if (check_max_value == true)
                 {
-                    for (i = 0;i < nb_data;i++)
+                    for (i = 0; i < nb_data; i++)
                     {
                         CORBA::ULong nb_data_elt = enc_seq[i].encoded_data.length();
-                        for (j = 0;j < nb_data_elt;j++)
+                        for (j = 0; j < nb_data_elt; j++)
                         {
                             if (enc_seq[i].encoded_data[j] > max_value.uch)
                             {
@@ -1844,31 +1870,31 @@ void WAttribute::check_written_value(const Tango::AttrValUnion &att_union,unsign
 
                                 o << "Set value for attribute " << name;
                                 o << " is above the maximum authorized (at least element " << i << ")" << ends;
-                                Except::throw_exception((const char *)API_WAttrOutsideLimit,
-                                             o.str(),
-                                            (const char *)"WAttribute::check_written_value()");
+                                Except::throw_exception((const char *) API_WAttrOutsideLimit,
+                                                        o.str(),
+                                                        (const char *) "WAttribute::check_written_value()");
                             }
                         }
                     }
                 }
             }
 
-			encoded_ptr = enc_seq.get_buffer();
-			if (data_format == Tango::SCALAR)
-			{
-				old_encoded_val = encoded_val;
-				encoded_val = enc_seq[0];
-				w_dim_x = 1;
-				w_dim_y = 0;
-			}
-			else
-			{
-				w_dim_x = x;
-				w_dim_y = y;
-			}
-		}
-		break;
-	}
+            encoded_ptr = enc_seq.get_buffer();
+            if (data_format == Tango::SCALAR)
+            {
+                old_encoded_val = encoded_val;
+                encoded_val = enc_seq[0];
+                w_dim_x = 1;
+                w_dim_y = 0;
+            }
+            else
+            {
+                w_dim_x = x;
+                w_dim_y = y;
+            }
+        }
+            break;
+    }
 
 }
 
@@ -1883,16 +1909,16 @@ void WAttribute::check_written_value(const Tango::AttrValUnion &att_union,unsign
 
 long WAttribute::get_write_value_length()
 {
-	long ret_val;
+    long ret_val;
 
-	if (data_format == Tango::SCALAR)
-		ret_val = 1;
-	else if (data_format == Tango::SPECTRUM)
-		ret_val = w_dim_x;
-	else
-		ret_val = w_dim_x * w_dim_y;
+    if (data_format == Tango::SCALAR)
+        ret_val = 1;
+    else if (data_format == Tango::SPECTRUM)
+        ret_val = w_dim_x;
+    else
+        ret_val = w_dim_x * w_dim_y;
 
-	return ret_val;
+    return ret_val;
 }
 
 
@@ -1911,549 +1937,549 @@ long WAttribute::get_write_value_length()
 
 void WAttribute::set_write_value(Tango::DevShort val)
 {
-	CORBA::Any tmp_any;
-	Tango::DevVarShortArray tmp_seq(1);
-	tmp_seq.length(1);
-	tmp_seq[0] = val;
+    CORBA::Any tmp_any;
+    Tango::DevVarShortArray tmp_seq(1);
+    tmp_seq.length(1);
+    tmp_seq[0] = val;
 
-	tmp_any <<= tmp_seq;
+    tmp_any <<= tmp_seq;
 
-	check_written_value(tmp_any,1,0);
-	copy_data(tmp_any);
-	set_user_set_write_value(true);
+    check_written_value(tmp_any, 1, 0);
+    copy_data(tmp_any);
+    set_user_set_write_value(true);
 }
 
 void WAttribute::set_write_value(Tango::DevShort *val, long x, long y)
 {
-	long nb_data;
+    long nb_data;
 
-	if (y == 0)
-		nb_data = x;
-	else
-		nb_data = x * y;
+    if (y == 0)
+        nb_data = x;
+    else
+        nb_data = x * y;
 
-	Tango::DevVarShortArray tmp_seq(nb_data,nb_data,val,false);
+    Tango::DevVarShortArray tmp_seq(nb_data, nb_data, val, false);
 
-	CORBA::Any 	tmp_any;
-	tmp_any <<= tmp_seq;
-	check_written_value(tmp_any, x, y);
-	copy_data(tmp_any);
-	set_user_set_write_value(true);
+    CORBA::Any tmp_any;
+    tmp_any <<= tmp_seq;
+    check_written_value(tmp_any, x, y);
+    copy_data(tmp_any);
+    set_user_set_write_value(true);
 }
 
 void WAttribute::set_write_value(vector<Tango::DevShort> &val, long x, long y)
 {
-	Tango::DevVarShortArray tmp_seq(val.size(),val.size(),&val[0],false);
+    Tango::DevVarShortArray tmp_seq(val.size(), val.size(), &val[0], false);
 
-	CORBA::Any 	tmp_any;
-	tmp_any <<= tmp_seq;
+    CORBA::Any tmp_any;
+    tmp_any <<= tmp_seq;
 
-	check_written_value(tmp_any, x, y);
-	copy_data(tmp_any);
-	set_user_set_write_value(true);
+    check_written_value(tmp_any, x, y);
+    copy_data(tmp_any);
+    set_user_set_write_value(true);
 }
 
 // DevLong:
 
 void WAttribute::set_write_value(Tango::DevLong val)
 {
-	Tango::DevVarLongArray tmp_seq(1);
-	tmp_seq.length(1);
-	tmp_seq[0] = val;
+    Tango::DevVarLongArray tmp_seq(1);
+    tmp_seq.length(1);
+    tmp_seq[0] = val;
 
-	CORBA::Any tmp_any;
-	tmp_any <<= tmp_seq;
+    CORBA::Any tmp_any;
+    tmp_any <<= tmp_seq;
 
-	check_written_value(tmp_any,1,0);
-	copy_data(tmp_any);
-	set_user_set_write_value(true);
+    check_written_value(tmp_any, 1, 0);
+    copy_data(tmp_any);
+    set_user_set_write_value(true);
 }
 
 void WAttribute::set_write_value(Tango::DevLong *val, long x, long y)
 {
-	long nb_data;
+    long nb_data;
 
-	if (y == 0)
-		nb_data = x;
-	else
-		nb_data = x * y;
+    if (y == 0)
+        nb_data = x;
+    else
+        nb_data = x * y;
 
-	Tango::DevVarLongArray tmp_seq(nb_data,nb_data,val,false);
+    Tango::DevVarLongArray tmp_seq(nb_data, nb_data, val, false);
 
-	CORBA::Any 	tmp_any;
-	tmp_any <<= tmp_seq;
-	check_written_value(tmp_any, x, y);
-	copy_data(tmp_any);
-	set_user_set_write_value(true);
+    CORBA::Any tmp_any;
+    tmp_any <<= tmp_seq;
+    check_written_value(tmp_any, x, y);
+    copy_data(tmp_any);
+    set_user_set_write_value(true);
 }
 
 void WAttribute::set_write_value(vector<Tango::DevLong> &val, long x, long y)
 {
-	Tango::DevVarLongArray tmp_seq(val.size(),val.size(),&val[0],false);
+    Tango::DevVarLongArray tmp_seq(val.size(), val.size(), &val[0], false);
 
-	CORBA::Any 	tmp_any;
-	tmp_any <<= tmp_seq;
+    CORBA::Any tmp_any;
+    tmp_any <<= tmp_seq;
 
-	check_written_value(tmp_any, x, y);
-	copy_data(tmp_any);
-	set_user_set_write_value(true);
+    check_written_value(tmp_any, x, y);
+    copy_data(tmp_any);
+    set_user_set_write_value(true);
 }
 
 // DevLong64:
 
 void WAttribute::set_write_value(Tango::DevLong64 val)
 {
-	Tango::DevVarLong64Array tmp_seq(1);
-	tmp_seq.length(1);
-	tmp_seq[0] = val;
+    Tango::DevVarLong64Array tmp_seq(1);
+    tmp_seq.length(1);
+    tmp_seq[0] = val;
 
-	CORBA::Any tmp_any;
-	tmp_any <<= tmp_seq;
-	check_written_value(tmp_any,1,0);
-	copy_data(tmp_any);
-	set_user_set_write_value(true);
+    CORBA::Any tmp_any;
+    tmp_any <<= tmp_seq;
+    check_written_value(tmp_any, 1, 0);
+    copy_data(tmp_any);
+    set_user_set_write_value(true);
 }
 
 void WAttribute::set_write_value(Tango::DevLong64 *val, long x, long y)
 {
-	long nb_data;
+    long nb_data;
 
-	if (y == 0)
-		nb_data = x;
-	else
-		nb_data = x * y;
+    if (y == 0)
+        nb_data = x;
+    else
+        nb_data = x * y;
 
-	Tango::DevVarLong64Array tmp_seq(nb_data, nb_data, val, false);
+    Tango::DevVarLong64Array tmp_seq(nb_data, nb_data, val, false);
 
-	CORBA::Any 	tmp_any;
-	tmp_any <<= tmp_seq;
-	check_written_value(tmp_any, x, y);
-	copy_data(tmp_any);
-	set_user_set_write_value(true);
+    CORBA::Any tmp_any;
+    tmp_any <<= tmp_seq;
+    check_written_value(tmp_any, x, y);
+    copy_data(tmp_any);
+    set_user_set_write_value(true);
 }
 
 void WAttribute::set_write_value(vector<Tango::DevLong64> &val, long x, long y)
 {
-	Tango::DevVarLong64Array tmp_seq(val.size(),val.size(),&val[0],false);
+    Tango::DevVarLong64Array tmp_seq(val.size(), val.size(), &val[0], false);
 
-	CORBA::Any 	tmp_any;
-	tmp_any <<= tmp_seq;
-	check_written_value(tmp_any, x, y);
-	copy_data(tmp_any);
-	set_user_set_write_value(true);
+    CORBA::Any tmp_any;
+    tmp_any <<= tmp_seq;
+    check_written_value(tmp_any, x, y);
+    copy_data(tmp_any);
+    set_user_set_write_value(true);
 }
 
 // DevDouble:
 
 void WAttribute::set_write_value(Tango::DevDouble val)
 {
-	Tango::DevVarDoubleArray tmp_seq(1);
-	tmp_seq.length(1);
-	tmp_seq[0] = val;
+    Tango::DevVarDoubleArray tmp_seq(1);
+    tmp_seq.length(1);
+    tmp_seq[0] = val;
 
-	CORBA::Any tmp_any;
-	tmp_any <<= tmp_seq;
-	check_written_value(tmp_any,1,0);
-	copy_data(tmp_any);
-	set_user_set_write_value(true);
+    CORBA::Any tmp_any;
+    tmp_any <<= tmp_seq;
+    check_written_value(tmp_any, 1, 0);
+    copy_data(tmp_any);
+    set_user_set_write_value(true);
 }
 
 void WAttribute::set_write_value(Tango::DevDouble *val, long x, long y)
 {
-	long nb_data;
+    long nb_data;
 
-	if (y == 0)
-		nb_data = x;
-	else
-		nb_data = x * y;
+    if (y == 0)
+        nb_data = x;
+    else
+        nb_data = x * y;
 
-	Tango::DevVarDoubleArray tmp_seq(nb_data,nb_data,val,false);
+    Tango::DevVarDoubleArray tmp_seq(nb_data, nb_data, val, false);
 
-	CORBA::Any 	tmp_any;
-	tmp_any <<= tmp_seq;
-	check_written_value(tmp_any, x, y);
-	copy_data(tmp_any);
-	set_user_set_write_value(true);
+    CORBA::Any tmp_any;
+    tmp_any <<= tmp_seq;
+    check_written_value(tmp_any, x, y);
+    copy_data(tmp_any);
+    set_user_set_write_value(true);
 }
 
 void WAttribute::set_write_value(vector<Tango::DevDouble> &val, long x, long y)
 {
-	CORBA::Any 	tmp_any;
-	Tango::DevVarDoubleArray tmp_seq(val.size(),val.size(),&val[0],false);
+    CORBA::Any tmp_any;
+    Tango::DevVarDoubleArray tmp_seq(val.size(), val.size(), &val[0], false);
 
-	tmp_any <<= tmp_seq;
-	check_written_value(tmp_any, x, y);
-	copy_data(tmp_any);
-	set_user_set_write_value(true);
+    tmp_any <<= tmp_seq;
+    check_written_value(tmp_any, x, y);
+    copy_data(tmp_any);
+    set_user_set_write_value(true);
 }
 
 // DevString:
 
 void WAttribute::set_write_value(Tango::DevString val)
 {
-	Tango::DevVarStringArray tmp_seq(1);
-	tmp_seq.length(1);
-	tmp_seq[0] = CORBA::string_dup(val);
+    Tango::DevVarStringArray tmp_seq(1);
+    tmp_seq.length(1);
+    tmp_seq[0] = CORBA::string_dup(val);
 
-	CORBA::Any tmp_any;
-	tmp_any <<= tmp_seq;
-	check_written_value(tmp_any,1,0);
-	copy_data(tmp_any);
-	set_user_set_write_value(true);
+    CORBA::Any tmp_any;
+    tmp_any <<= tmp_seq;
+    check_written_value(tmp_any, 1, 0);
+    copy_data(tmp_any);
+    set_user_set_write_value(true);
 }
 
 void WAttribute::set_write_value(string &val)
 {
-	Tango::DevVarStringArray tmp_seq(1);
-	tmp_seq.length(1);
-	tmp_seq[0] = val.c_str();
+    Tango::DevVarStringArray tmp_seq(1);
+    tmp_seq.length(1);
+    tmp_seq[0] = val.c_str();
 
-	CORBA::Any tmp_any;
-	tmp_any <<= tmp_seq;
-	check_written_value(tmp_any,1,0);
-	copy_data(tmp_any);
-	set_user_set_write_value(true);
+    CORBA::Any tmp_any;
+    tmp_any <<= tmp_seq;
+    check_written_value(tmp_any, 1, 0);
+    copy_data(tmp_any);
+    set_user_set_write_value(true);
 }
 
 void WAttribute::set_write_value(Tango::DevString *val, long x, long y)
 {
-	long nb_data;
+    long nb_data;
 
-	if (y == 0)
-		nb_data = x;
-	else
-		nb_data = x * y;
+    if (y == 0)
+        nb_data = x;
+    else
+        nb_data = x * y;
 
-	Tango::DevVarStringArray tmp_seq(nb_data,nb_data,val,false);
+    Tango::DevVarStringArray tmp_seq(nb_data, nb_data, val, false);
 
-	CORBA::Any tmp_any;
-	tmp_any <<= tmp_seq;
-	check_written_value(tmp_any, x, y);
-	copy_data(tmp_any);
-	set_user_set_write_value(true);
+    CORBA::Any tmp_any;
+    tmp_any <<= tmp_seq;
+    check_written_value(tmp_any, x, y);
+    copy_data(tmp_any);
+    set_user_set_write_value(true);
 }
 
 void WAttribute::set_write_value(vector<string> &val, long x, long y)
 {
-	Tango::DevVarStringArray tmp_seq;
-	tmp_seq << val;
+    Tango::DevVarStringArray tmp_seq;
+    tmp_seq << val;
 
-	CORBA::Any tmp_any;
-	tmp_any <<= tmp_seq;
-	check_written_value(tmp_any, x, y);
-	copy_data(tmp_any);
-	set_user_set_write_value(true);
+    CORBA::Any tmp_any;
+    tmp_any <<= tmp_seq;
+    check_written_value(tmp_any, x, y);
+    copy_data(tmp_any);
+    set_user_set_write_value(true);
 }
 
 // DevFloat:
 
 void WAttribute::set_write_value(Tango::DevFloat val)
 {
-	Tango::DevVarFloatArray tmp_seq(1);
-	tmp_seq.length(1);
-	tmp_seq[0] = val;
+    Tango::DevVarFloatArray tmp_seq(1);
+    tmp_seq.length(1);
+    tmp_seq[0] = val;
 
-	CORBA::Any tmp_any;
-	tmp_any <<= tmp_seq;
-	check_written_value(tmp_any,1,0);
-	copy_data(tmp_any);
-	set_user_set_write_value(true);
+    CORBA::Any tmp_any;
+    tmp_any <<= tmp_seq;
+    check_written_value(tmp_any, 1, 0);
+    copy_data(tmp_any);
+    set_user_set_write_value(true);
 }
 
 void WAttribute::set_write_value(Tango::DevFloat *val, long x, long y)
 {
-	long nb_data;
+    long nb_data;
 
-	if (y == 0)
-		nb_data = x;
-	else
-		nb_data = x * y;
+    if (y == 0)
+        nb_data = x;
+    else
+        nb_data = x * y;
 
-	Tango::DevVarFloatArray tmp_seq(nb_data,nb_data,val,false);
-	CORBA::Any tmp_any;
-	tmp_any <<= tmp_seq;
-	check_written_value(tmp_any, x, y);
-	copy_data(tmp_any);
-	set_user_set_write_value(true);
+    Tango::DevVarFloatArray tmp_seq(nb_data, nb_data, val, false);
+    CORBA::Any tmp_any;
+    tmp_any <<= tmp_seq;
+    check_written_value(tmp_any, x, y);
+    copy_data(tmp_any);
+    set_user_set_write_value(true);
 }
 
 void WAttribute::set_write_value(vector<Tango::DevFloat> &val, long x, long y)
 {
-	Tango::DevVarFloatArray tmp_seq(val.size(),val.size(),&val[0],false);
+    Tango::DevVarFloatArray tmp_seq(val.size(), val.size(), &val[0], false);
 
-	CORBA::Any tmp_any;
-	tmp_any <<= tmp_seq;
-	check_written_value(tmp_any, x, y);
-	copy_data(tmp_any);
-	set_user_set_write_value(true);
+    CORBA::Any tmp_any;
+    tmp_any <<= tmp_seq;
+    check_written_value(tmp_any, x, y);
+    copy_data(tmp_any);
+    set_user_set_write_value(true);
 }
 
 // DevBoolean:
 
 void WAttribute::set_write_value(Tango::DevBoolean val)
 {
-	Tango::DevVarBooleanArray tmp_seq(1);
-	tmp_seq.length(1);
-	tmp_seq[0] = val;
+    Tango::DevVarBooleanArray tmp_seq(1);
+    tmp_seq.length(1);
+    tmp_seq[0] = val;
 
-	CORBA::Any tmp_any;
-	tmp_any <<= tmp_seq;
-	check_written_value(tmp_any,1,0);
-	copy_data(tmp_any);
-	set_user_set_write_value(true);
+    CORBA::Any tmp_any;
+    tmp_any <<= tmp_seq;
+    check_written_value(tmp_any, 1, 0);
+    copy_data(tmp_any);
+    set_user_set_write_value(true);
 }
 
 void WAttribute::set_write_value(Tango::DevBoolean *val, long x, long y)
 {
-	long nb_data;
+    long nb_data;
 
-	if (y == 0)
-		nb_data = x;
-	else
-		nb_data = x * y;
+    if (y == 0)
+        nb_data = x;
+    else
+        nb_data = x * y;
 
-	Tango::DevVarBooleanArray tmp_seq(nb_data,nb_data,val,false);
+    Tango::DevVarBooleanArray tmp_seq(nb_data, nb_data, val, false);
 
-	CORBA::Any tmp_any;
-	tmp_any <<= tmp_seq;
-	check_written_value(tmp_any, x, y);
-	copy_data(tmp_any);
-	set_user_set_write_value(true);
+    CORBA::Any tmp_any;
+    tmp_any <<= tmp_seq;
+    check_written_value(tmp_any, x, y);
+    copy_data(tmp_any);
+    set_user_set_write_value(true);
 }
 
 void WAttribute::set_write_value(vector<Tango::DevBoolean> &val, long x, long y)
 {
-	Tango::DevVarBooleanArray tmp_seq;
-	tmp_seq << val;
+    Tango::DevVarBooleanArray tmp_seq;
+    tmp_seq << val;
 
-	CORBA::Any tmp_any;
-	tmp_any <<= tmp_seq;
-	check_written_value(tmp_any, x, y);
-	copy_data(tmp_any);
-	set_user_set_write_value(true);
+    CORBA::Any tmp_any;
+    tmp_any <<= tmp_seq;
+    check_written_value(tmp_any, x, y);
+    copy_data(tmp_any);
+    set_user_set_write_value(true);
 }
 
 // DevUShort:
 
 void WAttribute::set_write_value(Tango::DevUShort val)
 {
-	Tango::DevVarUShortArray tmp_seq(1);
-	tmp_seq.length(1);
-	tmp_seq[0] = val;
+    Tango::DevVarUShortArray tmp_seq(1);
+    tmp_seq.length(1);
+    tmp_seq[0] = val;
 
-	CORBA::Any tmp_any;
-	tmp_any <<= tmp_seq;
-	check_written_value(tmp_any,1,0);
-	copy_data(tmp_any);
-	set_user_set_write_value(true);
+    CORBA::Any tmp_any;
+    tmp_any <<= tmp_seq;
+    check_written_value(tmp_any, 1, 0);
+    copy_data(tmp_any);
+    set_user_set_write_value(true);
 }
 
 void WAttribute::set_write_value(Tango::DevUShort *val, long x, long y)
 {
-	long nb_data;
+    long nb_data;
 
-	if (y == 0)
-		nb_data = x;
-	else
-		nb_data = x * y;
+    if (y == 0)
+        nb_data = x;
+    else
+        nb_data = x * y;
 
-	Tango::DevVarUShortArray tmp_seq(nb_data,nb_data,val,false);
+    Tango::DevVarUShortArray tmp_seq(nb_data, nb_data, val, false);
 
-	CORBA::Any tmp_any;
-	tmp_any <<= tmp_seq;
-	check_written_value(tmp_any, x, y);
-	copy_data(tmp_any);
-	set_user_set_write_value(true);
+    CORBA::Any tmp_any;
+    tmp_any <<= tmp_seq;
+    check_written_value(tmp_any, x, y);
+    copy_data(tmp_any);
+    set_user_set_write_value(true);
 }
 
 void WAttribute::set_write_value(vector<Tango::DevUShort> &val, long x, long y)
 {
-	Tango::DevVarUShortArray tmp_seq(val.size(),val.size(),&val[0],false);
+    Tango::DevVarUShortArray tmp_seq(val.size(), val.size(), &val[0], false);
 
-	CORBA::Any tmp_any;
-	tmp_any <<= tmp_seq;
-	check_written_value(tmp_any, x, y);
-	copy_data(tmp_any);
-	set_user_set_write_value(true);
+    CORBA::Any tmp_any;
+    tmp_any <<= tmp_seq;
+    check_written_value(tmp_any, x, y);
+    copy_data(tmp_any);
+    set_user_set_write_value(true);
 }
 
 // DevUChar:
 
 void WAttribute::set_write_value(Tango::DevUChar val)
 {
-	Tango::DevVarCharArray tmp_seq(1);
-	tmp_seq.length(1);
-	tmp_seq[0] = val;
+    Tango::DevVarCharArray tmp_seq(1);
+    tmp_seq.length(1);
+    tmp_seq[0] = val;
 
-	CORBA::Any tmp_any;
-	tmp_any <<= tmp_seq;
-	check_written_value(tmp_any,1,0);
-	copy_data(tmp_any);
-	set_user_set_write_value(true);
+    CORBA::Any tmp_any;
+    tmp_any <<= tmp_seq;
+    check_written_value(tmp_any, 1, 0);
+    copy_data(tmp_any);
+    set_user_set_write_value(true);
 }
 
 void WAttribute::set_write_value(Tango::DevUChar *val, long x, long y)
 {
-	long nb_data;
+    long nb_data;
 
-	if (y == 0)
-		nb_data = x;
-	else
-		nb_data = x * y;
+    if (y == 0)
+        nb_data = x;
+    else
+        nb_data = x * y;
 
-	Tango::DevVarUCharArray tmp_seq(nb_data,nb_data,val,false);
+    Tango::DevVarUCharArray tmp_seq(nb_data, nb_data, val, false);
 
-	CORBA::Any tmp_any;
-	tmp_any <<= tmp_seq;
-	check_written_value(tmp_any, x, y);
-	copy_data(tmp_any);
-	set_user_set_write_value(true);
+    CORBA::Any tmp_any;
+    tmp_any <<= tmp_seq;
+    check_written_value(tmp_any, x, y);
+    copy_data(tmp_any);
+    set_user_set_write_value(true);
 }
 
 void WAttribute::set_write_value(vector<Tango::DevUChar> &val, long x, long y)
 {
-	Tango::DevVarUCharArray tmp_seq(val.size(),val.size(),&val[0],false);
+    Tango::DevVarUCharArray tmp_seq(val.size(), val.size(), &val[0], false);
 
-	CORBA::Any tmp_any;
-	tmp_any <<= tmp_seq;
-	check_written_value(tmp_any, x, y);
-	copy_data(tmp_any);
-	set_user_set_write_value(true);
+    CORBA::Any tmp_any;
+    tmp_any <<= tmp_seq;
+    check_written_value(tmp_any, x, y);
+    copy_data(tmp_any);
+    set_user_set_write_value(true);
 }
 
 // DevULong:
 
 void WAttribute::set_write_value(Tango::DevULong val)
 {
-	Tango::DevVarULongArray tmp_seq(1);
-	tmp_seq.length(1);
-	tmp_seq[0] = val;
+    Tango::DevVarULongArray tmp_seq(1);
+    tmp_seq.length(1);
+    tmp_seq[0] = val;
 
-	CORBA::Any tmp_any;
-	tmp_any <<= tmp_seq;
-	check_written_value(tmp_any,1,0);
-	copy_data(tmp_any);
-	set_user_set_write_value(true);
+    CORBA::Any tmp_any;
+    tmp_any <<= tmp_seq;
+    check_written_value(tmp_any, 1, 0);
+    copy_data(tmp_any);
+    set_user_set_write_value(true);
 }
 
 void WAttribute::set_write_value(Tango::DevULong *val, long x, long y)
 {
-	long nb_data;
+    long nb_data;
 
-	if (y == 0)
-		nb_data = x;
-	else
-		nb_data = x * y;
+    if (y == 0)
+        nb_data = x;
+    else
+        nb_data = x * y;
 
-	Tango::DevVarULongArray tmp_seq(nb_data,nb_data,val,false);
+    Tango::DevVarULongArray tmp_seq(nb_data, nb_data, val, false);
 
-	CORBA::Any tmp_any;
-	tmp_any <<= tmp_seq;
-	check_written_value(tmp_any, x, y);
-	copy_data(tmp_any);
-	set_user_set_write_value(true);
+    CORBA::Any tmp_any;
+    tmp_any <<= tmp_seq;
+    check_written_value(tmp_any, x, y);
+    copy_data(tmp_any);
+    set_user_set_write_value(true);
 }
 
 void WAttribute::set_write_value(vector<Tango::DevULong> &val, long x, long y)
 {
-	Tango::DevVarULongArray tmp_seq(val.size(),val.size(),&val[0],false);
+    Tango::DevVarULongArray tmp_seq(val.size(), val.size(), &val[0], false);
 
-	CORBA::Any tmp_any;
-	tmp_any <<= tmp_seq;
-	check_written_value(tmp_any, x, y);
-	copy_data(tmp_any);
-	set_user_set_write_value(true);
+    CORBA::Any tmp_any;
+    tmp_any <<= tmp_seq;
+    check_written_value(tmp_any, x, y);
+    copy_data(tmp_any);
+    set_user_set_write_value(true);
 }
 
 // DevULong64:
 
 void WAttribute::set_write_value(Tango::DevULong64 val)
 {
-	Tango::DevVarULong64Array tmp_seq(1);
-	tmp_seq.length(1);
-	tmp_seq[0] = val;
+    Tango::DevVarULong64Array tmp_seq(1);
+    tmp_seq.length(1);
+    tmp_seq[0] = val;
 
-	CORBA::Any tmp_any;
-	tmp_any <<= tmp_seq;
-	check_written_value(tmp_any,1,0);
-	copy_data(tmp_any);
-	set_user_set_write_value(true);
+    CORBA::Any tmp_any;
+    tmp_any <<= tmp_seq;
+    check_written_value(tmp_any, 1, 0);
+    copy_data(tmp_any);
+    set_user_set_write_value(true);
 }
 
 void WAttribute::set_write_value(Tango::DevULong64 *val, long x, long y)
 {
-	long nb_data;
+    long nb_data;
 
-	if (y == 0)
-		nb_data = x;
-	else
-		nb_data = x * y;
+    if (y == 0)
+        nb_data = x;
+    else
+        nb_data = x * y;
 
-	Tango::DevVarULong64Array tmp_seq(nb_data,nb_data,val,false);
+    Tango::DevVarULong64Array tmp_seq(nb_data, nb_data, val, false);
 
-	CORBA::Any tmp_any;
-	tmp_any <<= tmp_seq;
-	check_written_value(tmp_any, x, y);
-	copy_data(tmp_any);
-	set_user_set_write_value(true);
+    CORBA::Any tmp_any;
+    tmp_any <<= tmp_seq;
+    check_written_value(tmp_any, x, y);
+    copy_data(tmp_any);
+    set_user_set_write_value(true);
 }
 
 void WAttribute::set_write_value(vector<Tango::DevULong64> &val, long x, long y)
 {
-	Tango::DevVarULong64Array tmp_seq(val.size(),val.size(),&val[0],false);
+    Tango::DevVarULong64Array tmp_seq(val.size(), val.size(), &val[0], false);
 
-	CORBA::Any tmp_any;
-	tmp_any <<= tmp_seq;
-	check_written_value(tmp_any, x, y);
-	copy_data(tmp_any);
-	set_user_set_write_value(true);
+    CORBA::Any tmp_any;
+    tmp_any <<= tmp_seq;
+    check_written_value(tmp_any, x, y);
+    copy_data(tmp_any);
+    set_user_set_write_value(true);
 }
 
 // DevState:
 
 void WAttribute::set_write_value(Tango::DevState val)
 {
-	Tango::DevVarStateArray tmp_seq(1);
-	tmp_seq.length(1);
-	tmp_seq[0] = val;
+    Tango::DevVarStateArray tmp_seq(1);
+    tmp_seq.length(1);
+    tmp_seq[0] = val;
 
-	CORBA::Any tmp_any;
-	tmp_any <<= tmp_seq;
-	check_written_value(tmp_any,1,0);
-	copy_data(tmp_any);
-	set_user_set_write_value(true);
+    CORBA::Any tmp_any;
+    tmp_any <<= tmp_seq;
+    check_written_value(tmp_any, 1, 0);
+    copy_data(tmp_any);
+    set_user_set_write_value(true);
 }
 
 void WAttribute::set_write_value(Tango::DevState *val, long x, long y)
 {
-	long nb_data;
+    long nb_data;
 
-	if (y == 0)
-		nb_data = x;
-	else
-		nb_data = x * y;
+    if (y == 0)
+        nb_data = x;
+    else
+        nb_data = x * y;
 
-	Tango::DevVarStateArray tmp_seq(nb_data,nb_data,val,false);
+    Tango::DevVarStateArray tmp_seq(nb_data, nb_data, val, false);
 
-	CORBA::Any tmp_any;
-	tmp_any <<= tmp_seq;
-	check_written_value(tmp_any, x, y);
-	copy_data(tmp_any);
-	set_user_set_write_value(true);
+    CORBA::Any tmp_any;
+    tmp_any <<= tmp_seq;
+    check_written_value(tmp_any, x, y);
+    copy_data(tmp_any);
+    set_user_set_write_value(true);
 }
 
 void WAttribute::set_write_value(vector<Tango::DevState> &val, long x, long y)
 {
-	Tango::DevVarStateArray tmp_seq(val.size(),val.size(),&val[0],false);
+    Tango::DevVarStateArray tmp_seq(val.size(), val.size(), &val[0], false);
 
-	CORBA::Any tmp_any;
-	tmp_any <<= tmp_seq;
-	check_written_value(tmp_any, x, y);
-	copy_data(tmp_any);
-	set_user_set_write_value(true);
+    CORBA::Any tmp_any;
+    tmp_any <<= tmp_seq;
+    check_written_value(tmp_any, x, y);
+    copy_data(tmp_any);
+    set_user_set_write_value(true);
 }
 
-void WAttribute::set_write_value(Tango::DevEncoded *, TANGO_UNUSED(long x),TANGO_UNUSED(long y))
+void WAttribute::set_write_value(Tango::DevEncoded *, TANGO_UNUSED(long x), TANGO_UNUSED(long y))
 {
 
 //
@@ -2462,9 +2488,9 @@ void WAttribute::set_write_value(Tango::DevEncoded *, TANGO_UNUSED(long x),TANGO
 // Should never be called
 //
 
-	Tango::Except::throw_exception((const char *)API_NotSupportedFeature,
-								  (const char *)"This is a not supported call in case of DevEncoded attribute",
-								  (const char *)"Wattribute::set_write_value()");
+    Tango::Except::throw_exception((const char *) API_NotSupportedFeature,
+                                   (const char *) "This is a not supported call in case of DevEncoded attribute",
+                                   (const char *) "Wattribute::set_write_value()");
 }
 
 //+-------------------------------------------------------------------------
@@ -2479,58 +2505,58 @@ void WAttribute::set_write_value(Tango::DevEncoded *, TANGO_UNUSED(long x),TANGO
 
 void WAttribute::rollback()
 {
-	switch (data_type)
-	{
-	case Tango::DEV_SHORT :
-	case Tango::DEV_ENUM :
-		short_val = old_short_val;
-		break;
+    switch (data_type)
+    {
+        case Tango::DEV_SHORT :
+        case Tango::DEV_ENUM :
+            short_val = old_short_val;
+            break;
 
-	case Tango::DEV_LONG :
-		long_val = old_long_val;
-		break;
+        case Tango::DEV_LONG :
+            long_val = old_long_val;
+            break;
 
-	case Tango::DEV_LONG64 :
-		long64_val = old_long64_val;
-		break;
+        case Tango::DEV_LONG64 :
+            long64_val = old_long64_val;
+            break;
 
-	case Tango::DEV_DOUBLE :
-		double_val = old_double_val;
-		break;
+        case Tango::DEV_DOUBLE :
+            double_val = old_double_val;
+            break;
 
-	case Tango::DEV_STRING :
-		CORBA::string_free(str_val);
-		str_val = CORBA::string_dup(old_str_val);
-		break;
+        case Tango::DEV_STRING :
+            CORBA::string_free(str_val);
+            str_val = CORBA::string_dup(old_str_val);
+            break;
 
-	case Tango::DEV_FLOAT :
-		float_val = old_float_val;
-		break;
+        case Tango::DEV_FLOAT :
+            float_val = old_float_val;
+            break;
 
-	case Tango::DEV_BOOLEAN :
-		boolean_val = old_boolean_val;
-		break;
+        case Tango::DEV_BOOLEAN :
+            boolean_val = old_boolean_val;
+            break;
 
-	case Tango::DEV_USHORT :
-		double_val = old_double_val;
-		break;
+        case Tango::DEV_USHORT :
+            double_val = old_double_val;
+            break;
 
-	case Tango::DEV_UCHAR :
-		CORBA::string_free(str_val);
-		break;
+        case Tango::DEV_UCHAR :
+            CORBA::string_free(str_val);
+            break;
 
-	case Tango::DEV_ULONG :
-		ulong_val = old_ulong_val;
-		break;
+        case Tango::DEV_ULONG :
+            ulong_val = old_ulong_val;
+            break;
 
-	case Tango::DEV_ULONG64 :
-		ulong64_val = old_ulong64_val;
-		break;
+        case Tango::DEV_ULONG64 :
+            ulong64_val = old_ulong64_val;
+            break;
 
-	case Tango::DEV_STATE :
-		dev_state_val = old_dev_state_val;
-		break;
-	}
+        case Tango::DEV_STATE :
+            dev_state_val = old_dev_state_val;
+            break;
+    }
 }
 
 //+-------------------------------------------------------------------------
@@ -2546,137 +2572,136 @@ void WAttribute::rollback()
 
 void WAttribute::copy_data(const CORBA::Any &any)
 {
-	switch (data_type)
-	{
-	case Tango::DEV_SHORT :
-	case Tango::DEV_ENUM :
-		const Tango::DevVarShortArray *sh_ptr;
-		any >>= sh_ptr;
-		short_array_val = *sh_ptr;
-		break;
+    switch (data_type)
+    {
+        case Tango::DEV_SHORT :
+        case Tango::DEV_ENUM :
+            const Tango::DevVarShortArray *sh_ptr;
+            any >>= sh_ptr;
+            short_array_val = *sh_ptr;
+            break;
 
-	case Tango::DEV_LONG :
-		const Tango::DevVarLongArray *lo_ptr;
-		any >>= lo_ptr;
-		long_array_val = *lo_ptr;
-		break;
+        case Tango::DEV_LONG :
+            const Tango::DevVarLongArray *lo_ptr;
+            any >>= lo_ptr;
+            long_array_val = *lo_ptr;
+            break;
 
-	case Tango::DEV_LONG64 :
-		const Tango::DevVarLong64Array *lo64_ptr;
-		any >>= lo64_ptr;
-		long64_array_val = *lo64_ptr;
-		break;
+        case Tango::DEV_LONG64 :
+            const Tango::DevVarLong64Array *lo64_ptr;
+            any >>= lo64_ptr;
+            long64_array_val = *lo64_ptr;
+            break;
 
-	case Tango::DEV_DOUBLE :
-		const Tango::DevVarDoubleArray *db_ptr;
-		any >>= db_ptr;
-		double_array_val = *db_ptr;
-		break;
+        case Tango::DEV_DOUBLE :
+            const Tango::DevVarDoubleArray *db_ptr;
+            any >>= db_ptr;
+            double_array_val = *db_ptr;
+            break;
 
-	case Tango::DEV_STRING :
-		const Tango::DevVarStringArray *tmp_str_ptr;
-		any >>= tmp_str_ptr;
-		str_array_val = *tmp_str_ptr;
-		break;
+        case Tango::DEV_STRING :
+            const Tango::DevVarStringArray *tmp_str_ptr;
+            any >>= tmp_str_ptr;
+            str_array_val = *tmp_str_ptr;
+            break;
 
-	case Tango::DEV_FLOAT :
-		const Tango::DevVarFloatArray *fl_ptr;
-		any >>= fl_ptr;
-		float_array_val = *fl_ptr;
-		break;
+        case Tango::DEV_FLOAT :
+            const Tango::DevVarFloatArray *fl_ptr;
+            any >>= fl_ptr;
+            float_array_val = *fl_ptr;
+            break;
 
-	case Tango::DEV_BOOLEAN :
-		const Tango::DevVarBooleanArray *boo_ptr;
-		any >>= boo_ptr;
-		boolean_array_val = *boo_ptr;
-		break;
+        case Tango::DEV_BOOLEAN :
+            const Tango::DevVarBooleanArray *boo_ptr;
+            any >>= boo_ptr;
+            boolean_array_val = *boo_ptr;
+            break;
 
-	case Tango::DEV_USHORT :
-		const Tango::DevVarUShortArray *ush_ptr;
-		any >>= ush_ptr;
-		ushort_array_val = *ush_ptr;
-		break;
+        case Tango::DEV_USHORT :
+            const Tango::DevVarUShortArray *ush_ptr;
+            any >>= ush_ptr;
+            ushort_array_val = *ush_ptr;
+            break;
 
-	case Tango::DEV_UCHAR :
-		const Tango::DevVarCharArray *uch_ptr;
-		any >>= uch_ptr;
-		uchar_array_val = *uch_ptr;
-		break;
+        case Tango::DEV_UCHAR :
+            const Tango::DevVarCharArray *uch_ptr;
+            any >>= uch_ptr;
+            uchar_array_val = *uch_ptr;
+            break;
 
-	case Tango::DEV_ULONG :
-		const Tango::DevVarULongArray *ulo_ptr;
-		any >>= ulo_ptr;
-		ulong_array_val = *ulo_ptr;
-		break;
+        case Tango::DEV_ULONG :
+            const Tango::DevVarULongArray *ulo_ptr;
+            any >>= ulo_ptr;
+            ulong_array_val = *ulo_ptr;
+            break;
 
-	case Tango::DEV_ULONG64 :
-		const Tango::DevVarULong64Array *ulo64_ptr;
-		any >>= ulo64_ptr;
-		ulong64_array_val = *ulo64_ptr;
-		break;
+        case Tango::DEV_ULONG64 :
+            const Tango::DevVarULong64Array *ulo64_ptr;
+            any >>= ulo64_ptr;
+            ulong64_array_val = *ulo64_ptr;
+            break;
 
-	case Tango::DEV_STATE :
-		const Tango::DevVarStateArray *sta_ptr;
-		any >>= sta_ptr;
-		state_array_val = *sta_ptr;
-		break;
-	}
+        case Tango::DEV_STATE :
+            const Tango::DevVarStateArray *sta_ptr;
+            any >>= sta_ptr;
+            state_array_val = *sta_ptr;
+            break;
+    }
 }
-
 
 void WAttribute::copy_data(const Tango::AttrValUnion &the_union)
 {
-	switch (data_type)
-	{
-	case Tango::DEV_SHORT :
-	case Tango::DEV_ENUM :
-		short_array_val = the_union.short_att_value();
-		break;
+    switch (data_type)
+    {
+        case Tango::DEV_SHORT :
+        case Tango::DEV_ENUM :
+            short_array_val = the_union.short_att_value();
+            break;
 
-	case Tango::DEV_LONG :
-		long_array_val = the_union.long_att_value();
-		break;
+        case Tango::DEV_LONG :
+            long_array_val = the_union.long_att_value();
+            break;
 
-	case Tango::DEV_LONG64 :
-		long64_array_val = the_union.long64_att_value();
-		break;
+        case Tango::DEV_LONG64 :
+            long64_array_val = the_union.long64_att_value();
+            break;
 
-	case Tango::DEV_DOUBLE :
-		double_array_val = the_union.double_att_value();
-		break;
+        case Tango::DEV_DOUBLE :
+            double_array_val = the_union.double_att_value();
+            break;
 
-	case Tango::DEV_STRING :
-		str_array_val = the_union.string_att_value();
-		break;
+        case Tango::DEV_STRING :
+            str_array_val = the_union.string_att_value();
+            break;
 
-	case Tango::DEV_FLOAT :
-		float_array_val = the_union.float_att_value();
-		break;
+        case Tango::DEV_FLOAT :
+            float_array_val = the_union.float_att_value();
+            break;
 
-	case Tango::DEV_BOOLEAN :
-		boolean_array_val = the_union.bool_att_value();
-		break;
+        case Tango::DEV_BOOLEAN :
+            boolean_array_val = the_union.bool_att_value();
+            break;
 
-	case Tango::DEV_USHORT :
-		ushort_array_val = the_union.ushort_att_value();
-		break;
+        case Tango::DEV_USHORT :
+            ushort_array_val = the_union.ushort_att_value();
+            break;
 
-	case Tango::DEV_UCHAR :
-		uchar_array_val = the_union.uchar_att_value();
-		break;
+        case Tango::DEV_UCHAR :
+            uchar_array_val = the_union.uchar_att_value();
+            break;
 
-	case Tango::DEV_ULONG :
-		ulong_array_val = the_union.ulong_att_value();
-		break;
+        case Tango::DEV_ULONG :
+            ulong_array_val = the_union.ulong_att_value();
+            break;
 
-	case Tango::DEV_ULONG64 :
-		ulong64_array_val = the_union.ulong64_att_value();
-		break;
+        case Tango::DEV_ULONG64 :
+            ulong64_array_val = the_union.ulong64_att_value();
+            break;
 
-	case Tango::DEV_STATE :
-		state_array_val = the_union.state_att_value();
-		break;
-	}
+        case Tango::DEV_STATE :
+            state_array_val = the_union.state_att_value();
+            break;
+    }
 }
 //+-------------------------------------------------------------------------
 //
@@ -2689,18 +2714,18 @@ void WAttribute::copy_data(const Tango::AttrValUnion &the_union)
 void WAttribute::set_written_date()
 {
 #ifdef _TG_WINDOWS_
-	struct _timeb t;
-	_ftime(&t);
+    struct _timeb t;
+    _ftime(&t);
 
-	write_date.tv_sec = (CORBA::Long)t.time;
-	write_date.tv_usec = (CORBA::Long)(t.millitm * 1000);
+    write_date.tv_sec = (CORBA::Long)t.time;
+    write_date.tv_usec = (CORBA::Long)(t.millitm * 1000);
 #else
-	struct timezone tz;
-	struct timeval tv;
-	gettimeofday(&tv,&tz);
+    struct timezone tz;
+    struct timeval tv;
+    gettimeofday(&tv, &tz);
 
-	write_date.tv_sec = (CORBA::Long)tv.tv_sec;
-	write_date.tv_usec = (CORBA::Long)tv.tv_usec;
+    write_date.tv_sec = (CORBA::Long) tv.tv_sec;
+    write_date.tv_usec = (CORBA::Long) tv.tv_usec;
 #endif
 }
 
@@ -2718,334 +2743,346 @@ void WAttribute::set_written_date()
 
 bool WAttribute::check_rds_alarm()
 {
-	bool ret = false;
+    bool ret = false;
 
 //
 // Return immediately if the attribute has never been written
 //
 
-	if (write_date.tv_sec == 0)
-		return false;
+    if (write_date.tv_sec == 0)
+        return false;
 
 //
 // First, check if it is necessary to check attribute value
 // Give some time to the device to change its output
 //
 
-	struct timeval tv;
+    struct timeval tv;
 #ifdef _TG_WINDOWS_
-	struct _timeb t;
-	_ftime(&t);
+    struct _timeb t;
+    _ftime(&t);
 
-	tv.tv_sec = (CORBA::Long)t.time;
-	tv.tv_usec = (CORBA::Long)(t.millitm * 1000);
+    tv.tv_sec = (CORBA::Long)t.time;
+    tv.tv_usec = (CORBA::Long)(t.millitm * 1000);
 #else
-	struct timezone tz;
-	gettimeofday(&tv,&tz);
+    struct timezone tz;
+    gettimeofday(&tv, &tz);
 #endif
 
-	long time_diff;
-	COMPUTE_TIME_DIFF(time_diff,write_date,tv);
+    long time_diff;
+    COMPUTE_TIME_DIFF(time_diff, write_date, tv);
 
-	if (time_diff >= delta_t)
-	{
+    if (time_diff >= delta_t)
+    {
 
 //
 // Now check attribute value with again a switch on attribute data type
 //
 
-		long nb_written,nb_read,nb_data,i;
+        long nb_written, nb_read, nb_data, i;
 
-		switch (data_type)
-		{
-		case Tango::DEV_SHORT:
-			nb_written = short_array_val.length();
-			nb_read = (data_format == Tango::SCALAR) ? 1 : value.sh_seq->length();
-			nb_data = (nb_written > nb_read) ? nb_read : nb_written;
-			for (i = 0;i < nb_data;i++)
-			{
-				short delta = (data_format == Tango::SCALAR) ? short_array_val[0] - tmp_sh[0] : short_array_val[i] - (*value.sh_seq)[i];
-				if (abs(delta) >= delta_val.sh)
-				{
-					quality = Tango::ATTR_ALARM;
-					alarm.set(rds);
-					ret = true;
-					break;
-				}
-			}
-			break;
+        switch (data_type)
+        {
+            case Tango::DEV_SHORT:
+                nb_written = short_array_val.length();
+                nb_read = (data_format == Tango::SCALAR) ? 1 : value.sh_seq->length();
+                nb_data = (nb_written > nb_read) ? nb_read : nb_written;
+                for (i = 0; i < nb_data; i++)
+                {
+                    short delta = (data_format == Tango::SCALAR) ? short_array_val[0] - tmp_sh[0] : short_array_val[i]
+                        - (*value.sh_seq)[i];
+                    if (abs(delta) >= delta_val.sh)
+                    {
+                        quality = Tango::ATTR_ALARM;
+                        alarm.set(rds);
+                        ret = true;
+                        break;
+                    }
+                }
+                break;
 
-		case Tango::DEV_LONG:
-			nb_written = long_array_val.length();
-			nb_read = (data_format == Tango::SCALAR) ? 1 : value.lg_seq->length();
-			nb_data = (nb_written > nb_read) ? nb_read : nb_written;
-			for (i = 0;i < nb_data;i++)
-			{
-				DevLong delta = (data_format == Tango::SCALAR) ? long_array_val[0] - tmp_lo[0] : long_array_val[i] - (*value.lg_seq)[i];
-				if (abs(delta) >= delta_val.lg)
-				{
-					quality = Tango::ATTR_ALARM;
-					alarm.set(rds);
-					ret = true;
-					break;
-				}
-			}
-			break;
+            case Tango::DEV_LONG:
+                nb_written = long_array_val.length();
+                nb_read = (data_format == Tango::SCALAR) ? 1 : value.lg_seq->length();
+                nb_data = (nb_written > nb_read) ? nb_read : nb_written;
+                for (i = 0; i < nb_data; i++)
+                {
+                    DevLong delta = (data_format == Tango::SCALAR) ? long_array_val[0] - tmp_lo[0] : long_array_val[i]
+                        - (*value.lg_seq)[i];
+                    if (abs(delta) >= delta_val.lg)
+                    {
+                        quality = Tango::ATTR_ALARM;
+                        alarm.set(rds);
+                        ret = true;
+                        break;
+                    }
+                }
+                break;
 
-		case Tango::DEV_LONG64:
-			nb_written = long64_array_val.length();
-			nb_read = (data_format == Tango::SCALAR) ? 1 : value.lg64_seq->length();
-			nb_data = (nb_written > nb_read) ? nb_read : nb_written;
-			for (i = 0;i < nb_data;i++)
-			{
-				DevLong64 delta = (data_format == Tango::SCALAR) ? long64_array_val[0] - get_tmp_scalar_long64()[0] : long64_array_val[i] - (*value.lg64_seq)[i];
+            case Tango::DEV_LONG64:
+                nb_written = long64_array_val.length();
+                nb_read = (data_format == Tango::SCALAR) ? 1 : value.lg64_seq->length();
+                nb_data = (nb_written > nb_read) ? nb_read : nb_written;
+                for (i = 0; i < nb_data; i++)
+                {
+                    DevLong64 delta =
+                        (data_format == Tango::SCALAR) ? long64_array_val[0] - get_tmp_scalar_long64()[0] :
+                        long64_array_val[i] - (*value.lg64_seq)[i];
 
-				DevLong64 abs_delta;
-				if (delta < 0)
-					abs_delta = -delta;
-				else
-					abs_delta = delta;
+                    DevLong64 abs_delta;
+                    if (delta < 0)
+                        abs_delta = -delta;
+                    else
+                        abs_delta = delta;
 
-				if (abs_delta >= delta_val.lg64)
-				{
-					quality = Tango::ATTR_ALARM;
-					alarm.set(rds);
-					ret = true;
-					break;
-				}
-			}
-			break;
+                    if (abs_delta >= delta_val.lg64)
+                    {
+                        quality = Tango::ATTR_ALARM;
+                        alarm.set(rds);
+                        ret = true;
+                        break;
+                    }
+                }
+                break;
 
-		case Tango::DEV_DOUBLE:
-			nb_written = double_array_val.length();
-			nb_read = (data_format == Tango::SCALAR) ? 1 : value.db_seq->length();
-			nb_data = (nb_written > nb_read) ? nb_read : nb_written;
-			for (i = 0;i < nb_data;i++)
-			{
-				// check for NAN values
-				if ( data_format == Tango::SCALAR )
-				{
-					if ( Tango_isnan(double_array_val[0]) || Tango_isnan(tmp_db[0]) )
-					{
-						// send an alarm if only read or set value are NAN
-						if ( !(Tango_isnan(double_array_val[0]) && Tango_isnan(tmp_db[0])) )
-						{
-							quality = Tango::ATTR_ALARM;
-							alarm.set(rds);
-							ret = true;
-							break;
-						}
-					}
-				}
-				else
-				{
-					if ( Tango_isnan(double_array_val[i]) || Tango_isnan((*value.db_seq)[i]) )
-					{
-						// send an alarm if only read or set value are NAN
-						if ( !(Tango_isnan(double_array_val[i]) && Tango_isnan((*value.db_seq)[i])) )
-						{
-							quality = Tango::ATTR_ALARM;
-							alarm.set(rds);
-							ret = true;
-							break;
-						}
-					}
-				}
+            case Tango::DEV_DOUBLE:
+                nb_written = double_array_val.length();
+                nb_read = (data_format == Tango::SCALAR) ? 1 : value.db_seq->length();
+                nb_data = (nb_written > nb_read) ? nb_read : nb_written;
+                for (i = 0; i < nb_data; i++)
+                {
+                    // check for NAN values
+                    if (data_format == Tango::SCALAR)
+                    {
+                        if (Tango_isnan(double_array_val[0]) || Tango_isnan(tmp_db[0]))
+                        {
+                            // send an alarm if only read or set value are NAN
+                            if (!(Tango_isnan(double_array_val[0]) && Tango_isnan(tmp_db[0])))
+                            {
+                                quality = Tango::ATTR_ALARM;
+                                alarm.set(rds);
+                                ret = true;
+                                break;
+                            }
+                        }
+                    }
+                    else
+                    {
+                        if (Tango_isnan(double_array_val[i]) || Tango_isnan((*value.db_seq)[i]))
+                        {
+                            // send an alarm if only read or set value are NAN
+                            if (!(Tango_isnan(double_array_val[i]) && Tango_isnan((*value.db_seq)[i])))
+                            {
+                                quality = Tango::ATTR_ALARM;
+                                alarm.set(rds);
+                                ret = true;
+                                break;
+                            }
+                        }
+                    }
 
 
-				double delta = (data_format == Tango::SCALAR) ? double_array_val[0] - tmp_db[0] : double_array_val[i] - (*value.db_seq)[i];
-				if (fabs(delta) >= delta_val.db)
-				{
-					quality = Tango::ATTR_ALARM;
-					alarm.set(rds);
-					ret = true;
-					break;
-				}
-			}
-			break;
+                    double delta =
+                        (data_format == Tango::SCALAR) ? double_array_val[0] - tmp_db[0] : double_array_val[i]
+                            - (*value.db_seq)[i];
+                    if (fabs(delta) >= delta_val.db)
+                    {
+                        quality = Tango::ATTR_ALARM;
+                        alarm.set(rds);
+                        ret = true;
+                        break;
+                    }
+                }
+                break;
 
-		case Tango::DEV_FLOAT:
-			nb_written = float_array_val.length();
-			nb_read = (data_format == Tango::SCALAR) ? 1 : value.fl_seq->length();
-			nb_data = (nb_written > nb_read) ? nb_read : nb_written;
-			for (i = 0;i < nb_data;i++)
-			{
-				// check for NAN values
-				if ( data_format == Tango::SCALAR )
-				{
-					if ( Tango_isnan(float_array_val[0]) || Tango_isnan(tmp_fl[0]) )
-					{
-						// send an alarm if only read or set value are NAN
-						if ( !(Tango_isnan(float_array_val[0]) && Tango_isnan(tmp_fl[0])) )
-						{
-							quality = Tango::ATTR_ALARM;
-							alarm.set(rds);
-							ret = true;
-							break;
-						}
-					}
-				}
-				else
-				{
-					if ( Tango_isnan(float_array_val[i]) || Tango_isnan((*value.fl_seq)[i]) )
-					{
-						// send an alarm if only read or set value are NAN
-						if ( !(Tango_isnan(float_array_val[i]) && Tango_isnan((*value.fl_seq)[i])) )
-						{
-							quality = Tango::ATTR_ALARM;
-							alarm.set(rds);
-							ret = true;
-							break;
-						}
-					}
-				}
+            case Tango::DEV_FLOAT:
+                nb_written = float_array_val.length();
+                nb_read = (data_format == Tango::SCALAR) ? 1 : value.fl_seq->length();
+                nb_data = (nb_written > nb_read) ? nb_read : nb_written;
+                for (i = 0; i < nb_data; i++)
+                {
+                    // check for NAN values
+                    if (data_format == Tango::SCALAR)
+                    {
+                        if (Tango_isnan(float_array_val[0]) || Tango_isnan(tmp_fl[0]))
+                        {
+                            // send an alarm if only read or set value are NAN
+                            if (!(Tango_isnan(float_array_val[0]) && Tango_isnan(tmp_fl[0])))
+                            {
+                                quality = Tango::ATTR_ALARM;
+                                alarm.set(rds);
+                                ret = true;
+                                break;
+                            }
+                        }
+                    }
+                    else
+                    {
+                        if (Tango_isnan(float_array_val[i]) || Tango_isnan((*value.fl_seq)[i]))
+                        {
+                            // send an alarm if only read or set value are NAN
+                            if (!(Tango_isnan(float_array_val[i]) && Tango_isnan((*value.fl_seq)[i])))
+                            {
+                                quality = Tango::ATTR_ALARM;
+                                alarm.set(rds);
+                                ret = true;
+                                break;
+                            }
+                        }
+                    }
 
-				float delta = (data_format == Tango::SCALAR) ? float_array_val[0] - tmp_fl[0] : float_array_val[i] - (*value.fl_seq)[i];
-				double delta_d = (double)delta;
-				if (((float)fabs(delta_d)) >= delta_val.fl)
-				{
-					quality = Tango::ATTR_ALARM;
-					alarm.set(rds);
-					ret = true;
-					break;
-				}
-			}
-			break;
+                    float delta = (data_format == Tango::SCALAR) ? float_array_val[0] - tmp_fl[0] : float_array_val[i]
+                        - (*value.fl_seq)[i];
+                    double delta_d = (double) delta;
+                    if (((float) fabs(delta_d)) >= delta_val.fl)
+                    {
+                        quality = Tango::ATTR_ALARM;
+                        alarm.set(rds);
+                        ret = true;
+                        break;
+                    }
+                }
+                break;
 
-		case Tango::DEV_USHORT:
-			nb_written = ushort_array_val.length();
-			nb_read = (data_format == Tango::SCALAR) ? 1 : value.ush_seq->length();
-			nb_data = (nb_written > nb_read) ? nb_read : nb_written;
-			for (i = 0;i < nb_data;i++)
-			{
-				unsigned short delta = (data_format == Tango::SCALAR) ? ushort_array_val[0] - tmp_ush[0] : ushort_array_val[i] - (*value.ush_seq)[i];
-				if (abs(delta) >= delta_val.ush)
-				{
-					quality = Tango::ATTR_ALARM;
-					alarm.set(rds);
-					ret = true;
-					break;
-				}
-			}
-			break;
+            case Tango::DEV_USHORT:
+                nb_written = ushort_array_val.length();
+                nb_read = (data_format == Tango::SCALAR) ? 1 : value.ush_seq->length();
+                nb_data = (nb_written > nb_read) ? nb_read : nb_written;
+                for (i = 0; i < nb_data; i++)
+                {
+                    unsigned short delta =
+                        (data_format == Tango::SCALAR) ? ushort_array_val[0] - tmp_ush[0] : ushort_array_val[i]
+                            - (*value.ush_seq)[i];
+                    if (abs(delta) >= delta_val.ush)
+                    {
+                        quality = Tango::ATTR_ALARM;
+                        alarm.set(rds);
+                        ret = true;
+                        break;
+                    }
+                }
+                break;
 
-		case Tango::DEV_UCHAR:
-			nb_written = uchar_array_val.length();
-			nb_read = (data_format == Tango::SCALAR) ? 1 : value.cha_seq->length();
-			nb_data = (nb_written > nb_read) ? nb_read : nb_written;
-			for (i = 0;i < nb_data;i++)
-			{
-				unsigned char delta = (data_format == Tango::SCALAR) ? uchar_array_val[0] - tmp_cha[0] : uchar_array_val[i] - (*value.cha_seq)[i];
-				if (abs(delta) >= delta_val.uch)
-				{
-					quality = Tango::ATTR_ALARM;
-					alarm.set(rds);
-					ret = true;
-					break;
-				}
-			}
-			break;
+            case Tango::DEV_UCHAR:
+                nb_written = uchar_array_val.length();
+                nb_read = (data_format == Tango::SCALAR) ? 1 : value.cha_seq->length();
+                nb_data = (nb_written > nb_read) ? nb_read : nb_written;
+                for (i = 0; i < nb_data; i++)
+                {
+                    unsigned char delta =
+                        (data_format == Tango::SCALAR) ? uchar_array_val[0] - tmp_cha[0] : uchar_array_val[i]
+                            - (*value.cha_seq)[i];
+                    if (abs(delta) >= delta_val.uch)
+                    {
+                        quality = Tango::ATTR_ALARM;
+                        alarm.set(rds);
+                        ret = true;
+                        break;
+                    }
+                }
+                break;
 
-		case Tango::DEV_ULONG:
-			nb_written = ulong_array_val.length();
-			nb_read = (data_format == Tango::SCALAR) ? 1 : value.ulg_seq->length();
-			nb_data = (nb_written > nb_read) ? nb_read : nb_written;
-			for (i = 0;i < nb_data;i++)
-			{
-				DevLong delta = (data_format == Tango::SCALAR) ? ulong_array_val[0] - get_tmp_scalar_ulong()[0] : ulong_array_val[i] - (*value.ulg_seq)[i];
-				if ((unsigned int)abs(delta) >= delta_val.ulg)
-				{
-					quality = Tango::ATTR_ALARM;
-					alarm.set(rds);
-					ret = true;
-					break;
-				}
-			}
-			break;
+            case Tango::DEV_ULONG:
+                nb_written = ulong_array_val.length();
+                nb_read = (data_format == Tango::SCALAR) ? 1 : value.ulg_seq->length();
+                nb_data = (nb_written > nb_read) ? nb_read : nb_written;
+                for (i = 0; i < nb_data; i++)
+                {
+                    DevLong delta = (data_format == Tango::SCALAR) ? ulong_array_val[0] - get_tmp_scalar_ulong()[0] :
+                                    ulong_array_val[i] - (*value.ulg_seq)[i];
+                    if ((unsigned int) abs(delta) >= delta_val.ulg)
+                    {
+                        quality = Tango::ATTR_ALARM;
+                        alarm.set(rds);
+                        ret = true;
+                        break;
+                    }
+                }
+                break;
 
-		case Tango::DEV_ULONG64:
-			nb_written = ulong64_array_val.length();
-			nb_read = (data_format == Tango::SCALAR) ? 1 : value.ulg64_seq->length();
-			nb_data = (nb_written > nb_read) ? nb_read : nb_written;
-			for (i = 0;i < nb_data;i++)
-			{
-				DevLong64 delta = (data_format == Tango::SCALAR) ? ulong64_array_val[0] - get_tmp_scalar_ulong64()[0] : ulong64_array_val[i] - (*value.ulg64_seq)[i];
+            case Tango::DEV_ULONG64:
+                nb_written = ulong64_array_val.length();
+                nb_read = (data_format == Tango::SCALAR) ? 1 : value.ulg64_seq->length();
+                nb_data = (nb_written > nb_read) ? nb_read : nb_written;
+                for (i = 0; i < nb_data; i++)
+                {
+                    DevLong64 delta =
+                        (data_format == Tango::SCALAR) ? ulong64_array_val[0] - get_tmp_scalar_ulong64()[0] :
+                        ulong64_array_val[i] - (*value.ulg64_seq)[i];
 
-				DevULong64 abs_delta;
-				if (delta < 0)
-					abs_delta = -delta;
-				else
-					abs_delta = delta;
+                    DevULong64 abs_delta;
+                    if (delta < 0)
+                        abs_delta = -delta;
+                    else
+                        abs_delta = delta;
 
-				if (abs_delta >= delta_val.ulg64)
-				{
-					quality = Tango::ATTR_ALARM;
-					alarm.set(rds);
-					ret = true;
-					break;
-				}
-			}
-			break;
+                    if (abs_delta >= delta_val.ulg64)
+                    {
+                        quality = Tango::ATTR_ALARM;
+                        alarm.set(rds);
+                        ret = true;
+                        break;
+                    }
+                }
+                break;
 
-		case Tango::DEV_ENCODED:
-			nb_written = ::strlen(encoded_val.encoded_format.in());
-			nb_read = ::strlen((*value.enc_seq)[0].encoded_format.in());
-			if (nb_written != nb_read)
-			{
-				quality = Tango::ATTR_ALARM;
-				alarm.set(rds);
-				ret = true;
-				break;
-			}
-			if (::strcmp(encoded_val.encoded_format.in(),(*value.enc_seq)[0].encoded_format.in()) != 0)
-			{
-				quality = Tango::ATTR_ALARM;
-				alarm.set(rds);
-				ret = true;
-				break;
-			}
+            case Tango::DEV_ENCODED:
+                nb_written = ::strlen(encoded_val.encoded_format.in());
+                nb_read = ::strlen((*value.enc_seq)[0].encoded_format.in());
+                if (nb_written != nb_read)
+                {
+                    quality = Tango::ATTR_ALARM;
+                    alarm.set(rds);
+                    ret = true;
+                    break;
+                }
+                if (::strcmp(encoded_val.encoded_format.in(), (*value.enc_seq)[0].encoded_format.in()) != 0)
+                {
+                    quality = Tango::ATTR_ALARM;
+                    alarm.set(rds);
+                    ret = true;
+                    break;
+                }
 
-			nb_written = encoded_val.encoded_data.length();
-			nb_read = (*value.enc_seq)[0].encoded_data.length();
-			nb_data = (nb_written > nb_read) ? nb_read : nb_written;
-			for (i = 0;i < nb_data;i++)
-			{
-				unsigned char delta = encoded_val.encoded_data[i] - (*value.enc_seq)[0].encoded_data[i];
-				if (abs(delta) >= delta_val.uch)
-				{
-					quality = Tango::ATTR_ALARM;
-					alarm.set(rds);
-					ret = true;
-					break;
-				}
-			}
-			break;
-		}
-	}
+                nb_written = encoded_val.encoded_data.length();
+                nb_read = (*value.enc_seq)[0].encoded_data.length();
+                nb_data = (nb_written > nb_read) ? nb_read : nb_written;
+                for (i = 0; i < nb_data; i++)
+                {
+                    unsigned char delta = encoded_val.encoded_data[i] - (*value.enc_seq)[0].encoded_data[i];
+                    if (abs(delta) >= delta_val.uch)
+                    {
+                        quality = Tango::ATTR_ALARM;
+                        alarm.set(rds);
+                        ret = true;
+                        break;
+                    }
+                }
+                break;
+        }
+    }
 
-	return ret;
+    return ret;
 }
-
 
 void WAttribute::set_min_value(char *new_min_value_str)
 {
-	set_min_value(string(new_min_value_str));
+    set_min_value(string(new_min_value_str));
 }
 
 void WAttribute::set_min_value(const char *new_min_value_str)
 {
-	set_min_value(string(new_min_value_str));
+    set_min_value(string(new_min_value_str));
 }
-
 
 void WAttribute::set_max_value(char *new_max_value_str)
 {
-	set_max_value(string(new_max_value_str));
+    set_max_value(string(new_max_value_str));
 }
 
 void WAttribute::set_max_value(const char *new_max_value_str)
 {
-	set_max_value(string(new_max_value_str));
+    set_max_value(string(new_max_value_str));
 }
 
 //+-------------------------------------------------------------------------
@@ -3062,9 +3099,9 @@ void WAttribute::set_max_value(const char *new_max_value_str)
 //
 //--------------------------------------------------------------------------
 
-bool WAttribute::mem_value_below_above(MinMaxValueCheck check_type,string &ret_mem_value)
+bool WAttribute::mem_value_below_above(MinMaxValueCheck check_type, string &ret_mem_value)
 {
-	bool ret = false;
+    bool ret = false;
 
     if (mem_value == MemNotUsed)
         return false;
@@ -3073,7 +3110,7 @@ bool WAttribute::mem_value_below_above(MinMaxValueCheck check_type,string &ret_m
 // Check last written attribute value with the new threshold
 //
 
-    long nb_written,i;
+    long nb_written, i;
     stringstream ss;
 
     DevLong lg_val;
@@ -3091,470 +3128,470 @@ bool WAttribute::mem_value_below_above(MinMaxValueCheck check_type,string &ret_m
 
     switch (data_type)
     {
-    case Tango::DEV_SHORT:
-       if (svr_starting == true)
-        {
-            ss << mem_value;
-            ss >> sh_val;
-            if (check_type == MIN)
+        case Tango::DEV_SHORT:
+            if (svr_starting == true)
             {
-                if (sh_val < min_value.sh)
-                {
-                    ret_mem_value = mem_value;
-                    ret = true;
-                }
-            }
-            else
-            {
-                if (sh_val > max_value.sh)
-                {
-                    ret_mem_value = mem_value;
-                    ret = true;
-                }
-            }
-        }
-        else
-        {
-            nb_written = short_array_val.length();
-            for (i = 0;i < nb_written;i++)
-            {
+                ss << mem_value;
+                ss >> sh_val;
                 if (check_type == MIN)
                 {
-                    if (short_array_val[i] < min_value.sh)
+                    if (sh_val < min_value.sh)
                     {
-                        ss << short_array_val[i];
-                        ret_mem_value = ss.str();
+                        ret_mem_value = mem_value;
                         ret = true;
-                        break;
                     }
                 }
                 else
                 {
-                    if (short_array_val[i] > max_value.sh)
+                    if (sh_val > max_value.sh)
                     {
-                        ss << short_array_val[i];
-                        ret_mem_value = ss.str();
+                        ret_mem_value = mem_value;
                         ret = true;
-                        break;
                     }
-                }
-            }
-        }
-        break;
-
-    case Tango::DEV_LONG:
-        if (svr_starting == true)
-        {
-            ss << mem_value;
-            ss >> lg_val;
-            if (check_type == MIN)
-            {
-                if (lg_val < min_value.lg)
-                {
-                    ret_mem_value = mem_value;
-                    ret = true;
                 }
             }
             else
             {
-                if (lg_val > max_value.lg)
+                nb_written = short_array_val.length();
+                for (i = 0; i < nb_written; i++)
                 {
-                    ret_mem_value = mem_value;
-                    ret = true;
+                    if (check_type == MIN)
+                    {
+                        if (short_array_val[i] < min_value.sh)
+                        {
+                            ss << short_array_val[i];
+                            ret_mem_value = ss.str();
+                            ret = true;
+                            break;
+                        }
+                    }
+                    else
+                    {
+                        if (short_array_val[i] > max_value.sh)
+                        {
+                            ss << short_array_val[i];
+                            ret_mem_value = ss.str();
+                            ret = true;
+                            break;
+                        }
+                    }
                 }
             }
-        }
-        else
-        {
-            nb_written = long_array_val.length();
-            for (i = 0;i < nb_written;i++)
+            break;
+
+        case Tango::DEV_LONG:
+            if (svr_starting == true)
             {
+                ss << mem_value;
+                ss >> lg_val;
                 if (check_type == MIN)
                 {
-                    if (long_array_val[i] < min_value.lg)
+                    if (lg_val < min_value.lg)
                     {
-                        ss << long_array_val[i];
-                        ret_mem_value = ss.str();
+                        ret_mem_value = mem_value;
                         ret = true;
-                        break;
                     }
                 }
                 else
                 {
-                    if (long_array_val[i] > max_value.lg)
+                    if (lg_val > max_value.lg)
                     {
-                        ss << long_array_val[i];
-                        ret_mem_value = ss.str();
+                        ret_mem_value = mem_value;
                         ret = true;
-                        break;
                     }
-                }
-            }
-        }
-        break;
-
-    case Tango::DEV_LONG64:
-       if (svr_starting == true)
-        {
-            ss << mem_value;
-            ss >> lg64_val;
-            if (check_type == MIN)
-            {
-                if (lg64_val < min_value.lg64)
-                {
-                    ret_mem_value = mem_value;
-                    ret = true;
                 }
             }
             else
             {
-                if (lg64_val > max_value.lg64)
+                nb_written = long_array_val.length();
+                for (i = 0; i < nb_written; i++)
                 {
-                    ret_mem_value = mem_value;
-                    ret = true;
+                    if (check_type == MIN)
+                    {
+                        if (long_array_val[i] < min_value.lg)
+                        {
+                            ss << long_array_val[i];
+                            ret_mem_value = ss.str();
+                            ret = true;
+                            break;
+                        }
+                    }
+                    else
+                    {
+                        if (long_array_val[i] > max_value.lg)
+                        {
+                            ss << long_array_val[i];
+                            ret_mem_value = ss.str();
+                            ret = true;
+                            break;
+                        }
+                    }
                 }
             }
-        }
-        else
-        {
-            nb_written = long64_array_val.length();
-            for (i = 0;i < nb_written;i++)
+            break;
+
+        case Tango::DEV_LONG64:
+            if (svr_starting == true)
             {
+                ss << mem_value;
+                ss >> lg64_val;
                 if (check_type == MIN)
                 {
-                    if (long64_array_val[i] < min_value.lg64)
+                    if (lg64_val < min_value.lg64)
                     {
-                        ss << long64_array_val[i];
-                        ret_mem_value = ss.str();
+                        ret_mem_value = mem_value;
                         ret = true;
-                        break;
                     }
                 }
                 else
                 {
-                    if (long64_array_val[i] > max_value.lg64)
+                    if (lg64_val > max_value.lg64)
                     {
-                        ss << long64_array_val[i];
-                        ret_mem_value = ss.str();
+                        ret_mem_value = mem_value;
                         ret = true;
-                        break;
                     }
-                }
-            }
-        }
-        break;
-
-    case Tango::DEV_DOUBLE:
-        if (svr_starting == true)
-        {
-            ss << mem_value;
-            ss >> db_val;
-            if (check_type == MIN)
-            {
-                if (db_val < min_value.db)
-                {
-                    ret_mem_value = mem_value;
-                    ret = true;
                 }
             }
             else
             {
-                if (db_val > max_value.db)
+                nb_written = long64_array_val.length();
+                for (i = 0; i < nb_written; i++)
                 {
-                    ret_mem_value = mem_value;
-                    ret = true;
+                    if (check_type == MIN)
+                    {
+                        if (long64_array_val[i] < min_value.lg64)
+                        {
+                            ss << long64_array_val[i];
+                            ret_mem_value = ss.str();
+                            ret = true;
+                            break;
+                        }
+                    }
+                    else
+                    {
+                        if (long64_array_val[i] > max_value.lg64)
+                        {
+                            ss << long64_array_val[i];
+                            ret_mem_value = ss.str();
+                            ret = true;
+                            break;
+                        }
+                    }
                 }
             }
-        }
-        else
-        {
-            nb_written = double_array_val.length();
-            for (i = 0;i < nb_written;i++)
+            break;
+
+        case Tango::DEV_DOUBLE:
+            if (svr_starting == true)
             {
+                ss << mem_value;
+                ss >> db_val;
                 if (check_type == MIN)
                 {
-                    if (double_array_val[i] < min_value.db)
+                    if (db_val < min_value.db)
                     {
-                        ss << double_array_val[i];
-                        ret_mem_value = ss.str();
+                        ret_mem_value = mem_value;
                         ret = true;
-                        break;
                     }
                 }
                 else
                 {
-                    if (double_array_val[i] > max_value.db)
+                    if (db_val > max_value.db)
                     {
-                        ss << double_array_val[i];
-                        ret_mem_value = ss.str();
+                        ret_mem_value = mem_value;
                         ret = true;
-                        break;
                     }
-                }
-            }
-        }
-        break;
-
-    case Tango::DEV_FLOAT:
-        if (svr_starting == true)
-        {
-            ss << mem_value;
-            ss >> fl_val;
-            if (check_type == MIN)
-            {
-                if (fl_val < min_value.fl)
-                {
-                    ret_mem_value = mem_value;
-                    ret = true;
                 }
             }
             else
             {
-                if (fl_val > max_value.fl)
+                nb_written = double_array_val.length();
+                for (i = 0; i < nb_written; i++)
                 {
-                    ret_mem_value = mem_value;
-                    ret = true;
+                    if (check_type == MIN)
+                    {
+                        if (double_array_val[i] < min_value.db)
+                        {
+                            ss << double_array_val[i];
+                            ret_mem_value = ss.str();
+                            ret = true;
+                            break;
+                        }
+                    }
+                    else
+                    {
+                        if (double_array_val[i] > max_value.db)
+                        {
+                            ss << double_array_val[i];
+                            ret_mem_value = ss.str();
+                            ret = true;
+                            break;
+                        }
+                    }
                 }
             }
-        }
-        else
-        {
-            nb_written = float_array_val.length();
-            for (i = 0;i < nb_written;i++)
+            break;
+
+        case Tango::DEV_FLOAT:
+            if (svr_starting == true)
             {
+                ss << mem_value;
+                ss >> fl_val;
                 if (check_type == MIN)
                 {
-                    if (float_array_val[i] < min_value.fl)
+                    if (fl_val < min_value.fl)
                     {
-                        ss << float_array_val[i];
-                        ret_mem_value = ss.str();
+                        ret_mem_value = mem_value;
                         ret = true;
-                        break;
                     }
                 }
                 else
                 {
-                    if (float_array_val[i] > max_value.fl)
+                    if (fl_val > max_value.fl)
                     {
-                        ss << float_array_val[i];
-                        ret_mem_value = ss.str();
+                        ret_mem_value = mem_value;
                         ret = true;
-                        break;
                     }
-                }
-            }
-        }
-        break;
-
-    case Tango::DEV_USHORT:
-        if (svr_starting == true)
-        {
-            ss << mem_value;
-            ss >> ush_val;
-            if (check_type == MIN)
-            {
-                if (ush_val < min_value.ush)
-                {
-                    ret_mem_value = mem_value;
-                    ret = true;
                 }
             }
             else
             {
-                if (ush_val > max_value.ush)
+                nb_written = float_array_val.length();
+                for (i = 0; i < nb_written; i++)
                 {
-                    ret_mem_value = mem_value;
-                    ret = true;
+                    if (check_type == MIN)
+                    {
+                        if (float_array_val[i] < min_value.fl)
+                        {
+                            ss << float_array_val[i];
+                            ret_mem_value = ss.str();
+                            ret = true;
+                            break;
+                        }
+                    }
+                    else
+                    {
+                        if (float_array_val[i] > max_value.fl)
+                        {
+                            ss << float_array_val[i];
+                            ret_mem_value = ss.str();
+                            ret = true;
+                            break;
+                        }
+                    }
                 }
             }
-        }
-        else
-        {
-            nb_written = ushort_array_val.length();
-            for (i = 0;i < nb_written;i++)
+            break;
+
+        case Tango::DEV_USHORT:
+            if (svr_starting == true)
             {
+                ss << mem_value;
+                ss >> ush_val;
                 if (check_type == MIN)
                 {
-                    if (ushort_array_val[i] < min_value.ush)
+                    if (ush_val < min_value.ush)
                     {
-                        ss << ushort_array_val[i];
-                        ret_mem_value = ss.str();
+                        ret_mem_value = mem_value;
                         ret = true;
-                        break;
                     }
                 }
                 else
                 {
-                    if (ushort_array_val[i] > max_value.ush)
+                    if (ush_val > max_value.ush)
                     {
-                        ss << ushort_array_val[i];
-                        ret_mem_value = ss.str();
+                        ret_mem_value = mem_value;
                         ret = true;
-                        break;
                     }
-                }
-            }
-        }
-        break;
-
-    case Tango::DEV_UCHAR:
-        if (svr_starting == true)
-        {
-            ss << mem_value;
-            ss >> uch_val;
-            if (check_type == MIN)
-            {
-                if (uch_val < min_value.uch)
-                {
-                    ret_mem_value = mem_value;
-                    ret = true;
                 }
             }
             else
             {
-                if (uch_val > max_value.uch)
+                nb_written = ushort_array_val.length();
+                for (i = 0; i < nb_written; i++)
                 {
-                    ret_mem_value = mem_value;
-                    ret = true;
+                    if (check_type == MIN)
+                    {
+                        if (ushort_array_val[i] < min_value.ush)
+                        {
+                            ss << ushort_array_val[i];
+                            ret_mem_value = ss.str();
+                            ret = true;
+                            break;
+                        }
+                    }
+                    else
+                    {
+                        if (ushort_array_val[i] > max_value.ush)
+                        {
+                            ss << ushort_array_val[i];
+                            ret_mem_value = ss.str();
+                            ret = true;
+                            break;
+                        }
+                    }
                 }
             }
-        }
-        else
-        {
-            nb_written = uchar_array_val.length();
-            for (i = 0;i < nb_written;i++)
+            break;
+
+        case Tango::DEV_UCHAR:
+            if (svr_starting == true)
             {
+                ss << mem_value;
+                ss >> uch_val;
                 if (check_type == MIN)
                 {
-                    if (uchar_array_val[i] < min_value.uch)
+                    if (uch_val < min_value.uch)
                     {
-                        ss << uchar_array_val[i];
-                        ret_mem_value = ss.str();
+                        ret_mem_value = mem_value;
                         ret = true;
-                        break;
                     }
                 }
                 else
                 {
-                    if (uchar_array_val[i] > max_value.uch)
+                    if (uch_val > max_value.uch)
                     {
-                        ss << uchar_array_val[i];
-                        ret_mem_value = ss.str();
+                        ret_mem_value = mem_value;
                         ret = true;
-                        break;
                     }
-                }
-            }
-        }
-        break;
-
-    case Tango::DEV_ULONG:
-        if (svr_starting == true)
-        {
-            ss << mem_value;
-            ss >> ulg_val;
-            if (check_type == MIN)
-            {
-                if (ulg_val < min_value.ulg)
-                {
-                    ret_mem_value = mem_value;
-                    ret = true;
                 }
             }
             else
             {
-                if (ulg_val > max_value.ulg)
+                nb_written = uchar_array_val.length();
+                for (i = 0; i < nb_written; i++)
                 {
-                    ret_mem_value = mem_value;
-                    ret = true;
+                    if (check_type == MIN)
+                    {
+                        if (uchar_array_val[i] < min_value.uch)
+                        {
+                            ss << uchar_array_val[i];
+                            ret_mem_value = ss.str();
+                            ret = true;
+                            break;
+                        }
+                    }
+                    else
+                    {
+                        if (uchar_array_val[i] > max_value.uch)
+                        {
+                            ss << uchar_array_val[i];
+                            ret_mem_value = ss.str();
+                            ret = true;
+                            break;
+                        }
+                    }
                 }
             }
-        }
-        else
-        {
-            nb_written = ulong_array_val.length();
-            for (i = 0;i < nb_written;i++)
+            break;
+
+        case Tango::DEV_ULONG:
+            if (svr_starting == true)
             {
+                ss << mem_value;
+                ss >> ulg_val;
                 if (check_type == MIN)
                 {
-                    if (ulong_array_val[i] < min_value.ulg)
+                    if (ulg_val < min_value.ulg)
                     {
-                        ss << ulong_array_val[i];
-                        ret_mem_value = ss.str();
+                        ret_mem_value = mem_value;
                         ret = true;
-                        break;
                     }
                 }
                 else
                 {
-                    if (ulong_array_val[i] > max_value.ulg)
+                    if (ulg_val > max_value.ulg)
                     {
-                        ss << ulong_array_val[i];
-                        ret_mem_value = ss.str();
+                        ret_mem_value = mem_value;
                         ret = true;
-                        break;
                     }
-                }
-            }
-        }
-        break;
-
-    case Tango::DEV_ULONG64:
-        if (svr_starting == true)
-        {
-            ss << mem_value;
-            ss >> ulg64_val;
-            if (check_type == MIN)
-            {
-                if (ulg64_val < min_value.ulg64)
-                {
-                    ret_mem_value = mem_value;
-                    ret = true;
                 }
             }
             else
             {
-                if (ulg64_val > max_value.ulg64)
+                nb_written = ulong_array_val.length();
+                for (i = 0; i < nb_written; i++)
                 {
-                    ret_mem_value = mem_value;
-                    ret = true;
+                    if (check_type == MIN)
+                    {
+                        if (ulong_array_val[i] < min_value.ulg)
+                        {
+                            ss << ulong_array_val[i];
+                            ret_mem_value = ss.str();
+                            ret = true;
+                            break;
+                        }
+                    }
+                    else
+                    {
+                        if (ulong_array_val[i] > max_value.ulg)
+                        {
+                            ss << ulong_array_val[i];
+                            ret_mem_value = ss.str();
+                            ret = true;
+                            break;
+                        }
+                    }
                 }
             }
-        }
-        else
-        {
-            nb_written = ulong64_array_val.length();
-            for (i = 0;i < nb_written;i++)
+            break;
+
+        case Tango::DEV_ULONG64:
+            if (svr_starting == true)
             {
+                ss << mem_value;
+                ss >> ulg64_val;
                 if (check_type == MIN)
                 {
-                    if (ulong64_array_val[i] < min_value.ulg64)
+                    if (ulg64_val < min_value.ulg64)
                     {
-                        ss << ulong64_array_val[i];
-                        ret_mem_value = ss.str();
+                        ret_mem_value = mem_value;
                         ret = true;
-                        break;
                     }
                 }
                 else
                 {
-                    if (ulong64_array_val[i] > max_value.ulg64)
+                    if (ulg64_val > max_value.ulg64)
                     {
-                        ss << ulong64_array_val[i];
-                        ret_mem_value = ss.str();
+                        ret_mem_value = mem_value;
                         ret = true;
-                        break;
                     }
                 }
             }
-        }
-        break;
+            else
+            {
+                nb_written = ulong64_array_val.length();
+                for (i = 0; i < nb_written; i++)
+                {
+                    if (check_type == MIN)
+                    {
+                        if (ulong64_array_val[i] < min_value.ulg64)
+                        {
+                            ss << ulong64_array_val[i];
+                            ret_mem_value = ss.str();
+                            ret = true;
+                            break;
+                        }
+                    }
+                    else
+                    {
+                        if (ulong64_array_val[i] > max_value.ulg64)
+                        {
+                            ss << ulong64_array_val[i];
+                            ret_mem_value = ss.str();
+                            ret = true;
+                            break;
+                        }
+                    }
+                }
+            }
+            break;
 
-    default:
-        break;
+        default:
+            break;
     }
 
-	return ret;
+    return ret;
 }
 
 } // End of Tango namespace

--- a/cppapi/server/w_attribute.cpp
+++ b/cppapi/server/w_attribute.cpp
@@ -196,86 +196,134 @@ void WAttribute::set_rvalue()
         case Tango::DEV_SHORT:
         case Tango::DEV_ENUM:
             if (data_format == Tango::SCALAR)
+            {
                 set_value(&short_val, 1, 0, false);
+            }
             else
+            {
                 set_value(const_cast<DevShort *>(short_array_val.get_buffer()), w_dim_x, w_dim_y, false);
+            }
             break;
 
         case Tango::DEV_LONG:
             if (data_format == Tango::SCALAR)
+            {
                 set_value(&long_val, 1, 0, false);
+            }
             else
+            {
                 set_value(const_cast<DevLong *>(long_array_val.get_buffer()), w_dim_x, w_dim_y, false);
+            }
             break;
 
         case Tango::DEV_LONG64:
             if (data_format == Tango::SCALAR)
+            {
                 set_value(&long64_val, 1, 0, false);
+            }
             else
+            {
                 set_value(const_cast<DevLong64 *>(long64_array_val.get_buffer()), w_dim_x, w_dim_y, false);
+            }
             break;
 
         case Tango::DEV_DOUBLE:
             if (data_format == Tango::SCALAR)
+            {
                 set_value(&double_val, 1, 0, false);
+            }
             else
+            {
                 set_value(const_cast<DevDouble *>(double_array_val.get_buffer()), w_dim_x, w_dim_y, false);
+            }
             break;
 
         case Tango::DEV_STRING:
             if (data_format == Tango::SCALAR)
+            {
                 set_value(&str_val, 1, 0, false);
+            }
             else
+            {
                 set_value(const_cast<DevString *>(str_array_val.get_buffer()), w_dim_x, w_dim_y, false);
+            }
             break;
 
         case Tango::DEV_FLOAT:
             if (data_format == Tango::SCALAR)
+            {
                 set_value(&float_val, 1, 0, false);
+            }
             else
+            {
                 set_value(const_cast<DevFloat *>(float_array_val.get_buffer()), w_dim_x, w_dim_y, false);
+            }
             break;
 
         case Tango::DEV_BOOLEAN:
             if (data_format == Tango::SCALAR)
+            {
                 set_value(&boolean_val, 1, 0, false);
+            }
             else
+            {
                 set_value(const_cast<DevBoolean *>(boolean_array_val.get_buffer()), w_dim_x, w_dim_y, false);
+            }
             break;
 
         case Tango::DEV_USHORT:
             if (data_format == Tango::SCALAR)
+            {
                 set_value(&ushort_val, 1, 0, false);
+            }
             else
+            {
                 set_value(const_cast<DevUShort *>(ushort_array_val.get_buffer()), w_dim_x, w_dim_y, false);
+            }
             break;
 
         case Tango::DEV_UCHAR:
             if (data_format == Tango::SCALAR)
+            {
                 set_value(&uchar_val, 1, 0, false);
+            }
             else
+            {
                 set_value(const_cast<DevUChar *>(uchar_array_val.get_buffer()), w_dim_x, w_dim_y, false);
+            }
             break;
 
         case Tango::DEV_ULONG:
             if (data_format == Tango::SCALAR)
+            {
                 set_value(&ulong_val, 1, 0, false);
+            }
             else
+            {
                 set_value(const_cast<DevULong *>(ulong_array_val.get_buffer()), w_dim_x, w_dim_y, false);
+            }
             break;
 
         case Tango::DEV_ULONG64:
             if (data_format == Tango::SCALAR)
+            {
                 set_value(&ulong64_val, 1, 0, false);
+            }
             else
+            {
                 set_value(const_cast<DevULong64 *>(ulong64_array_val.get_buffer()), w_dim_x, w_dim_y, false);
+            }
             break;
 
         case Tango::DEV_STATE:
             if (data_format == Tango::SCALAR)
+            {
                 set_value(&dev_state_val, 1, 0, false);
+            }
             else
+            {
                 set_value(const_cast<DevState *>(state_array_val.get_buffer()), w_dim_x, w_dim_y, false);
+            }
             break;
 
         case Tango::DEV_ENCODED:
@@ -308,7 +356,9 @@ void WAttribute::check_written_value(const CORBA::Any &any, unsigned long x, uns
     Tango::Util *tg = Tango::Util::instance();
     Tango::TangoMonitor *mon_ptr = NULL;
     if (tg->is_svr_starting() == false && tg->is_device_restarting(d_name) == false)
+    {
         mon_ptr = &(get_att_device()->get_att_conf_monitor());
+    }
 
     switch (data_type)
     {
@@ -1164,7 +1214,9 @@ void WAttribute::check_written_value(const Tango::AttrValUnion &att_union, unsig
     Tango::Util *tg = Tango::Util::instance();
     Tango::TangoMonitor *mon_ptr = NULL;
     if (tg->is_svr_starting() == false && tg->is_device_restarting(d_name) == false)
+    {
         mon_ptr = &(get_att_device()->get_att_conf_monitor());
+    }
 
     switch (data_type)
     {
@@ -1912,11 +1964,17 @@ long WAttribute::get_write_value_length()
     long ret_val;
 
     if (data_format == Tango::SCALAR)
+    {
         ret_val = 1;
+    }
     else if (data_format == Tango::SPECTRUM)
+    {
         ret_val = w_dim_x;
+    }
     else
+    {
         ret_val = w_dim_x * w_dim_y;
+    }
 
     return ret_val;
 }
@@ -1954,9 +2012,13 @@ void WAttribute::set_write_value(Tango::DevShort *val, long x, long y)
     long nb_data;
 
     if (y == 0)
+    {
         nb_data = x;
+    }
     else
+    {
         nb_data = x * y;
+    }
 
     Tango::DevVarShortArray tmp_seq(nb_data, nb_data, val, false);
 
@@ -2000,9 +2062,13 @@ void WAttribute::set_write_value(Tango::DevLong *val, long x, long y)
     long nb_data;
 
     if (y == 0)
+    {
         nb_data = x;
+    }
     else
+    {
         nb_data = x * y;
+    }
 
     Tango::DevVarLongArray tmp_seq(nb_data, nb_data, val, false);
 
@@ -2045,9 +2111,13 @@ void WAttribute::set_write_value(Tango::DevLong64 *val, long x, long y)
     long nb_data;
 
     if (y == 0)
+    {
         nb_data = x;
+    }
     else
+    {
         nb_data = x * y;
+    }
 
     Tango::DevVarLong64Array tmp_seq(nb_data, nb_data, val, false);
 
@@ -2089,9 +2159,13 @@ void WAttribute::set_write_value(Tango::DevDouble *val, long x, long y)
     long nb_data;
 
     if (y == 0)
+    {
         nb_data = x;
+    }
     else
+    {
         nb_data = x * y;
+    }
 
     Tango::DevVarDoubleArray tmp_seq(nb_data, nb_data, val, false);
 
@@ -2146,9 +2220,13 @@ void WAttribute::set_write_value(Tango::DevString *val, long x, long y)
     long nb_data;
 
     if (y == 0)
+    {
         nb_data = x;
+    }
     else
+    {
         nb_data = x * y;
+    }
 
     Tango::DevVarStringArray tmp_seq(nb_data, nb_data, val, false);
 
@@ -2191,9 +2269,13 @@ void WAttribute::set_write_value(Tango::DevFloat *val, long x, long y)
     long nb_data;
 
     if (y == 0)
+    {
         nb_data = x;
+    }
     else
+    {
         nb_data = x * y;
+    }
 
     Tango::DevVarFloatArray tmp_seq(nb_data, nb_data, val, false);
     CORBA::Any tmp_any;
@@ -2234,9 +2316,13 @@ void WAttribute::set_write_value(Tango::DevBoolean *val, long x, long y)
     long nb_data;
 
     if (y == 0)
+    {
         nb_data = x;
+    }
     else
+    {
         nb_data = x * y;
+    }
 
     Tango::DevVarBooleanArray tmp_seq(nb_data, nb_data, val, false);
 
@@ -2279,9 +2365,13 @@ void WAttribute::set_write_value(Tango::DevUShort *val, long x, long y)
     long nb_data;
 
     if (y == 0)
+    {
         nb_data = x;
+    }
     else
+    {
         nb_data = x * y;
+    }
 
     Tango::DevVarUShortArray tmp_seq(nb_data, nb_data, val, false);
 
@@ -2323,9 +2413,13 @@ void WAttribute::set_write_value(Tango::DevUChar *val, long x, long y)
     long nb_data;
 
     if (y == 0)
+    {
         nb_data = x;
+    }
     else
+    {
         nb_data = x * y;
+    }
 
     Tango::DevVarUCharArray tmp_seq(nb_data, nb_data, val, false);
 
@@ -2367,9 +2461,13 @@ void WAttribute::set_write_value(Tango::DevULong *val, long x, long y)
     long nb_data;
 
     if (y == 0)
+    {
         nb_data = x;
+    }
     else
+    {
         nb_data = x * y;
+    }
 
     Tango::DevVarULongArray tmp_seq(nb_data, nb_data, val, false);
 
@@ -2411,9 +2509,13 @@ void WAttribute::set_write_value(Tango::DevULong64 *val, long x, long y)
     long nb_data;
 
     if (y == 0)
+    {
         nb_data = x;
+    }
     else
+    {
         nb_data = x * y;
+    }
 
     Tango::DevVarULong64Array tmp_seq(nb_data, nb_data, val, false);
 
@@ -2455,9 +2557,13 @@ void WAttribute::set_write_value(Tango::DevState *val, long x, long y)
     long nb_data;
 
     if (y == 0)
+    {
         nb_data = x;
+    }
     else
+    {
         nb_data = x * y;
+    }
 
     Tango::DevVarStateArray tmp_seq(nb_data, nb_data, val, false);
 
@@ -2750,7 +2856,9 @@ bool WAttribute::check_rds_alarm()
 //
 
     if (write_date.tv_sec == 0)
+    {
         return false;
+    }
 
 //
 // First, check if it is necessary to check attribute value
@@ -2831,9 +2939,13 @@ bool WAttribute::check_rds_alarm()
 
                     DevLong64 abs_delta;
                     if (delta < 0)
+                    {
                         abs_delta = -delta;
+                    }
                     else
+                    {
                         abs_delta = delta;
+                    }
 
                     if (abs_delta >= delta_val.lg64)
                     {
@@ -3012,9 +3124,13 @@ bool WAttribute::check_rds_alarm()
 
                     DevULong64 abs_delta;
                     if (delta < 0)
+                    {
                         abs_delta = -delta;
+                    }
                     else
+                    {
                         abs_delta = delta;
+                    }
 
                     if (abs_delta >= delta_val.ulg64)
                     {
@@ -3104,7 +3220,9 @@ bool WAttribute::mem_value_below_above(MinMaxValueCheck check_type, string &ret_
     bool ret = false;
 
     if (mem_value == MemNotUsed)
+    {
         return false;
+    }
 
 //
 // Check last written attribute value with the new threshold

--- a/cppapi/server/w_attribute.cpp
+++ b/cppapi/server/w_attribute.cpp
@@ -2969,7 +2969,7 @@ bool WAttribute::check_rds_alarm()
                         if (Tango_isnan(double_array_val[0]) || Tango_isnan(tmp_db[0]))
                         {
                             // send an alarm if only read or set value are NAN
-                            if (!(Tango_isnan(double_array_val[0]) && Tango_isnan(tmp_db[0])))
+                            if (not(Tango_isnan(double_array_val[0]) && Tango_isnan(tmp_db[0])))
                             {
                                 quality = Tango::ATTR_ALARM;
                                 alarm.set(rds);
@@ -2983,7 +2983,7 @@ bool WAttribute::check_rds_alarm()
                         if (Tango_isnan(double_array_val[i]) || Tango_isnan((*value.db_seq)[i]))
                         {
                             // send an alarm if only read or set value are NAN
-                            if (!(Tango_isnan(double_array_val[i]) && Tango_isnan((*value.db_seq)[i])))
+                            if (not(Tango_isnan(double_array_val[i]) && Tango_isnan((*value.db_seq)[i])))
                             {
                                 quality = Tango::ATTR_ALARM;
                                 alarm.set(rds);
@@ -3033,7 +3033,7 @@ bool WAttribute::check_rds_alarm()
                         if (Tango_isnan(float_array_val[i]) || Tango_isnan((*value.fl_seq)[i]))
                         {
                             // send an alarm if only read or set value are NAN
-                            if (!(Tango_isnan(float_array_val[i]) && Tango_isnan((*value.fl_seq)[i])))
+                            if (not(Tango_isnan(float_array_val[i]) && Tango_isnan((*value.fl_seq)[i])))
                             {
                                 quality = Tango::ATTR_ALARM;
                                 alarm.set(rds);


### PR DESCRIPTION
The files where these warnings were reported have been formatted by CLion using
the cppTango CLion code style already in use on the master branch.
Added CLion code style settings file based on Allman Braces code style (#364).