### PR TITLE
place opening bracket in the end of line

### DIFF
--- a/.idea/codeStyleSettings.xml
+++ b/.idea/codeStyleSettings.xml
@@ -7,9 +7,6 @@
         <Objective-C>
           <option name="INDENT_NAMESPACE_MEMBERS" value="0" />
           <option name="KEEP_STRUCTURES_IN_ONE_LINE" value="true" />
-          <option name="NAMESPACE_BRACE_PLACEMENT" value="2" />
-          <option name="FUNCTION_BRACE_PLACEMENT" value="2" />
-          <option name="BLOCK_BRACE_PLACEMENT" value="2" />
           <option name="FUNCTION_PARAMETERS_WRAP" value="5" />
           <option name="FUNCTION_CALL_ARGUMENTS_WRAP" value="5" />
           <option name="TEMPLATE_CALL_ARGUMENTS_WRAP" value="5" />
@@ -52,8 +49,6 @@
           <option name="BLANK_LINES_AROUND_FIELD" value="1" />
           <option name="BLANK_LINES_AROUND_METHOD" value="0" />
           <option name="BLANK_LINES_AROUND_METHOD_IN_INTERFACE" value="0" />
-          <option name="BRACE_STYLE" value="2" />
-          <option name="CLASS_BRACE_STYLE" value="2" />
           <option name="ELSE_ON_NEW_LINE" value="true" />
           <option name="WHILE_ON_NEW_LINE" value="true" />
           <option name="CATCH_ON_NEW_LINE" value="true" />


### PR DESCRIPTION
I suggest to change the code style to place opening bracket in the end of line. This helps to investigate code i.e. when I put the cursor onto the ending bracket CLion popups the code line with the opening one:

![code_highlight](https://user-images.githubusercontent.com/11678364/28754176-b37c555e-7540-11e7-96bc-4321219646c3.png)

Here I see the full if statement. Otherwise only the bracket is shown:

![code_highlight1](https://user-images.githubusercontent.com/11678364/28754185-c9a7f5e0-7540-11e7-8be5-3f1865172502.png)

As our code has tons of very long if/switch/classes/functions this is critical.

