### PR TITLE
Fix DeviceAttribute constructor for short and enum data types (#392)

### DIFF
--- a/cpp_test_suite/new_tests/cxx_cmd_types.cpp
+++ b/cpp_test_suite/new_tests/cxx_cmd_types.cpp
@@ -1191,6 +1191,107 @@ public:
 #endif
 	}
 
+// Test DeviceAttribute get_type method after constructor call
+    void test_DeviceAttribute_get_type_after_constructor_call(void)
+    {
+        string attr_name = "MyAttrName";
+        short my_short = 42;
+        DeviceAttribute da_short("MyAttributeName", my_short);
+        TS_ASSERT(da_short.get_type() == DEV_SHORT);
+        DeviceAttribute da_short2(attr_name, my_short);
+        TS_ASSERT(da_short2.get_type() == DEV_SHORT);
+
+        enum Color
+        {
+            red, green, blue
+        };
+        Color color = red;
+        DeviceAttribute da_enum("MyColorEnumAttr", color);
+        TS_ASSERT(da_enum.get_type() == DEV_ENUM);
+        DeviceAttribute da_enum2(attr_name, color);
+        TS_ASSERT(da_enum2.get_type() == DEV_ENUM);
+
+        vector<short> my_short_vector;
+        for (size_t i = 0; i < 10; i++)
+        {
+            my_short_vector.push_back(i);
+            my_short_vector.push_back(-i);
+        }
+        DeviceAttribute da_short_vec("MyShortSpectrumAttr", my_short_vector);
+        TS_ASSERT(da_short_vec.get_type() == DEV_SHORT);
+        DeviceAttribute da_short_vec2(attr_name, my_short_vector);
+        TS_ASSERT(da_short_vec2.get_type() == DEV_SHORT);
+
+        DeviceAttribute da_short_vec3("MyShortSpectrumAttr", my_short_vector, 4, 5);
+        TS_ASSERT(da_short_vec3.get_type() == DEV_SHORT);
+        DeviceAttribute da_short_vec4(attr_name, my_short_vector, 10, 2);
+        TS_ASSERT(da_short_vec4.get_type() == DEV_SHORT);
+
+        vector <Color> my_enum_vector;
+        my_enum_vector.push_back(red);
+        my_enum_vector.push_back(blue);
+        my_enum_vector.push_back(red);
+        my_enum_vector.push_back(green);
+
+        DeviceAttribute da_enum_vec("MyEnumSpectrumAttr", my_enum_vector);
+        TS_ASSERT(da_enum_vec.get_type() == DEV_ENUM);
+        DeviceAttribute da_enum_vec2(attr_name, my_enum_vector);
+        TS_ASSERT(da_enum_vec2.get_type() == DEV_ENUM);
+
+        DeviceAttribute da_enum_vec3("MyEnumSpectrumAttr", my_enum_vector, 2, 2);
+        TS_ASSERT(da_enum_vec3.get_type() == DEV_ENUM);
+        DeviceAttribute da_enum_vec4(attr_name, my_enum_vector, 4, 1);
+        TS_ASSERT(da_enum_vec4.get_type() == DEV_ENUM);
+    }
+
+// Test DeviceAttribute get_type method after short or enum insertion
+    void test_DeviceAttribute_get_type_after_short_or_enum_insertion(void)
+    {
+        string attr_name = "MyAttrName";
+        enum Color
+        {
+            red, green, blue
+        };
+
+        DeviceAttribute da;
+        TS_ASSERT(da.get_type() == DATA_TYPE_UNKNOWN);
+        short my_short = 42;
+        da << my_short;
+        TS_ASSERT(da.get_type() == DEV_SHORT);
+
+        Color color = blue;
+        da << color;
+        TS_ASSERT(da.get_type() == DEV_ENUM);
+
+        da << my_short;
+        TS_ASSERT(da.get_type() == DEV_ENUM);
+
+        vector<short> my_short_vector;
+        for (size_t i = 0; i < 10; i++)
+        {
+            my_short_vector.push_back(i);
+            my_short_vector.push_back(-i);
+        }
+
+        da << my_short_vector;
+        // If the device attribute data type was previously set to DEV_ENUM
+        // and we insert a short, we can still consider it as an enum
+        TS_ASSERT(da.get_type() == DEV_ENUM);
+
+        DeviceAttribute da2;
+        da2 << my_short_vector;
+        TS_ASSERT(da2.get_type() == DEV_SHORT);
+
+        vector <Color> my_enum_vector;
+        my_enum_vector.push_back(red);
+        my_enum_vector.push_back(blue);
+        my_enum_vector.push_back(red);
+        my_enum_vector.push_back(green);
+
+        da2 << my_enum_vector;
+        TS_ASSERT(da2.get_type() == DEV_ENUM);
+    }
+
 };
 #undef cout
 #endif // CmdTypesTestSuite_h

--- a/cpp_test_suite/new_tests/cxx_cmd_types.cpp
+++ b/cpp_test_suite/new_tests/cxx_cmd_types.cpp
@@ -1247,7 +1247,6 @@ public:
 // Test DeviceAttribute get_type method after short or enum insertion
     void test_DeviceAttribute_get_type_after_short_or_enum_insertion(void)
     {
-        string attr_name = "MyAttrName";
         enum Color
         {
             red, green, blue

--- a/cppapi/client/devapi_attr.cpp
+++ b/cppapi/client/devapi_attr.cpp
@@ -2069,9 +2069,18 @@ bool DeviceAttribute::is_empty()
 int DeviceAttribute::get_type()
 {
 	int da_type;
+	bool da_is_empty;
 
-	if (is_empty() == true)
-		return -1;
+	// reset is_empty exception flag to avoid throwing an exception
+	// during is_empty() call
+	bitset<DeviceAttribute::numFlags> bs = exceptions();
+	reset_exceptions(DeviceAttribute::isempty_flag);
+	da_is_empty = is_empty();
+	// restore is_empty exception flag
+	exceptions(bs);
+
+	if (da_is_empty)
+		return DATA_TYPE_UNKNOWN;
 	else
 	{
 		if (LongSeq.operator->() != NULL)
@@ -2103,7 +2112,7 @@ int DeviceAttribute::get_type()
 		else if ((StateSeq.operator->() != NULL) || (d_state_filled == true))
 			da_type = Tango::DEV_STATE;
         else
-            da_type = -1;
+            da_type = DATA_TYPE_UNKNOWN;
 	}
 
 	return da_type;

--- a/cppapi/client/devapi_attr.cpp
+++ b/cppapi/client/devapi_attr.cpp
@@ -1118,6 +1118,7 @@ DeviceAttribute::DeviceAttribute(string& new_name, vector<short> &datum):ext(new
 	exceptions_flags.set(isempty_flag);
 	ShortSeq = new(DevVarShortArray);
 	ShortSeq.inout() << datum;
+	data_type = DEV_SHORT;
 }
 
 DeviceAttribute::DeviceAttribute(const char *new_name, vector<short> &datum):ext(new DeviceAttributeExt)
@@ -1134,6 +1135,7 @@ DeviceAttribute::DeviceAttribute(const char *new_name, vector<short> &datum):ext
 	exceptions_flags.set(isempty_flag);
 	ShortSeq = new(DevVarShortArray);
 	ShortSeq.inout() << datum;
+	data_type = DEV_SHORT;
 }
 
 DeviceAttribute::DeviceAttribute(string& new_name, vector<short> &datum,int x,int y):ext(new DeviceAttributeExt)
@@ -1150,6 +1152,7 @@ DeviceAttribute::DeviceAttribute(string& new_name, vector<short> &datum,int x,in
 	exceptions_flags.set(isempty_flag);
 	ShortSeq = new(DevVarShortArray);
 	ShortSeq.inout() << datum;
+	data_type = DEV_SHORT;
 }
 
 DeviceAttribute::DeviceAttribute(const char *new_name, vector<short> &datum,int x,int y):ext(new DeviceAttributeExt)
@@ -1166,6 +1169,7 @@ DeviceAttribute::DeviceAttribute(const char *new_name, vector<short> &datum,int 
 	exceptions_flags.set(isempty_flag);
 	ShortSeq = new(DevVarShortArray);
 	ShortSeq.inout() << datum;
+	data_type = DEV_SHORT;
 }
 
 //-----------------------------------------------------------------------------
@@ -3015,6 +3019,9 @@ void DeviceAttribute::operator << (vector<short> &datum)
 	w_dim_y = 0;
 	quality = Tango::ATTR_VALID;
 	data_format = Tango::FMT_UNKNOWN;
+
+	if(data_type != DEV_ENUM)
+	{   data_type = DEV_SHORT;}
 
 	if (ShortSeq.operator->() == NULL)
 	{

--- a/cppapi/client/devapi_attr.cpp
+++ b/cppapi/client/devapi_attr.cpp
@@ -563,6 +563,7 @@ DeviceAttribute::DeviceAttribute(string &new_name, short datum):ext(new DeviceAt
 	ShortSeq = new(DevVarShortArray);
 	ShortSeq->length(1);
 	ShortSeq[0] = datum;
+	data_type = DEV_SHORT;
 }
 
 DeviceAttribute::DeviceAttribute(const char *new_name, short datum):ext(new DeviceAttributeExt)
@@ -580,6 +581,7 @@ DeviceAttribute::DeviceAttribute(const char *new_name, short datum):ext(new Devi
 	ShortSeq = new(DevVarShortArray);
 	ShortSeq->length(1);
 	ShortSeq[0] = datum;
+	data_type = DEV_SHORT;
 }
 
 //-----------------------------------------------------------------------------
@@ -2164,6 +2166,8 @@ void DeviceAttribute::operator << (short datum)
 	w_dim_y = 0;
 	quality = Tango::ATTR_VALID;
 	data_format = Tango::FMT_UNKNOWN;
+	if(data_type != DEV_ENUM)
+	{   data_type = DEV_SHORT;}
 
     DevVarShortArray *short_vararr = new(DevVarShortArray);
     short_vararr->length(1);

--- a/cppapi/client/devapi_attr.tpp
+++ b/cppapi/client/devapi_attr.tpp
@@ -114,6 +114,9 @@ void DeviceAttribute::base_vect(vector<T> &_val)
 	d_state_filled = false;
 	exceptions_flags.set(failed_flag);
 	exceptions_flags.set(isempty_flag);
+	// This is supposed to be used only for enum types since all
+	// the constructors for the other standard Tango types have a specialization defined
+	data_type = DEV_ENUM;
 	ShortSeq = new(DevVarShortArray);
 	ShortSeq->length(_val.size());
 	for (size_t loop = 0;loop < _val.size();loop++)
@@ -152,6 +155,9 @@ void DeviceAttribute::base_vect_size(vector<T> &_val)
 	exceptions_flags.set(isempty_flag);
 	ShortSeq = new(DevVarShortArray);
 	ShortSeq->length(_val.size());
+	// This is supposed to be used only for enum types since all
+	// the constructors for the other standard Tango types have a specialization defined
+	data_type = DEV_ENUM;
 	for (size_t loop = 0;loop < _val.size();loop++)
 		ShortSeq[loop] = static_cast<short>(_val[loop]);
 }
@@ -379,6 +385,7 @@ void DeviceAttribute::operator << (vector<T> &_datum)
 	w_dim_y = 0;
 	quality = Tango::ATTR_VALID;
 	data_format = Tango::FMT_UNKNOWN;
+	data_type = DEV_ENUM;
 
 	if (ShortSeq.operator->() == NULL)
 	{

--- a/cppapi/client/devapi_attr.tpp
+++ b/cppapi/client/devapi_attr.tpp
@@ -77,9 +77,12 @@ void DeviceAttribute::base_val(T _val)
 	d_state_filled = false;
 	exceptions_flags.set(failed_flag);
 	exceptions_flags.set(isempty_flag);
+	// This constructor is supposed to be used only for enum types since all
+	// the constructors for the other standard Tango types have a specialization defined
 	ShortSeq = new(DevVarShortArray);
 	ShortSeq->length(1);
 	ShortSeq[0] = static_cast<short>(_val);
+	data_type = DEV_ENUM;
 }
 
 //-----------------------------------------------------------------------------------------------------------------
@@ -354,6 +357,7 @@ void DeviceAttribute::operator << (T datum)
 	w_dim_y = 0;
 	quality = Tango::ATTR_VALID;
 	data_format = Tango::FMT_UNKNOWN;
+	data_type = DEV_ENUM;
 
     DevVarShortArray *short_vararr = new(DevVarShortArray);
     short_vararr->length(1);
@@ -397,7 +401,7 @@ void DeviceAttribute::insert(vector<T> &_datum,int _x,int _y)
 }
 
 template <typename T>
-bool DeviceAttribute::template_type_check(T &_datum)
+bool DeviceAttribute::template_type_check(T &TANGO_UNUSED(_datum))
 {
 #ifdef HAS_UNDERLYING
 	bool short_enum = is_same<short,typename underlying_type<T>::type>::value;


### PR DESCRIPTION
Add tests for DeviceAttribute constructors and tests for insertion operators for short and enum types.
DeviceAttribute::get_type() no longer throws an exception when DeviceAttribute object is empty.
It now returns DATA_TYPE_UNKNOWN in this case.