### PR TITLE
Tango 9 LTS fix#395 (Inserting const C string in DeviceData)

### DIFF
--- a/cpp_test_suite/old_tests/cmd_types.cpp
+++ b/cpp_test_suite/old_tests/cmd_types.cpp
@@ -216,9 +216,47 @@ int main(int argc, char **argv) {
         }
         const char *received;
         dout >> received;
-        assert(strcmp(str, "dcba"));
+        assert(strcmp(received, "dcba") == 0);
     }
-    cout << "   C string --> OK" << endl;
+    cout << "   const char * string --> OK" << endl;
+
+// test direct classical C string
+
+    for (i = 0; i < loop; i++) {
+        DeviceData din, dout;
+        din << "abcde";
+        try {
+            dout = device->command_inout("IOString", din);
+        }
+        catch (CORBA::Exception &e) {
+            Except::print_exception(e);
+            exit(-1);
+        }
+        const char *received;
+        dout >> received;
+        assert(strcmp(received, "edcba") == 0);
+    }
+    cout << "   direct const char * string --> OK" << endl;
+
+// test non-const C string
+
+    for (i = 0; i < loop; i++) {
+        char * in = strdup("abcdef");
+        DeviceData din, dout;
+        din << in;
+        free(in);
+        try {
+            dout = device->command_inout("IOString", din);
+        }
+        catch (CORBA::Exception &e) {
+            Except::print_exception(e);
+            exit(-1);
+        }
+        const char *received;
+        dout >> received;
+        assert(strcmp(received, "fedcba") == 0);
+    }
+    cout << "   char * string --> OK" << endl;
 
     // test DevVarBooleanArray
 

--- a/cppapi/client/DeviceData.h
+++ b/cppapi/client/DeviceData.h
@@ -378,8 +378,8 @@ public :
 	void operator << (DevULong64 datum) {any <<= datum;}
 	void operator << (float datum) {any <<= datum;}
 	void operator << (double datum) {any <<= datum;}
-	void operator << (char *&datum) {any <<= datum;}
-	void operator << (const char *&datum) {any <<= datum;}
+	void operator << (char *datum) {any <<= datum;}
+	void operator << (const char *datum) {any <<= datum;}
 	void operator << (string &datum) {any <<= datum.c_str();}
 	void operator << (vector<bool>&);
 	void operator << (vector<unsigned char>&);


### PR DESCRIPTION
This also fixes the bug in const char * DeviceData insertion test and add some new tests for const char * DeviceData insertions.