### PR TITLE
Fix bug leading occasionally Tango 9 DS to segmentation fault

### DIFF
--- a/cppapi/server/attribute.cpp
+++ b/cppapi/server/attribute.cpp
@@ -3515,10 +3515,7 @@ void Attribute::AttributeValue_5_2_AttributeValue_4(const Tango::AttributeValue_
 // First pass the data from one union to another WITHOUT copying them
 //
 
-	if (att_5->quality != Tango::ATTR_INVALID)
-	{
-		AttrValUnion_fake_copy(att_5,att_4);
-	}
+	AttrValUnion_fake_copy(att_5,att_4);
 
 //
 // The remaining fields
@@ -3561,10 +3558,7 @@ void Attribute::AttributeValue_4_2_AttributeValue_5(const Tango::AttributeValue_
 // First pass the data from one union to another WITHOUT copying them
 //
 
-	if (att_4->quality != Tango::ATTR_INVALID)
-	{
-		AttrValUnion_fake_copy(att_4,att_5);
-	}
+	AttrValUnion_fake_copy(att_4,att_5);
 
 //
 // The remaining fields

--- a/cppapi/server/attribute.tpp
+++ b/cppapi/server/attribute.tpp
@@ -1588,6 +1588,7 @@ void Attribute::AttrValUnion_fake_copy(const T *src, V *dst)
             break;
 
         case ATT_NO_DATA:
+            dst->value.union_no_data(true);
             break;
     }
 }


### PR DESCRIPTION
when an IDLv4 client had subscribed to an attribute and the attribute became
INVALID (quality factor).