### PR TITLE
Attribute: Don't treat an integer as an char*

### DIFF
--- a/src/server/attrgetsetprop.cpp
+++ b/src/server/attrgetsetprop.cpp
@@ -195,12 +195,15 @@ void Attribute::get_properties(Tango::AttributeConfig_3 &conf)
 	str.precision(TANGO_FLOAT_PRECISION);
 
 	if (event_period == INT_MAX)
-		conf.event_prop.per_event.period = Tango::string_dup((const char *)(DEFAULT_EVENT_PERIOD));
+	{
+		str << DEFAULT_EVENT_PERIOD;
+	}
 	else
 	{
 		str << event_period;
-		MEM_STREAM_2_CORBA(conf.event_prop.per_event.period,str);
 	}
+
+	MEM_STREAM_2_CORBA(conf.event_prop.per_event.period,str);
 
 //
 // Copy change event properties


### PR DESCRIPTION
Currently the compiler outputs

attrgetsetprop.cpp: In member function ‘void Tango::Attribute::get_properties(Tango::AttributeConfig_3&)’:
attrgetsetprop.cpp:200:91: warning: cast to pointer from integer of different size [-Wint-to-pointer-cast]
   conf.event_prop.per_event.period = CORBA::string_dup((const char *)(DEFAULT_EVENT_PERIOD));

and that is justified as DEFAULT_EVENT_PERIOD is an integer.

Using the plain output operator into the stream is the preferred way.