### PR TITLE
Fix build errors when using C++17

### DIFF
--- a/include/log4tango/Level.hh
+++ b/include/log4tango/Level.hh
@@ -116,8 +116,7 @@ public:
 	 * @throw std::invalid_argument if the level_name does not 
 	 * correspond with a known Level name or a number
 	 **/
-   static Value get_value (const std::string& level_name)
-	    throw(std::invalid_argument);
+   static Value get_value (const std::string& level_name);
 };
 
 } // namespace log4tango

--- a/include/tango/client/helpers/DeviceProxyHelper.h
+++ b/include/tango/client/helpers/DeviceProxyHelper.h
@@ -225,7 +225,6 @@ namespace Tango
 		//  client_device : Reference to the client device (for logging purpose).
 		//---------------------------------------------------------------------------
 		HelperBase (const std::string& device_name, Tango::DeviceImpl *client_device = 0)
-			throw (Tango::DevFailed)
 			: Tango::LogAdapter(client_device), device_proxy_(0)
 		{
 			_DEV_TRY_REACTION
@@ -292,7 +291,6 @@ namespace Tango
 		void internal_command (const std::string& cmd_name,
 			std::string file,
 			int line)
-			throw (Tango::DevFailed)
 		{
 			if (device_proxy_)
 			{
@@ -332,7 +330,6 @@ namespace Tango
 
 		template <class _IN, class _OUT>
 			void internal_command_inout (const std::string& cmd_name, const _IN& argin, _OUT& argout, std::string file= __FILE__, int line= __LINE__)
-			throw (Tango::DevFailed)
 		{
 			if (device_proxy_)
 			{
@@ -388,7 +385,6 @@ namespace Tango
 			std::vector<std::string>& _sv_out,
 			std::string file= __FILE__,
 			int line= __LINE__)
-			throw (Tango::DevFailed)
 		{
 
 			if (device_proxy_)
@@ -429,7 +425,6 @@ namespace Tango
 		//---------------------------------------------------------------------------
 		template <class _IN>
 			void internal_command_inout (const std::string& cmd_name, const _IN& argin, DevVarDoubleStringArray* argout,std::string file= __FILE__, int line= __LINE__)
-			throw (Tango::DevFailed)
 		{
 #if (defined(_MSC_VER) && _MSC_VER < 1300)
 #pragma message  (" TANGO WARNING ***** command_inout:Use only STL vector instead of DevVarDoubleStringArray *****")
@@ -447,7 +442,6 @@ namespace Tango
 		//---------------------------------------------------------------------------
 		template <class _IN>
 			void internal_command_inout (const std::string& cmd_name, const _IN& argin, DevVarLongStringArray* argout,std::string file= __FILE__, int line= __LINE__)
-			throw (Tango::DevFailed)
 		{
 #if (defined(_MSC_VER) && _MSC_VER < 1300)
 #pragma message  (" TANGO WARNING ***** command_inout:Use only STL vector instead of DevVarLongStringArray *****")
@@ -464,7 +458,6 @@ namespace Tango
 		//---------------------------------------------------------------------------
 		template <class _IN>
 			void internal_command_inout (const std::string& cmd_name, const _IN& argin, DevVarDoubleStringArray& argout,std::string file= __FILE__, int line= __LINE__)
-			throw (Tango::DevFailed)
 		{
 #if (defined(_MSC_VER) && _MSC_VER < 1300)
 #pragma message  (" TANGO WARNING ***** command_inout:Use only STL vector instead of DevVarDoubleStringArray *****")
@@ -482,7 +475,6 @@ namespace Tango
 		//---------------------------------------------------------------------------
 		template <class _IN>
 			void internal_command_inout (const std::string& cmd_name, const _IN& argin, DevVarLongStringArray& argout,std::string file= __FILE__, int line= __LINE__)
-			throw (Tango::DevFailed)
 		{
 #if (defined(_MSC_VER) && _MSC_VER < 1300)
 #pragma message  (" TANGO WARNING ***** command_inout:Use only STL vector instead of DevVarLongStringArray *****")
@@ -510,7 +502,6 @@ namespace Tango
 #endif
 		template <class _IN>
 			void internal_command_in (const std::string& cmd_name, const _IN& argin,  std::string file= __FILE__, int line= __LINE__)
-			throw (Tango::DevFailed)
 		{
 			if (device_proxy_)
 			{
@@ -548,7 +539,6 @@ namespace Tango
 			void internal_command_in (const std::string& cmd_name,
 			const std::vector<_IN>& _nv_in,
 			const std::vector<std::string>& _sv_in, std::string file= __FILE__, int line= __LINE__)
-			throw (Tango::DevFailed)
 		{
 			if (device_proxy_)
 			{
@@ -585,7 +575,6 @@ namespace Tango
 #endif
 		template <class _OUT>
 			void internal_command_out (const std::string& cmd_name, _OUT& argout,  std::string file= __FILE__, int line= __LINE__)
-			throw (Tango::DevFailed)
 		{
 
 			if (device_proxy_)
@@ -624,7 +613,6 @@ namespace Tango
 		//---------------------------------------------------------------------------
 		template <class _OUT>
 			void internal_command_out(_OUT dummy, DevVarDoubleStringArray* argout,  std::string file= __FILE__, int line= __LINE__)
-			throw (Tango::DevFailed)
 		{
 #if (defined(_MSC_VER) && _MSC_VER < 1300)
 #pragma message  (" TANGO WARNING ***** command_out:Use only STL vector instead of DevVarDoubleStringArray *****")
@@ -643,7 +631,6 @@ namespace Tango
 		//---------------------------------------------------------------------------
 		template <class _OUT>
 			void internal_command_out (_OUT dummy, DevVarLongStringArray* argout,  std::string file= __FILE__, int line= __LINE__)
-			throw (Tango::DevFailed)
 		{
 #if (defined(_MSC_VER) && _MSC_VER < 1300)
 #pragma message  (" TANGO WARNING ***** command_out:Use only STL vector instead of DevVarLongStringArray *****")
@@ -660,7 +647,6 @@ namespace Tango
 		//---------------------------------------------------------------------------
 		template <class _OUT>
 			void internal_command_out(_OUT dummy, DevVarDoubleStringArray& argout,  std::string file= __FILE__, int line= __LINE__)
-			throw (Tango::DevFailed)
 		{
 #if (defined(_MSC_VER) && _MSC_VER < 1300)
 #pragma message  (" TANGO WARNING ***** command_out:Use only STL vector instead of DevVarDoubleStringArray *****")
@@ -677,7 +663,6 @@ namespace Tango
 		//---------------------------------------------------------------------------
 		template <class _OUT>
 			void internal_command_out (_OUT dummy, DevVarLongStringArray& argout,  std::string file= __FILE__, int line= __LINE__)
-			throw (Tango::DevFailed)
 		{
 #if (defined(_MSC_VER) && _MSC_VER < 1300)
 #pragma message  (" TANGO WARNING ***** command_out:Use only STL vector instead of DevVarLongStringArray *****")
@@ -707,7 +692,6 @@ namespace Tango
 			std::vector<std::string>& _sv_out,
 			std::string file= __FILE__,
 			int line= __LINE__)
-			throw (Tango::DevFailed)
 		{
 			if (device_proxy_)
 			{
@@ -787,7 +771,6 @@ public:
 	//---------------------------------------------------------------------------
 	template <class _VAL>
 		void internal_write_attribute (const std::string& attr_name, const _VAL& attr_value, std::string file, int line)
-		throw (Tango::DevFailed)
 	{
 		if (device_proxy_)
 		{
@@ -817,7 +800,6 @@ public:
 	//---------------------------------------------------------------------------
 	template <class _VAL>
 		void internal_read_attribute (const std::string& attr_name, _VAL& attr_value, std::string file, int line )
-		throw (Tango::DevFailed)
 	{
 
 		if (device_proxy_)
@@ -860,7 +842,6 @@ public:
 	//---------------------------------------------------------------------------
 	template <class _VAL>
 		void internal_read_attribute_w (const std::string& attr_name, _VAL& w_attr_value, std::string file, int line )
-		throw (Tango::DevFailed)
 	{
 
 		if (device_proxy_)

--- a/include/tango/server/device_2.h
+++ b/include/tango/server/device_2.h
@@ -256,8 +256,7 @@ public:
  * Click <a href="../../../tango_idl/idl_html/_Tango.html#DevFailed">here</a> to read
  * <b>DevFailed</b> exception specification
  */
-    	virtual Tango::AttributeConfigList_2 *get_attribute_config_2(const Tango::DevVarStringArray& names)
-        throw(Tango::DevFailed, CORBA::SystemException);
+	virtual Tango::AttributeConfigList_2 *get_attribute_config_2(const Tango::DevVarStringArray& names);
 
 
 /**
@@ -281,8 +280,7 @@ public:
  * <b>DevFailed</b> exception specification
  */
 	virtual Tango::DevAttrHistoryList *read_attribute_history_2(const char* name,
-								  DevLong n)
-	throw(Tango::DevFailed, CORBA::SystemException);
+								  DevLong n);
 
 /**
  * Read command value history.
@@ -307,8 +305,7 @@ public:
  */
 
 	virtual Tango::DevCmdHistoryList *command_inout_history_2(const char* command,
-								DevLong n)
-	throw(Tango::DevFailed, CORBA::SystemException);
+								DevLong n);
 //@}
 
 private:

--- a/src/log4tango/Level.cpp
+++ b/src/log4tango/Level.cpp
@@ -77,7 +77,6 @@ static const std::string names[NUM_LEVELS] = {
 }
 
 Level::Value Level::get_value(const std::string& level_name) 
-    throw(std::invalid_argument) 
 {
 static const std::string names[NUM_LEVELS] = {
     std::string("OFF"),

--- a/src/server/device_2.cpp
+++ b/src/server/device_2.cpp
@@ -1108,8 +1108,7 @@ namespace Tango {
 //
 //--------------------------------------------------------------------------
 
-    Tango::AttributeConfigList_2 *Device_2Impl::get_attribute_config_2(const Tango::DevVarStringArray &names)
-    throw(Tango::DevFailed, CORBA::SystemException) {
+    Tango::AttributeConfigList_2 *Device_2Impl::get_attribute_config_2(const Tango::DevVarStringArray &names) {
         TangoMonitor &mon = get_att_conf_monitor();
         AutoTangoMonitor sync(&mon);
 
@@ -1212,8 +1211,7 @@ namespace Tango {
 //--------------------------------------------------------------------------
 
     Tango::DevCmdHistoryList *Device_2Impl::command_inout_history_2(const char *command,
-                                                                    DevLong n)
-    throw(Tango::DevFailed, CORBA::SystemException) {
+                                                                    DevLong n) {
         TangoMonitor &mon = get_poll_monitor();
         AutoTangoMonitor sync(&mon);
 
@@ -1386,8 +1384,7 @@ namespace Tango {
 //--------------------------------------------------------------------------
 
     Tango::DevAttrHistoryList *Device_2Impl::read_attribute_history_2(const char *name,
-                                                                      DevLong n)
-    throw(Tango::DevFailed, CORBA::SystemException) {
+                                                                      DevLong n) {
         TangoMonitor &mon = get_poll_monitor();
         AutoTangoMonitor sync(&mon);
 


### PR DESCRIPTION
/usr/local/include/tango/log4tango/Level.hh:120:6: error: ISO C++1z does not allow dynamic exception specifications
      throw(std::invalid_argument);
      ^~~~~
In file included from /usr/local/include/tango/tango.h:115:0,
                 from src/tango/deviceproxy_pool.hpp:12,
                 from src/tango/deviceproxy_pool.cpp:1:
/usr/local/include/tango/device_2.h:260:9: error: ISO C++1z does not allow dynamic exception specifications
         throw(Tango::DevFailed, CORBA::SystemException);
         ^~~~~
/usr/local/include/tango/device_2.h:285:2: error: ISO C++1z does not allow dynamic exception specifications
  throw(Tango::DevFailed, CORBA::SystemException);
  ^~~~~
/usr/local/include/tango/device_2.h:311:2: error: ISO C++1z does not allow dynamic exception specifications
  throw(Tango::DevFailed, CORBA::SystemException);

Dynamic exception specifications are deprecated since C++11
(see: http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2015/p0003r0.html)
but it doesn't seems mandatory remove these when using C++17.
Unfortunately GCC treats these as errors so remove these anyway
to make it happy.