### PR TITLE
remove event subscription sleeps on linux

### DIFF
--- a/cppapi/client/event.cpp
+++ b/cppapi/client/event.cpp
@@ -1814,7 +1814,7 @@ int EventConsumer::connect_event(DeviceProxy *device,
 // This sleep seems no longer needed on Debian 9
 	struct timespec ts;
 	//ts.tv_nsec = 20000000;
-	ts.tv_nsec = 1000000;
+	ts.tv_nsec = 500000;
 	ts.tv_sec = 0;
 	nanosleep(&ts,NULL);
 #else
@@ -3120,7 +3120,7 @@ void EventConsumer::get_fire_sync_event(DeviceProxy *device,CallBack *callback,E
 	struct timespec to_wait,inter;
 	to_wait.tv_sec = 0;
 	//to_wait.tv_nsec = 10000000;
-	to_wait.tv_nsec = 500000;
+	to_wait.tv_nsec = 100000;
 
 	nanosleep(&to_wait,&inter);
 #else

--- a/cppapi/client/event.cpp
+++ b/cppapi/client/event.cpp
@@ -1807,14 +1807,12 @@ int EventConsumer::connect_event(DeviceProxy *device,
 	get_fire_sync_event(device,callback,ev_queue,event,event_name,obj_name,iter->second,local_callback_key);
 
 //
-// Sleep for some mS (20) in order to give to ZMQ some times to propagate the subscription to the publisher
+// Sleep for some mS in order to give to ZMQ some times to propagate the subscription to the publisher
 //
 
 #ifndef _TG_WINDOWS_
-// This sleep seems no longer needed on Debian 9
 	struct timespec ts;
-	//ts.tv_nsec = 20000000;
-	ts.tv_nsec = 500000;
+	ts.tv_nsec = 1000000; //20000000;
 	ts.tv_sec = 0;
 	nanosleep(&ts,NULL);
 #else
@@ -3111,17 +3109,14 @@ void EventConsumer::get_fire_sync_event(DeviceProxy *device,CallBack *callback,E
 {
 
 //
-// A small 10 mS sleep here! This is required in case there is a push_event in the read_attribute (or pipe)
+// A small mS sleep here! This is required in case there is a push_event in the read_attribute (or pipe)
 // method on the device side. This sleep gives time to ZMQ to send its subscription message
 //
 
 #ifndef _TG_WINDOWS_
-// This sleep seems no longer needed on Debian 9
 	struct timespec to_wait,inter;
 	to_wait.tv_sec = 0;
-	//to_wait.tv_nsec = 10000000;
-	to_wait.tv_nsec = 100000;
-
+	to_wait.tv_nsec = 500000; //10000000;
 	nanosleep(&to_wait,&inter);
 #else
 	Sleep(25);

--- a/cppapi/client/event.cpp
+++ b/cppapi/client/event.cpp
@@ -1812,10 +1812,11 @@ int EventConsumer::connect_event(DeviceProxy *device,
 
 #ifndef _TG_WINDOWS_
 // This sleep seems no longer needed on Debian 9
-//     struct timespec ts;
-//     ts.tv_nsec = 20000000;
-//     ts.tv_sec = 0;
-//     nanosleep(&ts,NULL);
+	struct timespec ts;
+	//ts.tv_nsec = 20000000;
+	ts.tv_nsec = 5000000;
+	ts.tv_sec = 0;
+	nanosleep(&ts,NULL);
 #else
 	Sleep(20);
 #endif
@@ -3116,11 +3117,12 @@ void EventConsumer::get_fire_sync_event(DeviceProxy *device,CallBack *callback,E
 
 #ifndef _TG_WINDOWS_
 // This sleep seems no longer needed on Debian 9
-//	struct timespec to_wait,inter;
-//	to_wait.tv_sec = 0;
-//	to_wait.tv_nsec = 10000000;
+	struct timespec to_wait,inter;
+	to_wait.tv_sec = 0;
+	//to_wait.tv_nsec = 10000000;
+	to_wait.tv_nsec = 1000000;
 
-//	nanosleep(&to_wait,&inter);
+	nanosleep(&to_wait,&inter);
 #else
 	Sleep(25);
 #endif

--- a/cppapi/client/event.cpp
+++ b/cppapi/client/event.cpp
@@ -1814,7 +1814,7 @@ int EventConsumer::connect_event(DeviceProxy *device,
 // This sleep seems no longer needed on Debian 9
 	struct timespec ts;
 	//ts.tv_nsec = 20000000;
-	ts.tv_nsec = 5000000;
+	ts.tv_nsec = 1000000;
 	ts.tv_sec = 0;
 	nanosleep(&ts,NULL);
 #else
@@ -3120,7 +3120,7 @@ void EventConsumer::get_fire_sync_event(DeviceProxy *device,CallBack *callback,E
 	struct timespec to_wait,inter;
 	to_wait.tv_sec = 0;
 	//to_wait.tv_nsec = 10000000;
-	to_wait.tv_nsec = 1000000;
+	to_wait.tv_nsec = 500000;
 
 	nanosleep(&to_wait,&inter);
 #else

--- a/cppapi/client/event.cpp
+++ b/cppapi/client/event.cpp
@@ -1811,11 +1811,11 @@ int EventConsumer::connect_event(DeviceProxy *device,
 //
 
 #ifndef _TG_WINDOWS_
-    struct timespec ts;
-    ts.tv_nsec = 20000000;
-    ts.tv_sec = 0;
-
-    nanosleep(&ts,NULL);
+// This sleep seems no longer needed on Debian 9
+//     struct timespec ts;
+//     ts.tv_nsec = 20000000;
+//     ts.tv_sec = 0;
+//     nanosleep(&ts,NULL);
 #else
 	Sleep(20);
 #endif
@@ -3115,11 +3115,12 @@ void EventConsumer::get_fire_sync_event(DeviceProxy *device,CallBack *callback,E
 //
 
 #ifndef _TG_WINDOWS_
-	struct timespec to_wait,inter;
-	to_wait.tv_sec = 0;
-	to_wait.tv_nsec = 10000000;
+// This sleep seems no longer needed on Debian 9
+//	struct timespec to_wait,inter;
+//	to_wait.tv_sec = 0;
+//	to_wait.tv_nsec = 10000000;
 
-	nanosleep(&to_wait,&inter);
+//	nanosleep(&to_wait,&inter);
 #else
 	Sleep(25);
 #endif


### PR DESCRIPTION
I'm currently testing these changes using HDB++ and Taurus GUI's.
I have not detected any case yet in which removing the sleeps has caused subscription to fail.
Please, try it on your test suites to see if it has any unwanted consequence.