### PR TITLE
Enable Travis debian7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,8 @@ env:
   matrix:
     - OS_TYPE=debian8 CMAKE_BUILD_TYPE=DEBUG
     - OS_TYPE=debian8 CMAKE_BUILD_TYPE=RELEASE
-#    - OS_TYPE=debian7 CMAKE_BUILD_TYPE=RELEASE
+    - OS_TYPE=debian7 CMAKE_BUILD_TYPE=RELEASE
+    - OS_TYPE=debian7 CMAKE_BUILD_TYPE=DEBUG
 #    - OS_TYPE=win32
 # etc
 

--- a/.travis/debian7/Dockerfile
+++ b/.travis/debian7/Dockerfile
@@ -8,9 +8,11 @@ MAINTAINER TANGO Controls team <tango@esrf.fr>
 
 RUN apt-get update && apt-get install -y apt-utils
 
-RUN apt-get update && apt-get install -y build-essential
+RUN apt-get install -y build-essential
 
-RUN apt-get update && apt-get install -y wget
+RUN apt-get install -y procps
+
+RUN apt-get install -y wget
 
 RUN wget --no-check-certificate https://cmake.org/files/v3.10/cmake-3.10.0-Linux-x86_64.sh -O /tmp/cmake-install.sh
 
@@ -18,7 +20,7 @@ RUN chmod +x /tmp/cmake-install.sh
 
 RUN /tmp/cmake-install.sh --skip-license --exclude-subdir
 
-RUN apt-get update && apt-get install -y omniidl libomniorb4-dev libcos4-dev libomnithread3-dev libzmq3-dev
+RUN apt-get install -y omniidl libomniorb4-dev libcos4-dev libomnithread3-dev libzmq3-dev
 
 RUN groupadd -g "$APP_GID" tango
 

--- a/.travis/debian7/Dockerfile
+++ b/.travis/debian7/Dockerfile
@@ -8,7 +8,15 @@ MAINTAINER TANGO Controls team <tango@esrf.fr>
 
 RUN apt-get update && apt-get install -y apt-utils
 
-RUN apt-get update && apt-get install -y build-essential cmake
+RUN apt-get update && apt-get install -y build-essential
+
+RUN apt-get update && apt-get install -y wget
+
+RUN wget --no-check-certificate https://cmake.org/files/v3.10/cmake-3.10.0-Linux-x86_64.sh -O /tmp/cmake-install.sh
+
+RUN chmod +x /tmp/cmake-install.sh
+
+RUN /tmp/cmake-install.sh --skip-license --exclude-subdir
 
 RUN apt-get update && apt-get install -y omniidl libomniorb4-dev libcos4-dev libomnithread3-dev libzmq3-dev
 


### PR DESCRIPTION
Enable Travis CI tests for Debian 7.
CMake v3.10 is downloaded and installed using the installer script provided by CMake.org