### PR TITLE
Fix issue with polling not starting automatically on dynamic attributes

### DIFF
--- a/cppapi/server/device.cpp
+++ b/cppapi/server/device.cpp
@@ -3443,8 +3443,7 @@ void DeviceImpl::add_attribute(Tango::Attr *new_attr)
 //
 
     long per = new_attr->get_polling_period();
-    Tango::Util *tg = Tango::Util::instance();
-    if (tg->is_svr_starting() == false && per != 0)
+    if ((!is_attribute_polled(attr_name)) && (per != 0))
     {
         poll_attribute(attr_name, per);
     }


### PR DESCRIPTION
Fix issue with polling not starting automatically on dynamic attributes created in device_factory() and with a polling period defined in POGO and having no polling period yet defined in the Tango database