### PR TITLE
Add a map in MultiAttribute object to improve performances (#424)

### DIFF
--- a/cppapi/server/attribute.h
+++ b/cppapi/server/attribute.h
@@ -68,20 +68,6 @@ struct WantedProp : public  binary_function<A1,A2,R>
 	}
 };
 
-template <typename A1, typename A2, typename R>
-struct WantedAttr : public binary_function<A1,A2,R>
-{
-	R operator() (A1 attr_ptr, A2 name) const
-	{
-		string st(name);
-		if (st.size() != attr_ptr->get_name_size())
-			return false;
-		transform(st.begin(),st.end(),st.begin(),::tolower);
-		return attr_ptr->get_name_lower() == st;
-	}
-};
-
-
 class AttrProperty;
 class DeviceClass;
 

--- a/cppapi/server/multiattribute.cpp
+++ b/cppapi/server/multiattribute.cpp
@@ -811,10 +811,7 @@ void MultiAttribute::add_attribute(string &dev_name,DeviceClass *dev_class_ptr,l
 			Attribute * new_attr = new WAttribute(prop_list,attr,dev_name,index);
 			attr_list.insert(ite,new_attr);
 			index = attr_list.size() - 3;
-			MultiAttributeExt::AttributePtrAndIndex mapElement;
-			mapElement.att_ptr = new_attr;
-			mapElement.att_index_in_vector = index;
-			ext->attr_map[new_attr->get_name_lower()] = mapElement;
+			ext->put_attribute_in_map(new_attr,index);
 		}
 	}
 	else
@@ -830,10 +827,7 @@ void MultiAttribute::add_attribute(string &dev_name,DeviceClass *dev_class_ptr,l
 			Attribute * new_attr = new Attribute(prop_list,attr,dev_name,index);
 			attr_list.insert(ite,new_attr);
 			index = attr_list.size() - 3;
-			MultiAttributeExt::AttributePtrAndIndex mapElement;
-			mapElement.att_ptr = new_attr;
-			mapElement.att_index_in_vector = index;
-			ext->attr_map[new_attr->get_name_lower()] = mapElement;
+			ext->put_attribute_in_map(new_attr,index);
 		}
 	}
 
@@ -967,10 +961,7 @@ void MultiAttribute::add_fwd_attribute(string &dev_name,DeviceClass *dev_class_p
 	Attribute * new_fwd_attr = new FwdAttribute(prop_list,*new_attr,dev_name,index);
 	attr_list.insert(ite,new_fwd_attr);
 	index = attr_list.size() - 3;
-	MultiAttributeExt::AttributePtrAndIndex mapElement;
-	mapElement.att_ptr = new_fwd_attr;
-	mapElement.att_index_in_vector = index;
-	ext->attr_map[new_fwd_attr->get_name_lower()] = mapElement;
+	ext->put_attribute_in_map(new_fwd_attr,index);
 
 //
 // If it is writable, add it to the writable attribute list
@@ -1858,10 +1849,7 @@ void MultiAttribute::add_alarmed_quality_factor(string &status)
 void MultiAttribute::add_attr(Attribute *att)
 {
     attr_list.push_back(att);
-    MultiAttributeExt::AttributePtrAndIndex mapElement;
-    mapElement.att_ptr = att;
-    mapElement.att_index_in_vector = attr_list.size() - 1;
-    ext->attr_map[att->get_name_lower()] = mapElement;
+    ext->put_attribute_in_map(att,attr_list.size() - 1);
 }
 
 //+------------------------------------------------------------------------------------------------------------------

--- a/cppapi/server/multiattribute.cpp
+++ b/cppapi/server/multiattribute.cpp
@@ -88,7 +88,7 @@ static OptAttrProp Tango_OptAttrProp[] = {
 //------------------------------------------------------------------------------------------------------------------
 
 MultiAttribute::MultiAttribute(string &dev_name,DeviceClass *dev_class_ptr,DeviceImpl *dev)
-:ext(Tango_nullptr)
+:ext(new MultiAttribute::MultiAttributeExt)
 {
 	long i;
 	cout4 << "Entering MultiAttribute class constructor for device " << dev_name << endl;
@@ -269,16 +269,28 @@ MultiAttribute::MultiAttribute(string &dev_name,DeviceClass *dev_class_ptr,Devic
 					(attr.get_writable() == Tango::READ_WRITE))
 				{
 					if (attr.is_fwd() == true)
-						attr_list.push_back(new FwdAttribute(prop_list,attr,dev_name,i));
+					{
+						Attribute * new_attr = new FwdAttribute(prop_list,attr,dev_name,i);
+						add_attr(new_attr);
+					}
 					else
-						attr_list.push_back(new WAttribute(prop_list,attr,dev_name,i));
+					{
+						Attribute * new_attr = new WAttribute(prop_list, attr, dev_name, i);
+						add_attr(new_attr);
+					}
 				}
 				else
 				{
 					if (attr.is_fwd() == true)
-						attr_list.push_back(new FwdAttribute(prop_list,attr,dev_name,i));
+					{
+						Attribute * new_attr = new FwdAttribute(prop_list, attr, dev_name, i);
+						add_attr(new_attr);
+					}
 					else
-						attr_list.push_back(new Attribute(prop_list,attr,dev_name,i));
+					{
+						Attribute * new_attr = new Attribute(prop_list, attr, dev_name, i);
+						add_attr(new_attr);
+					}
 				}
 
 //
@@ -348,6 +360,10 @@ MultiAttribute::~MultiAttribute()
 {
 	for(unsigned long i = 0;i < attr_list.size();i++)
 		delete attr_list[i];
+	ext->attr_map.clear();
+#ifndef HAS_UNIQUE_PTR
+	delete ext;
+#endif
 }
 
 //+-----------------------------------------------------------------------------------------------------------------
@@ -786,26 +802,38 @@ void MultiAttribute::add_attribute(string &dev_name,DeviceClass *dev_class_ptr,l
 	{
 		if (idl_3 == false)
 		{
-			attr_list.push_back(new WAttribute(prop_list,attr,dev_name,index));
+			Attribute * new_attr = new WAttribute(prop_list,attr,dev_name,index);
+			add_attr(new_attr);
 			index = attr_list.size() - 1;
 		}
 		else
 		{
-			attr_list.insert(ite,new WAttribute(prop_list,attr,dev_name,index));
+			Attribute * new_attr = new WAttribute(prop_list,attr,dev_name,index);
+			attr_list.insert(ite,new_attr);
 			index = attr_list.size() - 3;
+			MultiAttributeExt::AttributePtrAndIndex mapElement;
+			mapElement.att_ptr = new_attr;
+			mapElement.att_index_in_vector = index;
+			ext->attr_map[new_attr->get_name_lower()] = mapElement;
 		}
 	}
 	else
 	{
 		if (idl_3 == false)
 		{
-			attr_list.push_back(new Attribute(prop_list,attr,dev_name,index));
+			Attribute * new_attr = new Attribute(prop_list,attr,dev_name,index);
+			add_attr(new_attr);
 			index = attr_list.size() - 1;
 		}
 		else
 		{
-			attr_list.insert(ite,new Attribute(prop_list,attr,dev_name,index));
+			Attribute * new_attr = new Attribute(prop_list,attr,dev_name,index);
+			attr_list.insert(ite,new_attr);
 			index = attr_list.size() - 3;
+			MultiAttributeExt::AttributePtrAndIndex mapElement;
+			mapElement.att_ptr = new_attr;
+			mapElement.att_index_in_vector = index;
+			ext->attr_map[new_attr->get_name_lower()] = mapElement;
 		}
 	}
 
@@ -936,8 +964,13 @@ void MultiAttribute::add_fwd_attribute(string &dev_name,DeviceClass *dev_class_p
 	vector<Attribute *>::iterator ite;
 	ite = attr_list.end() - 2;
 
-	attr_list.insert(ite,new FwdAttribute(prop_list,*new_attr,dev_name,index));
+	Attribute * new_fwd_attr = new FwdAttribute(prop_list,*new_attr,dev_name,index);
+	attr_list.insert(ite,new_fwd_attr);
 	index = attr_list.size() - 3;
+	MultiAttributeExt::AttributePtrAndIndex mapElement;
+	mapElement.att_ptr = new_fwd_attr;
+	mapElement.att_index_in_vector = index;
+	ext->attr_map[new_fwd_attr->get_name_lower()] = mapElement;
 
 //
 // If it is writable, add it to the writable attribute list
@@ -1005,6 +1038,7 @@ void MultiAttribute::remove_attribute(string &attr_name,bool update_idx)
 	DeviceImpl *the_dev = att->get_att_device();
 	string &dev_class_name = the_dev->get_device_class()->get_name();
 
+	ext->attr_map.erase(att->get_name_lower());
 	delete att;
 	vector<Tango::Attribute *>::iterator pos = attr_list.begin();
 	advance(pos,att_index);
@@ -1081,7 +1115,6 @@ void MultiAttribute::remove_attribute(string &attr_name,bool update_idx)
 		check_associated(i,default_dev_name);
 	}
 
-
 	cout4 << "Leaving MultiAttribute::remove_attribute" << endl;
 }
 
@@ -1105,23 +1138,40 @@ void MultiAttribute::remove_attribute(string &attr_name,bool update_idx)
 
 Attribute &MultiAttribute::get_attr_by_name(const char *attr_name)
 {
-	vector<Attribute *>::iterator pos;
+    Attribute * attr = 0;
+    string st(attr_name);
+    transform(st.begin(),st.end(),st.begin(),::tolower);
+#ifdef HAS_MAP_AT
+    try
+    {
+        attr = ext->attr_map.at(st).att_ptr;
+    }
+    catch(out_of_range e)
+    {
+        cout3 << "MultiAttribute::get_attr_by_name throwing exception" << endl;
+        TangoSys_OMemStream o;
 
-	pos = find_if(attr_list.begin(),attr_list.end(),
-		      bind2nd(WantedAttr<Attribute *,const char *,bool>(),attr_name));
+        o << attr_name << " attribute not found" << ends;
+        Except::throw_exception((const char *)API_AttrNotFound,
+                                o.str(),
+                                (const char *)"MultiAttribute::get_attr_by_name");
+    }
+#else
+    map<string, MultiAttributeExt::AttributePtrAndIndex>::iterator it;
+    it = ext->attr_map.find(st);
+    if (it == ext->attr_map.end())
+    {
+        cout3 << "MultiAttribute::get_attr_by_name throwing exception" << endl;
+        TangoSys_OMemStream o;
 
-	if (pos == attr_list.end())
-	{
-		cout3 << "MultiAttribute::get_attr_by_name throwing exception" << endl;
-		TangoSys_OMemStream o;
-
-		o << attr_name << " attribute not found" << ends;
-		Except::throw_exception((const char *)API_AttrNotFound,
-				      o.str(),
-				      (const char *)"MultiAttribute::get_attr_by_name");
-	}
-
-	return *(*pos);
+        o << attr_name << " attribute not found" << ends;
+        Except::throw_exception((const char *)API_AttrNotFound,
+                                o.str(),
+                                (const char *)"MultiAttribute::get_attr_by_name");
+    }
+    attr = it->second.att_ptr;
+#endif
+    return *attr;
 }
 
 //+------------------------------------------------------------------------------------------------------------------
@@ -1143,28 +1193,53 @@ Attribute &MultiAttribute::get_attr_by_name(const char *attr_name)
 
 WAttribute &MultiAttribute::get_w_attr_by_name(const char *attr_name)
 {
-	vector<Attribute *>::iterator pos;
+    Attribute * attr = 0;
+    string st(attr_name);
+    transform(st.begin(),st.end(),st.begin(),::tolower);
+#ifdef HAS_MAP_AT
+    try
+    {
+        attr = ext->attr_map.at(st).att_ptr;
+    }
+    catch(out_of_range e)
+    {
+        cout3 << "MultiAttribute::get_attr_by_name throwing exception" << endl;
+        TangoSys_OMemStream o;
 
-	pos = find_if(attr_list.begin(),attr_list.end(),
-		      bind2nd(WantedAttr<Attribute *,const char *,bool>(),attr_name));
+        o << attr_name << " writable attribute not found" << ends;
+        Except::throw_exception((const char *)API_AttrNotFound,
+                                o.str(),
+                                (const char *)"MultiAttribute::get_w_attr_by_name");
+    }
+#else
+    map<string, MultiAttributeExt::AttributePtrAndIndex>::iterator it;
+    it = ext->attr_map.find(st);
+    if (it == ext->attr_map.end())
+    {
+        cout3 << "MultiAttribute::get_attr_by_name throwing exception" << endl;
+        TangoSys_OMemStream o;
 
-	if ( (    pos == attr_list.end() ) ||
-		  ( ((*pos)->get_writable() != Tango::WRITE) &&
-		    ((*pos)->get_writable() != Tango::READ_WRITE) ) )
-	{
-		cout3 << "MultiAttribute::get_w_attr_by_name throwing exception" << endl;
-		TangoSys_OMemStream o;
+        o << attr_name << " writable attribute not found" << ends;
+        Except::throw_exception((const char *)API_AttrNotFound,
+                                o.str(),
+                                (const char *)"MultiAttribute::get_w_attr_by_name");
+    }
+    attr = it->second.att_ptr;
+#endif
 
-		o << attr_name << " writable attribute not found" << ends;
-		Except::throw_exception((const char *)API_AttrNotFound,
-				      o.str(),
-				      (const char *)"MultiAttribute::get_w_attr_by_name");
-	}
+    if ((attr->get_writable() != Tango::WRITE) &&
+        (attr->get_writable() != Tango::READ_WRITE))
+    {
+        cout3 << "MultiAttribute::get_attr_by_name throwing exception" << endl;
+        TangoSys_OMemStream o;
 
-
-	return static_cast<WAttribute &>(*(*pos));
+        o << attr_name << " writable attribute not found" << ends;
+        Except::throw_exception((const char *)API_AttrNotFound,
+                                o.str(),
+                                (const char *)"MultiAttribute::get_w_attr_by_name");
+    }
+    return static_cast<WAttribute &>(*attr);
 }
-
 
 //+-------------------------------------------------------------------------------------------------------------------
 //
@@ -1185,32 +1260,41 @@ WAttribute &MultiAttribute::get_w_attr_by_name(const char *attr_name)
 
 long MultiAttribute::get_attr_ind_by_name(const char *attr_name)
 {
-	long i;
+    long i;
+    string st(attr_name);
 
-	long nb_attr = attr_list.size();
-	string st(attr_name);
-	transform(st.begin(),st.end(),st.begin(),::tolower);
+    transform(st.begin(),st.end(),st.begin(),::tolower);
+#ifdef HAS_MAP_AT
+    try
+    {
+        i = ext->attr_map.at(st).att_index_in_vector;
+    }
+    catch(out_of_range e)
+    {
+        cout3 << "MultiAttribute::get_attr_ind_by_name throwing exception" << endl;
+        TangoSys_OMemStream o;
 
-	for (i = 0;i < nb_attr;i++)
-	{
-		if (attr_list[i]->get_name_size() != st.size())
-			continue;
-		if (attr_list[i]->get_name_lower() == st)
-			break;
-	}
+        o << attr_name << " attribute not found" << ends;
+        Except::throw_exception((const char *)API_AttrNotFound,
+                                o.str(),
+                                (const char *)"MultiAttribute::get_attr_ind_by_name");
+    }
+#else
+    map<string, MultiAttributeExt::AttributePtrAndIndex>::iterator it;
+    it = ext->attr_map.find(st);
+    if (it == ext->attr_map.end())
+    {
+        cout3 << "MultiAttribute::get_attr_ind_by_name throwing exception" << endl;
+        TangoSys_OMemStream o;
 
-	if (i == nb_attr)
-	{
-		cout3 << "MultiAttribute::get_attr_ind_by_name throwing exception" << endl;
-		TangoSys_OMemStream o;
-
-		o << attr_name << " attribute not found" << ends;
-		Except::throw_exception((const char *)API_AttrNotFound,
-				      o.str(),
-				      (const char *)"MultiAttribute::get_attr_ind_by_name");
-	}
-
-	return i;
+        o << attr_name << " attribute not found" << ends;
+        Except::throw_exception((const char *)API_AttrNotFound,
+                                o.str(),
+                                (const char *)"MultiAttribute::get_attr_ind_by_name");
+    }
+    i = it->second.att_index_in_vector;
+#endif
+    return i;
 }
 
 //+--------------------------------------------------------------------------------------------------------------------
@@ -1756,7 +1840,28 @@ void MultiAttribute::add_alarmed_quality_factor(string &status)
 			status = status + str;
 		}
 	}
+}
 
+//+------------------------------------------------------------------------------------------------------------------
+//
+// method :
+//		MultiAttribute::add_attr()
+//
+// description :
+//		Add given attribute to the attribute list vector and map
+//
+// argument:
+//		in :
+//			- att : The newly configured attribute
+//
+//-------------------------------------------------------------------------------------------------------------------
+void MultiAttribute::add_attr(Attribute *att)
+{
+    attr_list.push_back(att);
+    MultiAttributeExt::AttributePtrAndIndex mapElement;
+    mapElement.att_ptr = att;
+    mapElement.att_index_in_vector = attr_list.size() - 1;
+    ext->attr_map[att->get_name_lower()] = mapElement;
 }
 
 //+------------------------------------------------------------------------------------------------------------------

--- a/cppapi/server/multiattribute.h
+++ b/cppapi/server/multiattribute.h
@@ -290,7 +290,7 @@ public:
 	void add_attr(Attribute *att);
 	void update(Attribute &,string &);
 	void check_idl_release(DeviceImpl *);
-    bool is_opt_prop(const string &);
+	bool is_opt_prop(const string &);
 
 private:
     class MultiAttributeExt
@@ -303,6 +303,13 @@ private:
 		};
 		MultiAttributeExt() {}
 		map<string, AttributePtrAndIndex> attr_map;
+		void put_attribute_in_map(Attribute * att, long index)
+		{
+			AttributePtrAndIndex mapElement;
+			mapElement.att_ptr = att;
+			mapElement.att_index_in_vector = index;
+			attr_map[att->get_name_lower()] = mapElement;
+		}
     };
 
 	void concat(vector<AttrProperty> &,vector<AttrProperty> &,vector<AttrProperty> &);

--- a/cppapi/server/multiattribute.h
+++ b/cppapi/server/multiattribute.h
@@ -287,7 +287,7 @@ public:
 	void set_event_param(vector<EventPar> &);
 	void add_alarmed_quality_factor(string &);
 	void add_default(vector<AttrProperty> &,string &,string &,long);
-	void add_attr(Attribute *att) {attr_list.push_back(att);}
+	void add_attr(Attribute *att);
 	void update(Attribute &,string &);
 	void check_idl_release(DeviceImpl *);
     bool is_opt_prop(const string &);
@@ -295,6 +295,14 @@ public:
 private:
     class MultiAttributeExt
     {
+	public:
+		struct AttributePtrAndIndex
+		{
+			Attribute * att_ptr;
+			long att_index_in_vector;
+		};
+		MultiAttributeExt() {}
+		map<string, AttributePtrAndIndex> attr_map;
     };
 
 	void concat(vector<AttrProperty> &,vector<AttrProperty> &,vector<AttrProperty> &);

--- a/cppapi/server/tango_config.h
+++ b/cppapi/server/tango_config.h
@@ -83,9 +83,11 @@
             #define WIN32_VC10
 		#elif ((_MSC_VER >= 1700) && (_MSC_VER < 1800))
 			#define WIN32_VC11
-		#elif (_MSC_VER >= 1800)
+		#elif ((_MSC_VER >= 1800) && (_MSC_VER < 1900))
 			#define WIN32_VC12
-        #endif   // VC8+/VC9/VC10/VC11/VC12
+        #elif (_MSC_VER >= 1900)
+			#define WIN32_VC14
+        #endif   // VC8+/VC9/VC10/VC11/VC12/VC14
     #endif
 #endif
 
@@ -132,6 +134,7 @@
 
 //
 // Some C++11 feature
+// map::at() -> gcc 4.1.0 (See C++ Standard Library Defect Report 464)
 // Unique_ptr -> gcc 4.3
 // rvalues -> gcc 4.3
 // Lambda function -> gcc 4.5
@@ -141,6 +144,9 @@
 #ifndef _TG_WINDOWS_
     #if defined(__GNUC__)
         #if __GNUC__ == 4
+            #if __GNUC_MINOR__ > 0
+                #define HAS_MAP_AT
+            #endif
             #if __GNUC_MINOR__ > 3
                 #define HAS_UNIQUE_PTR
                 #define HAS_RVALUE
@@ -172,6 +178,7 @@
 				#define HAS_TYPE_TRAITS
 				#define HAS_UNDERLYING
 				#define HAS_VARIADIC_TEMPLATE
+				#define HAS_MAP_AT
         #endif
     #endif
 #else
@@ -181,6 +188,7 @@
         #define HAS_NULLPTR
         #define HAS_RVALUE
         #define HAS_TYPE_TRAITS
+        #define HAS_MAP_AT
     #endif
     #ifdef WIN32_VC11
         #define HAS_UNIQUE_PTR
@@ -190,6 +198,7 @@
 		#define HAS_RANGE_BASE_FOR
         #define HAS_TYPE_TRAITS
         #define HAS_UNDERLYING
+        #define HAS_MAP_AT
     #endif
     #ifdef WIN32_VC12
         #define HAS_UNIQUE_PTR
@@ -200,6 +209,18 @@
         #define HAS_TYPE_TRAITS
         #define HAS_UNDERLYING
         #define HAS_VARIADIC_TEMPLATE
+        #define HAS_MAP_AT
+    #endif
+    #ifdef WIN32_VC14
+        #define HAS_UNIQUE_PTR
+        #define HAS_LAMBDA_FUNC
+        #define HAS_NULLPTR
+        #define HAS_RVALUE
+        #define HAS_RANGE_BASE_FOR
+        #define HAS_TYPE_TRAITS
+        #define HAS_UNDERLYING
+        #define HAS_VARIADIC_TEMPLATE
+        #define HAS_MAP_AT
     #endif
 #endif
 


### PR DESCRIPTION
This solution is using an std::map.
Using an unordered_map if the compiler supports it could slightly improve the performances even more.
The gain is already big using an std::map.