### PR TITLE
tango_config.h: Add clang detection

### DIFF
--- a/cppapi/server/tango_config.h
+++ b/cppapi/server/tango_config.h
@@ -182,6 +182,23 @@
             #define HAS_MAP_AT
             #define HAS_ATTRIBUTE_SPECIFIERS
         #endif
+        #if defined(__clang__)
+            #if __clang_major__ > 3
+                #define HAS_UNIQUE_PTR
+                #define HAS_RVALUE
+                #define HAS_LAMBDA_FUNC
+                #define HAS_ISNAN_IN_STD
+                #define HAS_NULLPTR
+                #define HAS_RANGE_BASE_FOR
+                #define INIT_LIST
+                #define HAS_THREAD
+                #define HAS_TYPE_TRAITS
+                #define HAS_UNDERLYING
+                #define HAS_VARIADIC_TEMPLATE
+                #define HAS_MAP_AT
+                #define HAS_ATTRIBUTE_SPECIFIERS
+            #endif
+        #endif
     #endif
 #else
     #ifdef WIN32_VC10


### PR DESCRIPTION
According to [1] clang 3.3 has full C++11 support and 3.4 full C++14
support. So by requiring version 4 or higher we are on the safe side.

[1]: https://clang.llvm.org/cxx_status.html