### PR TITLE
Set the ZMQ Receive Buffer High Water Mark only if it changes (#444)

### DIFF
--- a/cppapi/client/eventconsumer.h
+++ b/cppapi/client/eventconsumer.h
@@ -638,6 +638,7 @@ private :
 	void print_error_message(const char *mess) {ApiUtil *au=ApiUtil::instance();au->print_error_message(mess);}
 	void set_ctrl_sock_bound() {sock_bound_mutex.lock();ctrl_socket_bound=true;sock_bound_mutex.unlock();}
 	bool is_ctrl_sock_bound() {bool _b;sock_bound_mutex.lock();_b=ctrl_socket_bound;sock_bound_mutex.unlock();return _b;}
+	void set_socket_hwm(size_t hwm);
 
     bool check_zmq_endpoint(const string &);
 


### PR DESCRIPTION
This is to reduce the impact of a bug present in ZMQ 4.2.0 and ZMQ 4.2.1 which led to a bad lwm and hwm calculation when ZMQ_RCVHWM was set after the bind of the socket. See #444 for more details