### PR TITLE
Pollthread: Fix multiline macro definitions

### DIFF
--- a/cppapi/server/pollthread.h
+++ b/cppapi/server/pollthread.h
@@ -183,30 +183,42 @@ public:
 // Three macros
 //
 
-#define T_DIFF(A,B,C) \
-	long delta_sec = B.tv_sec - A.tv_sec; \
-	if (delta_sec == 0) \
-		C = B.tv_usec - A.tv_usec; \
-	else \
-	{ \
-		C = ((delta_sec - 1) * 1000000) + (1000000 - A.tv_usec) + B.tv_usec; \
-	}
+#define T_DIFF(A,B,C)                                                      \
+  do                                                                       \
+  {                                                                        \
+    long delta_sec = B.tv_sec - A.tv_sec;                                  \
+    if (delta_sec == 0)                                                    \
+      C = B.tv_usec - A.tv_usec;                                           \
+    else                                                                   \
+    {                                                                      \
+      C = ((delta_sec - 1) * 1000000) + (1000000 - A.tv_usec) + B.tv_usec; \
+    }                                                                      \
+  }                                                                        \
+  while(0)
 
-#define T_ADD(A,B) \
-	A.tv_usec = A.tv_usec + B; \
-	while (A.tv_usec > 1000000) \
-	{ \
-		A.tv_sec++; \
-		A.tv_usec = A.tv_usec - 1000000; \
-	}
+#define T_ADD(A,B)                     \
+  do                                   \
+  {                                    \
+    A.tv_usec = A.tv_usec + B;         \
+    while (A.tv_usec > 1000000)        \
+    {                                  \
+      A.tv_sec++;                      \
+      A.tv_usec = A.tv_usec - 1000000; \
+    }                                  \
+  }                                    \
+  while(0)
 
-#define T_DEC(A,B) \
-	A.tv_usec = A.tv_usec - B; \
-	if (A.tv_usec < 0) \
-	{ \
-		A.tv_sec--; \
-		A.tv_usec = 1000000 + A.tv_usec; \
-	}
+#define T_DEC(A,B)                     \
+  do                                   \
+  {                                    \
+    A.tv_usec = A.tv_usec - B;         \
+    if (A.tv_usec < 0)                 \
+    {                                  \
+      A.tv_sec--;                      \
+      A.tv_usec = 1000000 + A.tv_usec; \
+    }                                  \
+  }                                    \
+  while(0)
 
 } // End of Tango namespace
 


### PR DESCRIPTION
GCC 8.1.0 outputs

/home/firma/devel/cppTango/cppapi/server/pollthread.cpp:1269:11: warning: macro expands to multiple statements [-Wmultistatement-macros]
     T_ADD(ite_next->wake_up_date,min_delta - diff);
           ^~~~~~~~
/home/firma/devel/cppTango/cppapi/server/pollthread.h:196:2: note: in definition of macro ‘T_ADD’
  A.tv_usec = A.tv_usec + B; \
  ^
/home/firma/devel/cppTango/cppapi/server/pollthread.cpp:1268:4: note: some parts of macro expansion are not guarded by this ‘if’ clause
    if (diff < min_delta)
    ^~

which is correct as T_ADD is a multiline macro and thus should be
enclosed in do { } while(0) as described in https://gcc.gnu.org/onlinedocs/cpp/Swallowing-the-Semicolon.html#Swallowing-the-Semicolon.