### PR TITLE
Fix some compilation warnings

### DIFF
--- a/cpp_test_suite/cpp_test_ds/TypeCmds.cpp
+++ b/cpp_test_suite/cpp_test_ds/TypeCmds.cpp
@@ -612,6 +612,7 @@ CORBA::Any *IOString::execute(TANGO_UNUSED(Tango::DeviceImpl *device),const CORB
 	catch (CORBA::Exception &e)
 	  {
 	    Tango::Except::print_exception(e);
+	    throw;
 	  }
 }
 

--- a/cpp_test_suite/cpp_test_ds/fwd_ds/main.cpp
+++ b/cpp_test_suite/cpp_test_ds/fwd_ds/main.cpp
@@ -46,7 +46,7 @@
 #  define INSTALL_CRASH_HANDLER
 #endif
 
-DECLARE_CRASH_HANDLER;
+DECLARE_CRASH_HANDLER
 
 int main(int argc,char *argv[])
 {

--- a/cpp_test_suite/cxxtest/include/cxxtest/Descriptions.cpp
+++ b/cpp_test_suite/cxxtest/include/cxxtest/Descriptions.cpp
@@ -53,6 +53,6 @@ namespace CxxTest
         return s;
     }
 #endif // _CXXTEST_FACTOR
-};
+}
 
 #endif // __cxxtest__Descriptions_cpp__

--- a/cpp_test_suite/cxxtest/include/cxxtest/ErrorFormatter.h
+++ b/cpp_test_suite/cxxtest/include/cxxtest/ErrorFormatter.h
@@ -276,6 +276,6 @@ namespace CxxTest
         const char *_preLine;
         const char *_postLine;
     };
-};
+}
 
 #endif // __cxxtest__ErrorFormatter_h__

--- a/cpp_test_suite/cxxtest/include/cxxtest/LinkedList.cpp
+++ b/cpp_test_suite/cxxtest/include/cxxtest/LinkedList.cpp
@@ -167,6 +167,6 @@ namespace CxxTest
         else
             l._tail = _prev;
     }
-};
+}
 
 #endif // __cxxtest__LinkedList_cpp__

--- a/cpp_test_suite/cxxtest/include/cxxtest/StdValueTraits.h
+++ b/cpp_test_suite/cxxtest/include/cxxtest/StdValueTraits.h
@@ -222,7 +222,7 @@ namespace CxxTest
         }
     };
 #endif // _CXXTEST_PARTIAL_TEMPLATE_SPECIALIZATION
-};
+}
 
 #endif // CXXTEST_USER_VALUE_TRAITS
 

--- a/cpp_test_suite/cxxtest/include/cxxtest/TestRunner.h
+++ b/cpp_test_suite/cxxtest/include/cxxtest/TestRunner.h
@@ -119,7 +119,7 @@ namespace CxxTest
     // For --no-static-init
     //
     void initialize();
-};
+}
 
 
 #endif // __cxxtest_TestRunner_h__

--- a/cpp_test_suite/cxxtest/include/cxxtest/TestSuite.cpp
+++ b/cpp_test_suite/cxxtest/include/cxxtest/TestSuite.cpp
@@ -133,6 +133,6 @@ namespace CxxTest
         tracker().failedAssertThrowsNot( file, line, expression );
         TS_ABORT();
     }
-};
+}
 
 #endif // __cxxtest__TestSuite_cpp__

--- a/cpp_test_suite/cxxtest/include/cxxtest/TestTracker.cpp
+++ b/cpp_test_suite/cxxtest/include/cxxtest/TestTracker.cpp
@@ -243,6 +243,6 @@ namespace CxxTest
                 ++ _failedSuites;
         }
     }
-};
+}
 
 #endif // __cxxtest__TestTracker_cpp__

--- a/cpp_test_suite/cxxtest/include/cxxtest/TestTracker.h
+++ b/cpp_test_suite/cxxtest/include/cxxtest/TestTracker.h
@@ -109,6 +109,6 @@ namespace CxxTest
     };
 
     inline TestTracker &tracker() { return TestTracker::tracker(); }
-};
+}
 
 #endif // __cxxtest__TestTracker_h__

--- a/cpp_test_suite/cxxtest/include/cxxtest/ValueTraits.cpp
+++ b/cpp_test_suite/cxxtest/include/cxxtest/ValueTraits.cpp
@@ -135,6 +135,6 @@ namespace CxxTest
         return numberToString<double>( t, s, BASE, skip, max );
     }
 #endif // !CXXTEST_USER_VALUE_TRAITS
-};
+}
 
 #endif // __cxxtest__ValueTraits_cpp__

--- a/cpp_test_suite/cxxtest/include/cxxtest/ValueTraits.h
+++ b/cpp_test_suite/cxxtest/include/cxxtest/ValueTraits.h
@@ -338,7 +338,7 @@ namespace CxxTest
     CXXTEST_COPY_TRAITS( const float, const double );
     CXXTEST_COPY_CONST_TRAITS( float );
 #endif // !CXXTEST_USER_VALUE_TRAITS
-};
+}
 
 #ifdef _CXXTEST_HAVE_STD
 #   include <cxxtest/StdValueTraits.h>

--- a/cppapi/client/eventconsumer.h
+++ b/cppapi/client/eventconsumer.h
@@ -638,7 +638,7 @@ private :
 	void print_error_message(const char *mess) {ApiUtil *au=ApiUtil::instance();au->print_error_message(mess);}
 	void set_ctrl_sock_bound() {sock_bound_mutex.lock();ctrl_socket_bound=true;sock_bound_mutex.unlock();}
 	bool is_ctrl_sock_bound() {bool _b;sock_bound_mutex.lock();_b=ctrl_socket_bound;sock_bound_mutex.unlock();return _b;}
-	void set_socket_hwm(size_t hwm);
+	void set_socket_hwm(int hwm);
 
     bool check_zmq_endpoint(const string &);
 

--- a/cppapi/client/zmqeventconsumer.cpp
+++ b/cppapi/client/zmqeventconsumer.cpp
@@ -886,7 +886,7 @@ bool ZmqEventConsumer::process_ctrl(zmq::message_t &received_ctrl,zmq::pollitem_
 
             if (connect_pub == true)
             {
-                set_socket_hwm(sub_hwm);
+                set_socket_hwm((int) sub_hwm);
 
                 event_sub_sock->connect(endpoint);
                 if (force_connect == 0)
@@ -3502,7 +3502,7 @@ void ZmqEventConsumer::get_subscribed_event_ids(DeviceProxy *_dev,vector<int> &_
  *
  * @param hwm: new ZMQ receive buffer high water mark
  */
-void ZmqEventConsumer::set_socket_hwm(size_t hwm)
+void ZmqEventConsumer::set_socket_hwm(int hwm)
 {
     int current_sub_hwm = SUB_HWM;
     size_t curr_sub_hw_size = sizeof(current_sub_hwm);

--- a/cppapi/client/zmqeventconsumer.cpp
+++ b/cppapi/client/zmqeventconsumer.cpp
@@ -1972,7 +1972,6 @@ void ZmqEventConsumer::push_zmq_event(string &ev_name,unsigned char endian,zmq::
     map<std::string,EventCallBackStruct>::iterator ipos;
     size_t loop;
     bool no_db_dev = false;
-    bool first_search_succeed = false;
 
     size_t pos = ev_name.find('/',8);
     string base_tango_host = ev_name.substr(0,pos + 1);
@@ -1999,9 +1998,6 @@ void ZmqEventConsumer::push_zmq_event(string &ev_name,unsigned char endian,zmq::
 
         if (ipos != event_callback_map.end())
         {
-        	if (loop == 0)
-				first_search_succeed = true;
-
             const AttributeValue *attr_value = NULL;
             const AttributeValue_3 *attr_value_3 = NULL;
             const ZmqAttributeValue_4 *z_attr_value_4 = NULL;


### PR DESCRIPTION
This PR was created to fix the following compilation warnings observed when compiling in Debug mode with gcc 6.3.0:

cppapi/client/zmqeventconsumer.cpp: In member function ‘void Tango::ZmqEventConsumer::push_zmq_event(std::__cxx11::string&, unsigned char, zmq::message_t&, bool, const DevULong&)’:
cppapi/client/zmqeventconsumer.cpp:1975:10: warning: variable ‘first_search_succeed’ set but not used [-Wunused-but-set-variable]
     bool first_search_succeed = false;
          ^~~~~~~~~~~~~~~~~~~~
cppapi/client/zmqeventconsumer.cpp: In member function ‘void Tango::ZmqEventConsumer::set_socket_hwm(size_t)’:
cppapi/client/zmqeventconsumer.cpp:3514:12: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
     if(hwm != current_sub_hwm)
        ~~~~^~~~~~~~~~~~~~~~~~

In file included from cpp_test_suite/cxxtest/runner.cpp:17:0:
cpp_test_suite/cxxtest/include/cxxtest/TestTracker.h:112:2: warning: extra ‘;’ [-Wpedantic]
 };
  ^

In file included from cpp_test_suite/cxxtest/include/cxxtest/ValueTraits.h:344:0,
                 from cpp_test_suite/cxxtest/include/cxxtest/TestSuite.h:13,
                 from cpp_test_suite/cxxtest/include/cxxtest/RealDescriptions.h:9,
                 from cpp_test_suite/cxxtest/include/cxxtest/TestRunner.h:11,
                 from cpp_test_suite/cxxtest/runner.cpp:18:
cpp_test_suite/cxxtest/include/cxxtest/StdValueTraits.h:225:2: warning: extra ‘;’ [-Wpedantic]
 };
  ^
In file included from cpp_test_suite/cxxtest/runner.cpp:18:0:
cpp_test_suite/cxxtest/include/cxxtest/TestRunner.h:122:2: warning: extra ‘;’ [-Wpedantic]
 };
  ^
In file included from cpp_test_suite/cxxtest/include/cxxtest/TangoPrinter.h:15:0,
                 from cpp_test_suite/cxxtest/runner.cpp:21:
cpp_test_suite/cxxtest/include/cxxtest/ErrorFormatter.h:279:2: warning: extra ‘;’ [-Wpedantic]
};

In file included from cpp_test_suite/cxxtest/include/cxxtest/Root.cpp:9:0,
                 from cpp_test_suite/cxxtest/runner.cpp:1965:
cpp_test_suite/cxxtest/include/cxxtest/Descriptions.cpp:56:2: warning: extra ‘;’ [-Wpedantic]
 };
  ^
In file included from cpp_test_suite/cxxtest/include/cxxtest/Root.cpp:12:0,
                 from cpp_test_suite/cxxtest/runner.cpp:1965:
cpp_test_suite/cxxtest/include/cxxtest/LinkedList.cpp:170:2: warning: extra ‘;’ [-Wpedantic]
 };
  ^
In file included from cpp_test_suite/cxxtest/include/cxxtest/Root.cpp:14:0,
                 from cpp_test_suite/cxxtest/runner.cpp:1965:
cpp_test_suite/cxxtest/include/cxxtest/TestSuite.cpp:136:2: warning: extra ‘;’ [-Wpedantic]
 };
  ^
In file included from cpp_test_suite/cxxtest/include/cxxtest/Root.cpp:15:0,
                 from cpp_test_suite/cxxtest/runner.cpp:1965:
cpp_test_suite/cxxtest/include/cxxtest/TestTracker.cpp:246:2: warning: extra ‘;’ [-Wpedantic]
 };
  ^
In file included from cpp_test_suite/cxxtest/include/cxxtest/Root.cpp:16:0,
                 from cpp_test_suite/cxxtest/runner.cpp:1965:
cpp_test_suite/cxxtest/include/cxxtest/ValueTraits.cpp:138:2: warning: extra ‘;’ [-Wpedantic]
 };
  ^
  
  cpp_test_suite/cpp_test_ds/fwd_ds/main.cpp:49:22: warning: extra ‘;’ [-Wpedantic]
 DECLARE_CRASH_HANDLER;
                      ^

cpp_test_suite/cpp_test_ds/TypeCmds.cpp: In member function ‘virtual CORBA::Any* IOString::execute(Tango::DeviceImpl*, const CORBA::Any&)’:
cpp_test_suite/cpp_test_ds/TypeCmds.cpp:616:1: warning: control reaches end of non-void function [-Wreturn-type]
 }
 ^