### PR TITLE
State and Status attributes are always at the end of attr list vector

### DIFF
--- a/cppapi/server/multiattribute.cpp
+++ b/cppapi/server/multiattribute.cpp
@@ -1050,7 +1050,8 @@ void MultiAttribute::remove_attribute(string &attr_name,bool update_idx)
 		for (;pos != attr_list.end();++pos)
 		{
 			(*pos)->set_attr_idx((*pos)->get_attr_idx() - 1);
-			ext->attr_map[(*pos)->get_name_lower()].att_index_in_vector--;
+			string & attr_name_lower = (*pos)->get_name_lower();
+			ext->attr_map[attr_name_lower].att_index_in_vector--;
 		}
 
 		Tango::Util *tg = Tango::Util::instance();
@@ -1063,13 +1064,15 @@ void MultiAttribute::remove_attribute(string &attr_name,bool update_idx)
 				continue;
 
 			vector<Attribute *> &dev_att_list = (*dev_ite)->get_device_attr()->get_attribute_list();
-			for (unsigned int loop = 0;loop < dev_att_list.size();++loop)
+			for (unsigned int i = 0;i < dev_att_list.size();++i)
 			{
-				int idx = dev_att_list[loop]->get_attr_idx();
+				int idx = dev_att_list[i]->get_attr_idx();
 				if (idx > old_idx)
 				{
-					dev_att_list[loop]->set_attr_idx(idx - 1);
-					(*dev_ite)->get_device_attr()->ext->attr_map[dev_att_list[loop]->get_name_lower()].att_index_in_vector--;
+					dev_att_list[i]->set_attr_idx(idx - 1);
+					string & attr_name_lower = dev_att_list[i]->get_name_lower();
+					MultiAttribute * dev_multi_attr = (*dev_ite)->get_device_attr();
+					dev_multi_attr->ext->attr_map[attr_name_lower].att_index_in_vector--;
 				}
 			}
 		}

--- a/cppapi/server/multiattribute.cpp
+++ b/cppapi/server/multiattribute.cpp
@@ -1063,7 +1063,8 @@ void MultiAttribute::remove_attribute(string &attr_name,bool update_idx)
 			if (*dev_ite == the_dev)
 				continue;
 
-			vector<Attribute *> &dev_att_list = (*dev_ite)->get_device_attr()->get_attribute_list();
+			MultiAttribute * dev_multi_attr = (*dev_ite)->get_device_attr();
+			vector<Attribute *> &dev_att_list = dev_multi_attr->get_attribute_list();
 			for (unsigned int i = 0;i < dev_att_list.size();++i)
 			{
 				int idx = dev_att_list[i]->get_attr_idx();
@@ -1071,7 +1072,6 @@ void MultiAttribute::remove_attribute(string &attr_name,bool update_idx)
 				{
 					dev_att_list[i]->set_attr_idx(idx - 1);
 					string & attr_name_lower = dev_att_list[i]->get_name_lower();
-					MultiAttribute * dev_multi_attr = (*dev_ite)->get_device_attr();
 					dev_multi_attr->ext->attr_map[attr_name_lower].att_index_in_vector--;
 				}
 			}

--- a/cppapi/server/multiattribute.cpp
+++ b/cppapi/server/multiattribute.cpp
@@ -812,6 +812,7 @@ void MultiAttribute::add_attribute(string &dev_name,DeviceClass *dev_class_ptr,l
 			attr_list.insert(ite,new_attr);
 			index = attr_list.size() - 3;
 			ext->put_attribute_in_map(new_attr,index);
+			ext->increment_state_and_status_indexes();
 		}
 	}
 	else
@@ -828,6 +829,7 @@ void MultiAttribute::add_attribute(string &dev_name,DeviceClass *dev_class_ptr,l
 			attr_list.insert(ite,new_attr);
 			index = attr_list.size() - 3;
 			ext->put_attribute_in_map(new_attr,index);
+			ext->increment_state_and_status_indexes();
 		}
 	}
 
@@ -962,6 +964,7 @@ void MultiAttribute::add_fwd_attribute(string &dev_name,DeviceClass *dev_class_p
 	attr_list.insert(ite,new_fwd_attr);
 	index = attr_list.size() - 3;
 	ext->put_attribute_in_map(new_fwd_attr,index);
+	ext->increment_state_and_status_indexes();
 
 //
 // If it is writable, add it to the writable attribute list
@@ -1045,7 +1048,10 @@ void MultiAttribute::remove_attribute(string &attr_name,bool update_idx)
 	if (update_idx == true)
 	{
 		for (;pos != attr_list.end();++pos)
+		{
 			(*pos)->set_attr_idx((*pos)->get_attr_idx() - 1);
+			ext->attr_map[(*pos)->get_name_lower()].att_index_in_vector--;
+		}
 
 		Tango::Util *tg = Tango::Util::instance();
 		vector<DeviceImpl *> &dev_list = tg->get_device_list_by_class(dev_class_name);
@@ -1061,7 +1067,10 @@ void MultiAttribute::remove_attribute(string &attr_name,bool update_idx)
 			{
 				int idx = dev_att_list[loop]->get_attr_idx();
 				if (idx > old_idx)
+				{
 					dev_att_list[loop]->set_attr_idx(idx - 1);
+					(*dev_ite)->get_device_attr()->ext->attr_map[dev_att_list[loop]->get_name_lower()].att_index_in_vector--;
+				}
 			}
 		}
 	}

--- a/cppapi/server/multiattribute.h
+++ b/cppapi/server/multiattribute.h
@@ -310,6 +310,11 @@ private:
 			mapElement.att_index_in_vector = index;
 			attr_map[att->get_name_lower()] = mapElement;
 		}
+		void increment_state_and_status_indexes()
+		{
+			attr_map["state"].att_index_in_vector++;
+			attr_map["status"].att_index_in_vector++;
+		}
     };
 
 	void concat(vector<AttrProperty> &,vector<AttrProperty> &,vector<AttrProperty> &);


### PR DESCRIPTION
Indexes are now correctly updated taking this into account (#458).
This should fix a bug introduced in #430 which was impacting servers using dynamic attributes.