### PR TITLE
Add Tango::string_free and fix memory leak in zmq_event_subscription_change() (#457)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ enable_testing()
 #need to define the version of the library
 set(MAJOR_VERSION "9")
 set(MINOR_VERSION "3")
-set(PATCH_VERSION "1")
+set(PATCH_VERSION "2")
 
 if(WIN32)
     include(configure/cmake_win_defs.cmake)

--- a/cppapi/server/eventcmds.cpp
+++ b/cppapi/server/eventcmds.cpp
@@ -1080,7 +1080,9 @@ DevVarLongStringArray *DServer::zmq_event_subscription_change(const Tango::DevVa
         ret_data->svalue[size] = Tango::string_dup(event_topic.c_str());
 
         string channel_name = ev->get_fqdn_prefix();
-        channel_name += dev->adm_name();
+        char * adm_name = dev->adm_name();
+        channel_name += adm_name;
+        Tango::string_free(adm_name);
         transform(channel_name.begin(), channel_name.end(), channel_name.begin(), ::tolower);
         assert(!(channel_name.empty()));
         cout4 << "Sending channel_name = " << channel_name << endl;

--- a/cppapi/server/tango_const.h.in
+++ b/cppapi/server/tango_const.h.in
@@ -461,6 +461,8 @@ const char* const API_ZmqInitFailed                = "API_ZmqInitFailed";
 
 inline char * string_dup(char *s) {return CORBA::string_dup(s);}
 inline char * string_dup(const char *s) {return CORBA::string_dup(s);}
+// A short inline function to hide the CORBA::string_free function
+inline void string_free(char *s) {return CORBA::string_free(s);}
 
 //
 // Many, many typedef


### PR DESCRIPTION
Add Tango::string_free() to hide CORBA::string_free()
Fix memory leak in DServer::zmq_event_subscription_change()