### PR TITLE
Fix DServer Misc test when not executed from a docker container

### DIFF
--- a/cpp_test_suite/CMakeLists.txt
+++ b/cpp_test_suite/CMakeLists.txt
@@ -14,7 +14,7 @@ set(DEV20 "${INST_NAME}2/debian8/20")
 set(FWD_DEV "${INST_NAME}/fwd_debian8/10")
 set(DEV1_ALIAS "debian8_alias")
 set(ATTR_ALIAS "debian8_attr_alias")
-cmake_host_system_information(RESULT HOST_NAME QUERY HOSTNAME)
+cmake_host_system_information(RESULT HOST_NAME QUERY FQDN)
 string(TOLOWER ${HOST_NAME} HOST_NAME)
 message("HOST_NAME=${HOST_NAME}")
 


### PR DESCRIPTION
Give FQDN instead of simple HOSTNAME when passing the hostname in serverhost and clienthost tests parameters.
FQDN is what is expected by the tests, as described in cpp_test_suite/README file:

> clienthost		--clienthost=		client host's fully qualified domain name, e.g. mypc.myinstitute.com (small caps)
>serverhost		--serverhost=		fully qualified domain name of the host on which the server is running, e.g. myserver.myinstitute.com (small caps)

This avoids DServer Misc test failure when the test is not executed from a Docker container.