### PR TITLE
Fix reconnection issues when a client subscribes to several event (#455)

### DIFF
--- a/cpp_test_suite/event/CMakeLists.txt
+++ b/cpp_test_suite/event/CMakeLists.txt
@@ -22,7 +22,8 @@ set(TESTS   archive_event
 #            reco_event
             reco_zmq
             server_event
-            stateless_sub)
+            stateless_sub
+            reco_several_events)
 
 foreach(TEST ${TESTS})
     TEST_SUITE_ADD_TEST(${TEST})

--- a/cpp_test_suite/event/reco_several_events.cpp
+++ b/cpp_test_suite/event/reco_several_events.cpp
@@ -20,7 +20,7 @@ bool verbose = false;
 class EventCallback : public Tango::CallBack
 {
 public:
-    EventCallback(string cb_name): cb_executed(0), cb_err(0), name(cb_name) { };
+    explicit EventCallback(string cb_name): cb_executed(0), cb_err(0), name(cb_name) { };
     ~EventCallback() { };
     void push_event( Tango::EventData *ed );
 

--- a/cpp_test_suite/event/reco_several_events.cpp
+++ b/cpp_test_suite/event/reco_several_events.cpp
@@ -20,7 +20,7 @@ bool verbose = false;
 class EventCallback : public Tango::CallBack
 {
 public:
-    EventCallback(string cb_name)  { name = cb_name; };
+    EventCallback(string cb_name): cb_executed(0), cb_err(0), name(cb_name) { };
     ~EventCallback() { };
     void push_event( Tango::EventData *ed );
 

--- a/cpp_test_suite/event/reco_several_events.cpp
+++ b/cpp_test_suite/event/reco_several_events.cpp
@@ -1,0 +1,255 @@
+/* 
+ * example of a client using the TANGO device api.
+ * This client can be used to test the reconnection
+ * when a client subscribed to several events
+ */
+
+#include <tango.h>
+#include <assert.h>
+
+#ifndef WIN32
+#include <unistd.h>
+#endif
+
+#define	coutv	if (verbose == true) cout
+
+using namespace Tango;
+
+bool verbose = false;
+
+class EventCallback : public Tango::CallBack
+{
+public:
+    EventCallback(string cb_name)  { name = cb_name; };
+    ~EventCallback() { };
+    void push_event( Tango::EventData *ed );
+
+	int cb_executed;
+	int cb_err;
+	string name;
+};
+
+void EventCallback::push_event( Tango::EventData *ed )
+{
+	coutv << "In callback " << name << " with error flag = " << std::boolalpha << ed->err << endl;
+    if(ed->err == false)
+	{
+		cb_executed++;
+	}
+    else
+	{
+		cb_err++;
+		coutv << "Error: " << ed->errors[0].reason << endl;
+	}
+}
+
+int main(int argc, char **argv)
+{
+	DeviceProxy *device1;
+    DeviceProxy *device2;
+	
+	if (argc < 3)
+	{
+		cout << "usage: %s device1 device2 [-v]" << endl;
+		exit(-1);
+	}
+
+	string device_name1 = argv[1];
+    string device_name2 = argv[2];
+
+	if (argc == 4)
+	{
+		if (strcmp(argv[3],"-v") == 0)
+			verbose = true;
+	}
+	
+	try 
+	{
+		device1 = new DeviceProxy(device_name1);
+        device2 = new DeviceProxy(device_name2);
+	}
+	catch (CORBA::Exception &e)
+	{
+		Except::print_exception(e);
+		exit(1);
+	}
+
+	string att_name ("event_change_tst");
+	
+	try
+	{
+
+//
+// Subscribe to a user event on device 1
+//
+
+    	const vector<string>  filters;
+    	EventCallback *eventCallback1 = new EventCallback("1");
+		eventCallback1->cb_executed = 0;
+		eventCallback1->cb_err = 0;
+
+        device1->subscribe_event(att_name,Tango::USER_EVENT,eventCallback1,filters);
+
+//
+// Fire one event on device1
+//
+		device1->command_inout("IOPushEvent");
+		sleep(1);
+
+//
+// Subscribe to a user event on device 2
+//
+        EventCallback *eventCallback2 = new EventCallback("2");
+        eventCallback2->cb_executed = 0;
+        eventCallback2->cb_err = 0;
+
+        device2->subscribe_event(att_name,Tango::USER_EVENT,eventCallback2,filters);
+
+
+// Fire events on device 1 and 2
+		device1->command_inout("IOPushEvent");
+        device2->command_inout("IOPushEvent");
+		
+		Tango_sleep(1);
+
+		coutv << "Callback1 execution before re-connection = " << eventCallback1->cb_executed << endl;
+		coutv << "Callback1 error before re-connection = " << eventCallback1->cb_err << endl;
+		
+		assert (eventCallback1->cb_executed == 3);
+		assert (eventCallback1->cb_err == 0);
+
+        coutv << "Callback2 execution before re-connection = " << eventCallback2->cb_executed << endl;
+        coutv << "Callback2 error before re-connection = " << eventCallback2->cb_err << endl;
+
+        assert (eventCallback2->cb_executed == 2);
+        assert (eventCallback2->cb_err == 0);
+
+//
+// Kill device servers (using their admin device)
+//
+
+		string adm_name1 = device1->adm_name();
+		DeviceProxy admin_dev1(adm_name1);
+        string adm_name2 = device2->adm_name();
+        DeviceProxy admin_dev2(adm_name2);
+		admin_dev1.command_inout("kill");
+        admin_dev2.command_inout("kill");
+
+//
+// Wait for some error and re-connection - A script or the user will restart the servers
+//
+
+		Tango_sleep(40);
+	
+//
+// Check error and re-connection
+//
+
+		coutv << "Callback1 execution after re-connection = " << eventCallback1->cb_executed << endl;
+		coutv << "Callback1 error after re-connection = " << eventCallback1->cb_err << endl;
+
+		assert (eventCallback1->cb_err >= 1);
+		assert (eventCallback1->cb_executed == 4);
+
+        coutv << "Callback2 execution after re-connection = " << eventCallback2->cb_executed << endl;
+        coutv << "Callback2 error after re-connection = " << eventCallback2->cb_err << endl;
+
+        assert (eventCallback2->cb_err >= 1);
+        assert (eventCallback2->cb_executed == 3);
+
+//
+// Fire other events
+//
+
+		device1->command_inout("IOPushEvent");
+		device2->command_inout("IOPushEvent");
+        device2->command_inout("IOPushEvent");
+
+
+        Tango_sleep(1);
+
+		coutv << "Callback1 execution after re-connection and event = " << eventCallback1->cb_executed << endl;
+		coutv << "Callback1 error after re-connection and event = " << eventCallback1->cb_err << endl;
+	
+		assert (eventCallback1->cb_executed == 5);
+		assert (eventCallback1->cb_err >= 1);
+
+        coutv << "Callback2 execution after re-connection and event = " << eventCallback2->cb_executed << endl;
+        coutv << "Callback2 error after re-connection and event = " << eventCallback2->cb_err << endl;
+
+        assert (eventCallback1->cb_executed == 5);
+        assert (eventCallback1->cb_err >= 1);
+
+		cout << "   Event re-connection (client subscribing to 2 attributes from 2 different devices - different ports) --> OK" << endl;
+
+//
+// Clear call back counters and kill device servers once more
+//
+
+        eventCallback1->cb_executed = 0;
+        eventCallback1->cb_err = 0;
+        eventCallback2->cb_executed = 0;
+        eventCallback2->cb_err = 0;
+
+		admin_dev1.command_inout("kill");
+        admin_dev2.command_inout("kill");
+
+//
+// Wait for some error and re-connectiongit d
+//
+
+		Tango_sleep(40);
+	
+//
+// Check error and re-connection
+//
+
+		coutv << "Callback1 execution after second re-connection = " << eventCallback1->cb_executed << endl;
+		coutv << "Callback1 error after second re-connection = " << eventCallback1->cb_err << endl;
+
+		assert (eventCallback1->cb_err >= 1);
+		assert (eventCallback1->cb_executed == 1);
+
+        coutv << "Callback2 execution after second re-connection = " << eventCallback2->cb_executed << endl;
+        coutv << "Callback2 error after second re-connection = " << eventCallback2->cb_err << endl;
+
+        assert (eventCallback2->cb_err >= 1);
+        assert (eventCallback2->cb_executed == 1);
+
+//
+// Fire yet another event
+//
+
+		device1->command_inout("IOPushEvent");
+        device2->command_inout("IOPushEvent");
+        device1->command_inout("IOPushEvent");
+        device2->command_inout("IOPushEvent");
+        device2->command_inout("IOPushEvent");
+		
+		Tango_sleep(2);
+
+		coutv << "Callback1 execution after second re-connection and event = " << eventCallback1->cb_executed << endl;
+		coutv << "Callback1 error after second re-connection and event = " << eventCallback1->cb_err << endl;
+	
+		assert (eventCallback1->cb_executed == 3);
+		assert (eventCallback1->cb_err >= 1);
+
+        coutv << "Callback2 execution after second re-connection and event = " << eventCallback2->cb_executed << endl;
+        coutv << "Callback2 error after second re-connection and event = " << eventCallback2->cb_err << endl;
+
+        assert (eventCallback2->cb_executed == 4);
+        assert (eventCallback2->cb_err >= 1);
+
+
+		cout << "   Event re-connection (client subscribing to 2 attributes from 2 different devices - same ports) --> OK" << endl;
+	}
+	catch (Tango::DevFailed &e)
+	{
+		Except::print_exception(e);
+		exit(-1);
+	}
+	delete device1;
+	delete device2;
+	
+	return 0;
+}

--- a/cpp_test_suite/event/test_reconnection.sh.cmake
+++ b/cpp_test_suite/event/test_reconnection.sh.cmake
@@ -28,7 +28,9 @@ kill_servers(){
     sleep 2
 }
 
+kill_servers
 
+start_server "@INST_NAME@"
 start_server "@INST_NAME@2"
 sleep 20
 
@@ -70,12 +72,34 @@ sleep 24 &&  start_server "@INST_NAME@2" &
 ret=$?
 check_return_value $ret
 
-#kill extra server
+# kill DevTest servers
+kill_servers
+
+#
+# Start DevTest servers
+#
+
+start_server "@INST_NAME@"
+start_server "@INST_NAME@2"
+sleep 20
+#
+# Next test will restart servers
+#
+
+echo "Testing event re-connection with client subscribing to several devices (takes time...)"
+sleep 18 &&  start_server "@INST_NAME@" && start_server "@INST_NAME@2" &
+sleep 62 &&  start_server "@INST_NAME@" && start_server "@INST_NAME@2" &
+./reco_several_events @DEV1@ @DEV20@ -v
+ret=$?
+check_return_value $ret
+
+
+# kill DevTest servers
 kill_servers
 
 #restart DEV1
 start_server "@INST_NAME@"
 
-sleep 20
+sleep 5
 
 echo "PID=$(<@PROJECT_BINARY_DIR@/cpp_test_ds/DevTest_@INST_NAME@.pid)"

--- a/cppapi/client/zmqeventconsumer.cpp
+++ b/cppapi/client/zmqeventconsumer.cpp
@@ -1764,8 +1764,8 @@ void ZmqEventConsumer::connect_event_system(string &device_name,string &obj_name
         ::strcpy(&(buffer[length]),endpoint.c_str());
         length = length + endpoint.size() + 1;
 
-        ::strcpy(&(buffer[length]), received_from_admin.event_name.c_str());
-        length = length + received_from_admin.event_name.size() + 1;
+        ::strcpy(&(buffer[length]), full_event_name.c_str());
+        length = length + full_event_name.size() + 1;
 
         DevLong user_hwm = au->get_user_sub_hwm();
         if (user_hwm != -1)


### PR DESCRIPTION
The first commit of this pull request adds a new test to reproduce the reconnection problem described in #455 when a client subscribes to several events.
The following commit(s) will attempt to fix this issue.