### PR TITLE
Polling refactoring proposal [24h]

### DIFF
--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -2,6 +2,7 @@
 ==================
 1. Add Tango::string_free and fix memory leak in zmq_event_subscription_change() (#457,#460)
 2. Fix bug impacting device servers using dynamic attributes (#458,#459)
+3. Polling refactoring
 
 9.3.1
 =====


### PR DESCRIPTION
This is to track progress on polling refactoring. Current code base analysis is available [here](https://tango-v10-design-doc.readthedocs.io/en/latest/server/#existing-codebase)

Basically proposal is as the following:

- [ ] separate "control thread" and "worker thread"
- [ ] extract new entity - ExecutionTasksQueue
- [ ] refactor classes structure as in the diagram below
- [ ] add "Monitor thread" that will be responsible for monitoring and reporting _bad_ tasks

New classes diagram:

![package_polling](https://user-images.githubusercontent.com/11678364/44341699-5d759400-a491-11e8-8be4-3a3c2f3db69c.png)

This proposal is not final and subject for discussion during the next Tango kernel meeting.
