### PR TITLE
Backport #378: PipeBlob as command's in/out

### DIFF
--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -1,3 +1,7 @@
+9.4.0 [UNRELEASED -- THIS PR]
+
+1. DevicePipeBlob as command in/out argument
+
 9.3.2 [UNRELEASED]
 ==================
 1. Add Tango::string_free and fix memory leak in zmq_event_subscription_change() (#457,#460)

--- a/cpp_test_suite/cpp_test_ds/DevTestClass.cpp
+++ b/cpp_test_suite/cpp_test_ds/DevTestClass.cpp
@@ -538,6 +538,7 @@ void DevTestClass::command_factory()
 					    Tango::DEV_ENCODED,
 					    "void",
 					    "DevEncoded structure to test polling/history"));
+    command_list.push_back(new IOPipeBlob());
 	command_list.push_back(new PollingPoolTst("PollingPoolTst",
 					    Tango::DEV_VOID,
 					    Tango::DEVVAR_STRINGARRAY,
@@ -671,8 +672,8 @@ void DevTestClass::device_factory(const Tango::DevVarStringArray *devlist_ptr) {
 // Create device and add it into the device list
 //
 
-    device_list.push_back(new DevTest(this,
-				      (*devlist_ptr)[i]));
+      string dev_name((*devlist_ptr)[i]);
+      device_list.push_back(new DevTest(this, dev_name));
 
     //
     // Export device to the outside world

--- a/cpp_test_suite/cpp_test_ds/TypeCmds.cpp
+++ b/cpp_test_suite/cpp_test_ds/TypeCmds.cpp
@@ -40,17 +40,17 @@ bool IOVoid::is_allowed(Tango::DeviceImpl *device, TANGO_UNUSED(const CORBA::Any
 		return(false);
 }
 
-
-CORBA::Any *IOVoid::execute(TANGO_UNUSED(Tango::DeviceImpl *device),TANGO_UNUSED(const CORBA::Any &in_any))
+CORBA::Any *IOVoid::execute(TANGO_UNUSED(Tango::DeviceImpl *device), TANGO_UNUSED(const CORBA::Any &in_any))
 {
-  try {
-    cout << "[IOVoid::execute] " << endl;
-    return insert();
-  }
-  catch (CORBA::Exception &e)
+    try
     {
-      Tango::Except::print_exception(e);
-      throw ;
+        cout << "[IOVoid::execute] " << endl;
+        return insert();
+    }
+    catch (CORBA::Exception &e)
+    {
+        Tango::Except::print_exception(e);
+        throw;
     }
 }
 
@@ -70,10 +70,10 @@ CORBA::Any *IOVoid::execute(TANGO_UNUSED(Tango::DeviceImpl *device),TANGO_UNUSED
 //
 //-----------------------------------------------------------------------------
 
-IOBool::IOBool(const char *name,Tango::CmdArgType in,
-		   Tango::CmdArgType out,const char *in_desc,
-		   const char *out_desc)
-:Tango::Command(name,in,out,in_desc,out_desc)
+IOBool::IOBool(const char *name, Tango::CmdArgType in,
+               Tango::CmdArgType out, const char *in_desc,
+               const char *out_desc)
+    : Tango::Command(name, in, out, in_desc, out_desc)
 {
 }
 
@@ -85,27 +85,28 @@ bool IOBool::is_allowed(Tango::DeviceImpl *device, TANGO_UNUSED(const CORBA::Any
 // command allowed only if the device is on
 //
 
-	if (device->get_state() == Tango::ON)
-		return(true);
-	else
-		return(false);
+    if (device->get_state() == Tango::ON)
+        return (true);
+    else
+        return (false);
 }
 
 
 CORBA::Any *IOBool::execute(TANGO_UNUSED(Tango::DeviceImpl *device),const CORBA::Any &in_any)
 {
-  try {
-    Tango::DevBoolean theNumber;
-    extract(in_any,theNumber);
-    cout << "[IOBool::execute] received number " << theNumber << endl;
-    theNumber = !theNumber;
-    cout << "[IOBool::execute] return number " << theNumber << endl;
-    return insert(theNumber);
-  }
-  catch (CORBA::Exception &e)
+    try
     {
-      Tango::Except::print_exception(e);
-      throw ;
+        Tango::DevBoolean theNumber;
+        extract(in_any, theNumber);
+        cout << "[IOBool::execute] received number " << theNumber << endl;
+        theNumber = !theNumber;
+        cout << "[IOBool::execute] return number " << theNumber << endl;
+        return insert(theNumber);
+    }
+    catch (CORBA::Exception &e)
+    {
+        Tango::Except::print_exception(e);
+        throw;
     }
 }
 
@@ -125,10 +126,10 @@ CORBA::Any *IOBool::execute(TANGO_UNUSED(Tango::DeviceImpl *device),const CORBA:
 //
 //-----------------------------------------------------------------------------
 
-IOShort::IOShort(const char *name,Tango::CmdArgType in,
-		   Tango::CmdArgType out,const char *in_desc,
-		   const char *out_desc)
-:Tango::Command(name,in,out,in_desc,out_desc)
+IOShort::IOShort(const char *name, Tango::CmdArgType in,
+                 Tango::CmdArgType out, const char *in_desc,
+                 const char *out_desc)
+    : Tango::Command(name, in, out, in_desc, out_desc)
 {
 }
 
@@ -139,27 +140,28 @@ bool IOShort::is_allowed(Tango::DeviceImpl *device, TANGO_UNUSED(const CORBA::An
 // command allowed only if the device is on
 //
 
-	if (device->get_state() == Tango::ON)
-		return(true);
-	else
-		return(false);
+    if (device->get_state() == Tango::ON)
+        return (true);
+    else
+        return (false);
 }
 
 
 CORBA::Any *IOShort::execute(TANGO_UNUSED(Tango::DeviceImpl *device),const CORBA::Any &in_any)
 {
-  try {
-    Tango::DevShort theNumber;
-    extract(in_any,theNumber);
-    cout << "[IOShort::execute] received number " << theNumber << endl;
-    theNumber = theNumber * 2;
-    cout << "[IOShort::execute] return number " << theNumber << endl;
-    return insert(theNumber);
-  }
-  catch (CORBA::Exception &e)
+    try
     {
-      Tango::Except::print_exception(e);
-      throw ;
+        Tango::DevShort theNumber;
+        extract(in_any, theNumber);
+        cout << "[IOShort::execute] received number " << theNumber << endl;
+        theNumber = theNumber * 2;
+        cout << "[IOShort::execute] return number " << theNumber << endl;
+        return insert(theNumber);
+    }
+    catch (CORBA::Exception &e)
+    {
+        Tango::Except::print_exception(e);
+        throw;
     }
 }
 
@@ -178,10 +180,10 @@ CORBA::Any *IOShort::execute(TANGO_UNUSED(Tango::DeviceImpl *device),const CORBA
 //
 //-----------------------------------------------------------------------------
 
-IOLong::IOLong(const char *name,Tango::CmdArgType in,
-		   Tango::CmdArgType out,const char *in_desc,
-		   const char *out_desc)
-:Tango::Command(name,in,out,in_desc,out_desc)
+IOLong::IOLong(const char *name, Tango::CmdArgType in,
+               Tango::CmdArgType out, const char *in_desc,
+               const char *out_desc)
+    : Tango::Command(name, in, out, in_desc, out_desc)
 {
 }
 
@@ -193,29 +195,29 @@ bool IOLong::is_allowed(Tango::DeviceImpl *device, TANGO_UNUSED(const CORBA::Any
 // command allowed only if the device is on
 //
 
-	if (device->get_state() == Tango::ON)
-		return(true);
-	else
-		return(false);
+    if (device->get_state() == Tango::ON)
+        return (true);
+    else
+        return (false);
 }
 
-
-CORBA::Any *IOLong::execute(Tango::DeviceImpl *device,const CORBA::Any &in_any)
+CORBA::Any *IOLong::execute(Tango::DeviceImpl *device, const CORBA::Any &in_any)
 {
-  try {
-    Tango::DevLong theNumber;
-    extract(in_any,theNumber);
-    cout << "[IOLong::execute] received number " << theNumber << endl;
-    DEV_DEBUG_STREAM(device) << "[IOLong::execute] received number " << theNumber;
-    theNumber = theNumber * 2;
-    cout << "[IOLong::execute] return number " << theNumber << endl;
-    DEV_DEBUG_STREAM(device) << "[IOLong::execute] return number " << theNumber << endl;
-    return insert(theNumber);
-  }
-  catch (CORBA::Exception &e)
+    try
     {
-      Tango::Except::print_exception(e);
-      throw ;
+        Tango::DevLong theNumber;
+        extract(in_any, theNumber);
+        cout << "[IOLong::execute] received number " << theNumber << endl;
+        DEV_DEBUG_STREAM(device) << "[IOLong::execute] received number " << theNumber;
+        theNumber = theNumber * 2;
+        cout << "[IOLong::execute] return number " << theNumber << endl;
+        DEV_DEBUG_STREAM(device) << "[IOLong::execute] return number " << theNumber << endl;
+        return insert(theNumber);
+    }
+    catch (CORBA::Exception &e)
+    {
+        Tango::Except::print_exception(e);
+        throw;
     }
 }
 
@@ -235,10 +237,10 @@ CORBA::Any *IOLong::execute(Tango::DeviceImpl *device,const CORBA::Any &in_any)
 //
 //-----------------------------------------------------------------------------
 
-IOLong64::IOLong64(const char *name,Tango::CmdArgType in,
-		   Tango::CmdArgType out,const char *in_desc,
-		   const char *out_desc)
-:Tango::Command(name,in,out,in_desc,out_desc)
+IOLong64::IOLong64(const char *name, Tango::CmdArgType in,
+                   Tango::CmdArgType out, const char *in_desc,
+                   const char *out_desc)
+    : Tango::Command(name, in, out, in_desc, out_desc)
 {
 }
 
@@ -250,29 +252,29 @@ bool IOLong64::is_allowed(Tango::DeviceImpl *device, TANGO_UNUSED(const CORBA::A
 // command allowed only if the device is on
 //
 
-	if (device->get_state() == Tango::ON)
-		return(true);
-	else
-		return(false);
+    if (device->get_state() == Tango::ON)
+        return (true);
+    else
+        return (false);
 }
 
-
-CORBA::Any *IOLong64::execute(Tango::DeviceImpl *device,const CORBA::Any &in_any)
+CORBA::Any *IOLong64::execute(Tango::DeviceImpl *device, const CORBA::Any &in_any)
 {
-  try {
-    Tango::DevLong theNumber;
-    extract(in_any,theNumber);
-    cout << "[IOLong64::execute] received number " << theNumber << endl;
-    DEV_DEBUG_STREAM(device) << "[IOLong64::execute] received number " << theNumber;
-    theNumber = theNumber * 2;
-    cout << "[IOLong64::execute] return number " << theNumber << endl;
-    DEV_DEBUG_STREAM(device) << "[IOLong64::execute] return number " << theNumber << endl;
-    return insert(theNumber);
-  }
-  catch (CORBA::Exception &e)
+    try
     {
-      Tango::Except::print_exception(e);
-      throw ;
+        Tango::DevLong theNumber;
+        extract(in_any, theNumber);
+        cout << "[IOLong64::execute] received number " << theNumber << endl;
+        DEV_DEBUG_STREAM(device) << "[IOLong64::execute] received number " << theNumber;
+        theNumber = theNumber * 2;
+        cout << "[IOLong64::execute] return number " << theNumber << endl;
+        DEV_DEBUG_STREAM(device) << "[IOLong64::execute] return number " << theNumber << endl;
+        return insert(theNumber);
+    }
+    catch (CORBA::Exception &e)
+    {
+        Tango::Except::print_exception(e);
+        throw;
     }
 }
 
@@ -291,10 +293,10 @@ CORBA::Any *IOLong64::execute(Tango::DeviceImpl *device,const CORBA::Any &in_any
 //
 //-----------------------------------------------------------------------------
 
-IOFloat::IOFloat(const char *name,Tango::CmdArgType in,
-		   Tango::CmdArgType out,const char *in_desc,
-		   const char *out_desc)
-:Tango::Command(name,in,out,in_desc,out_desc)
+IOFloat::IOFloat(const char *name, Tango::CmdArgType in,
+                 Tango::CmdArgType out, const char *in_desc,
+                 const char *out_desc)
+    : Tango::Command(name, in, out, in_desc, out_desc)
 {
 }
 
@@ -306,27 +308,28 @@ bool IOFloat::is_allowed(Tango::DeviceImpl *device, TANGO_UNUSED(const CORBA::An
 // command allowed only if the device is on
 //
 
-	if (device->get_state() == Tango::ON)
-		return(true);
-	else
-		return(false);
+    if (device->get_state() == Tango::ON)
+        return (true);
+    else
+        return (false);
 }
 
 
 CORBA::Any *IOFloat::execute(TANGO_UNUSED(Tango::DeviceImpl *device),const CORBA::Any &in_any)
 {
-  try {
-    Tango::DevFloat theNumber;
-    extract(in_any,theNumber);
-    cout << "[IOFloat::execute] received number " << theNumber << endl;
-    theNumber = theNumber * 2;
-    cout << "[IOFloat::execute] return number " << theNumber << endl;
-    return insert(theNumber);
-  }
-  catch (CORBA::Exception &e)
+    try
     {
-      Tango::Except::print_exception(e);
-      throw ;
+        Tango::DevFloat theNumber;
+        extract(in_any, theNumber);
+        cout << "[IOFloat::execute] received number " << theNumber << endl;
+        theNumber = theNumber * 2;
+        cout << "[IOFloat::execute] return number " << theNumber << endl;
+        return insert(theNumber);
+    }
+    catch (CORBA::Exception &e)
+    {
+        Tango::Except::print_exception(e);
+        throw;
     }
 }
 
@@ -346,10 +349,10 @@ CORBA::Any *IOFloat::execute(TANGO_UNUSED(Tango::DeviceImpl *device),const CORBA
 //
 //-----------------------------------------------------------------------------
 
-IODouble::IODouble(const char *name,Tango::CmdArgType in,
-		   Tango::CmdArgType out,const char *in_desc,
-		   const char *out_desc)
-:Tango::Command(name,in,out,in_desc,out_desc)
+IODouble::IODouble(const char *name, Tango::CmdArgType in,
+                   Tango::CmdArgType out, const char *in_desc,
+                   const char *out_desc)
+    : Tango::Command(name, in, out, in_desc, out_desc)
 {
 }
 
@@ -361,27 +364,28 @@ bool IODouble::is_allowed(Tango::DeviceImpl *device, TANGO_UNUSED(const CORBA::A
 // command allowed only if the device is on
 //
 
-	if (device->get_state() == Tango::ON)
-		return(true);
-	else
-		return(false);
+    if (device->get_state() == Tango::ON)
+        return (true);
+    else
+        return (false);
 }
 
 
 CORBA::Any *IODouble::execute(TANGO_UNUSED(Tango::DeviceImpl *device),const CORBA::Any &in_any)
 {
-  try {
-    Tango::DevDouble theNumber;
-    extract(in_any,theNumber);
-    cout << "[IODouble::execute] received number " << theNumber << endl;
-    theNumber = theNumber * 2;
-    cout << "[IODouble::execute] return number " << theNumber << endl;
-    return insert(theNumber);
-  }
-  catch (CORBA::Exception &e)
+    try
     {
-      Tango::Except::print_exception(e);
-      throw ;
+        Tango::DevDouble theNumber;
+        extract(in_any, theNumber);
+        cout << "[IODouble::execute] received number " << theNumber << endl;
+        theNumber = theNumber * 2;
+        cout << "[IODouble::execute] return number " << theNumber << endl;
+        return insert(theNumber);
+    }
+    catch (CORBA::Exception &e)
+    {
+        Tango::Except::print_exception(e);
+        throw;
     }
 }
 
@@ -401,10 +405,10 @@ CORBA::Any *IODouble::execute(TANGO_UNUSED(Tango::DeviceImpl *device),const CORB
 //
 //-----------------------------------------------------------------------------
 
-IOUShort::IOUShort(const char *name,Tango::CmdArgType in,
-		   Tango::CmdArgType out,const char *in_desc,
-		   const char *out_desc)
-:Tango::Command(name,in,out,in_desc,out_desc)
+IOUShort::IOUShort(const char *name, Tango::CmdArgType in,
+                   Tango::CmdArgType out, const char *in_desc,
+                   const char *out_desc)
+    : Tango::Command(name, in, out, in_desc, out_desc)
 {
 }
 
@@ -416,27 +420,28 @@ bool IOUShort::is_allowed(Tango::DeviceImpl *device, TANGO_UNUSED(const CORBA::A
 // command allowed only if the device is on
 //
 
-	if (device->get_state() == Tango::ON)
-		return(true);
-	else
-		return(false);
+    if (device->get_state() == Tango::ON)
+        return (true);
+    else
+        return (false);
 }
 
 
 CORBA::Any *IOUShort::execute(TANGO_UNUSED(Tango::DeviceImpl *device),const CORBA::Any &in_any)
 {
-  try {
-    Tango::DevUShort theNumber;
-    extract(in_any,theNumber);
-    cout << "[IOUShort::execute] received number " << theNumber << endl;
-    theNumber = theNumber * 2;
-    cout << "[IOUShort::execute] return number " << theNumber << endl;
-    return insert(theNumber);
-  }
-  catch (CORBA::Exception &e)
+    try
     {
-      Tango::Except::print_exception(e);
-      throw ;
+        Tango::DevUShort theNumber;
+        extract(in_any, theNumber);
+        cout << "[IOUShort::execute] received number " << theNumber << endl;
+        theNumber = theNumber * 2;
+        cout << "[IOUShort::execute] return number " << theNumber << endl;
+        return insert(theNumber);
+    }
+    catch (CORBA::Exception &e)
+    {
+        Tango::Except::print_exception(e);
+        throw;
     }
 }
 
@@ -455,10 +460,10 @@ CORBA::Any *IOUShort::execute(TANGO_UNUSED(Tango::DeviceImpl *device),const CORB
 //
 //-----------------------------------------------------------------------------
 
-IOULong::IOULong(const char *name,Tango::CmdArgType in,
-		   Tango::CmdArgType out,const char *in_desc,
-		   const char *out_desc)
-:Tango::Command(name,in,out,in_desc,out_desc)
+IOULong::IOULong(const char *name, Tango::CmdArgType in,
+                 Tango::CmdArgType out, const char *in_desc,
+                 const char *out_desc)
+    : Tango::Command(name, in, out, in_desc, out_desc)
 {
 }
 
@@ -470,27 +475,28 @@ bool IOULong::is_allowed(Tango::DeviceImpl *device, TANGO_UNUSED(const CORBA::An
 // command allowed only if the device is on
 //
 
-	if (device->get_state() == Tango::ON)
-		return(true);
-	else
-		return(false);
+    if (device->get_state() == Tango::ON)
+        return (true);
+    else
+        return (false);
 }
 
 
 CORBA::Any *IOULong::execute(TANGO_UNUSED(Tango::DeviceImpl *device),const CORBA::Any &in_any)
 {
-  try {
-    Tango::DevULong theNumber;
-    extract(in_any,theNumber);
-    cout << "[IOULong::execute] received number " << theNumber << endl;
-    theNumber = theNumber * 2;
-    cout << "[IOULong::execute] return number " << theNumber << endl;
-    return insert(theNumber);
-  }
-  catch (CORBA::Exception &e)
+    try
     {
-      Tango::Except::print_exception(e);
-      throw ;
+        Tango::DevULong theNumber;
+        extract(in_any, theNumber);
+        cout << "[IOULong::execute] received number " << theNumber << endl;
+        theNumber = theNumber * 2;
+        cout << "[IOULong::execute] return number " << theNumber << endl;
+        return insert(theNumber);
+    }
+    catch (CORBA::Exception &e)
+    {
+        Tango::Except::print_exception(e);
+        throw;
     }
 }
 
@@ -511,10 +517,10 @@ CORBA::Any *IOULong::execute(TANGO_UNUSED(Tango::DeviceImpl *device),const CORBA
 //
 //-----------------------------------------------------------------------------
 
-IOULong64::IOULong64(const char *name,Tango::CmdArgType in,
-		   Tango::CmdArgType out,const char *in_desc,
-		   const char *out_desc)
-:Tango::Command(name,in,out,in_desc,out_desc)
+IOULong64::IOULong64(const char *name, Tango::CmdArgType in,
+                     Tango::CmdArgType out, const char *in_desc,
+                     const char *out_desc)
+    : Tango::Command(name, in, out, in_desc, out_desc)
 {
 }
 
@@ -526,27 +532,28 @@ bool IOULong64::is_allowed(Tango::DeviceImpl *device, TANGO_UNUSED(const CORBA::
 // command allowed only if the device is on
 //
 
-	if (device->get_state() == Tango::ON)
-		return(true);
-	else
-		return(false);
+    if (device->get_state() == Tango::ON)
+        return (true);
+    else
+        return (false);
 }
 
 
 CORBA::Any *IOULong64::execute(TANGO_UNUSED(Tango::DeviceImpl *device),const CORBA::Any &in_any)
 {
-  try {
-    Tango::DevULong64 theNumber;
-    extract(in_any,theNumber);
-    cout << "[IOULong64::execute] received number " << theNumber << endl;
-    theNumber = theNumber * 2;
-    cout << "[IOULong64::execute] return number " << theNumber << endl;
-    return insert(theNumber);
-  }
-  catch (CORBA::Exception &e)
+    try
     {
-      Tango::Except::print_exception(e);
-      throw ;
+        Tango::DevULong64 theNumber;
+        extract(in_any, theNumber);
+        cout << "[IOULong64::execute] received number " << theNumber << endl;
+        theNumber = theNumber * 2;
+        cout << "[IOULong64::execute] return number " << theNumber << endl;
+        return insert(theNumber);
+    }
+    catch (CORBA::Exception &e)
+    {
+        Tango::Except::print_exception(e);
+        throw;
     }
 }
 
@@ -566,10 +573,10 @@ CORBA::Any *IOULong64::execute(TANGO_UNUSED(Tango::DeviceImpl *device),const COR
 //
 //-----------------------------------------------------------------------------
 
-IOString::IOString(const char *name,Tango::CmdArgType in,
-		   Tango::CmdArgType out,const char *in_desc,
-		   const char *out_desc)
-:Tango::Command(name,in,out,in_desc,out_desc)
+IOString::IOString(const char *name, Tango::CmdArgType in,
+                   Tango::CmdArgType out, const char *in_desc,
+                   const char *out_desc)
+    : Tango::Command(name, in, out, in_desc, out_desc)
 {
 }
 
@@ -580,32 +587,31 @@ bool IOString::is_allowed(Tango::DeviceImpl *device, TANGO_UNUSED(const CORBA::A
 // command allowed only if the device is on
 //
 
-	if (device->get_state() == Tango::ON)
-		return(true);
-	else
-		return(false);
+    if (device->get_state() == Tango::ON)
+        return (true);
+    else
+        return (false);
 }
 
 
 CORBA::Any *IOString::execute(TANGO_UNUSED(Tango::DeviceImpl *device),const CORBA::Any &in_any)
 {
 
-	cout2 << "[IOString::execute] arrived" << endl;
-	try {
+    cout2 << "[IOString::execute] arrived" << endl;
+    try
+    {
 
-	  Tango::DevString theWord;
-	  extract(in_any,theWord);
-	  string palindrome;
-	  string firstWord = theWord;
-	  string::reverse_iterator currentChar(firstWord.rbegin());
-	  string::reverse_iterator endChar(firstWord.rend());
+        Tango::DevString theWord;
+        extract(in_any, theWord);
 
-	  cout << "[IOString::execute] firstWord = " << firstWord << endl;
+        string firstWord = theWord;
+        string::reverse_iterator currentChar(firstWord.rbegin());
+        string::reverse_iterator endChar(firstWord.rend());
 
-	  for ( ; currentChar != endChar; currentChar++) {
-	    cout << "[IOString::execute]  currentChar = " << *currentChar <<endl;
-	    palindrome += *currentChar;
-	  }
+        cout << "[IOString::execute] firstWord = " << firstWord << endl;
+
+        string palindrome{currentChar, endChar};
+
 	  cout << "[IOString::execute] palindrome = " << palindrome << endl;
 	  return insert(palindrome.c_str());
 	}
@@ -632,10 +638,10 @@ CORBA::Any *IOString::execute(TANGO_UNUSED(Tango::DeviceImpl *device),const CORB
 //
 //-----------------------------------------------------------------------------
 
-IOCharArray::IOCharArray(const char *name,Tango::CmdArgType in,
-		   Tango::CmdArgType out,const char *in_desc,
-		   const char *out_desc)
-:Tango::Command(name,in,out,in_desc,out_desc)
+IOCharArray::IOCharArray(const char *name, Tango::CmdArgType in,
+                         Tango::CmdArgType out, const char *in_desc,
+                         const char *out_desc)
+    : Tango::Command(name, in, out, in_desc, out_desc)
 {
 }
 
@@ -646,30 +652,32 @@ bool IOCharArray::is_allowed(Tango::DeviceImpl *device, TANGO_UNUSED(const CORBA
 // command allowed only if the device is on
 //
 
-	if (device->get_state() == Tango::ON)
-		return(true);
-	else
-		return(false);
+    if (device->get_state() == Tango::ON)
+        return (true);
+    else
+        return (false);
 }
 
 CORBA::Any *IOCharArray::execute(TANGO_UNUSED(Tango::DeviceImpl *device),const CORBA::Any &in_any)
 {
-  try {
-    cout << "[IOCharArray::execute] entering "  << endl;
-    const Tango::DevVarCharArray *theCharArray;
-    extract(in_any,theCharArray);
-    Tango::DevVarCharArray *theReturnedArray = new Tango::DevVarCharArray();
-    theReturnedArray->length(theCharArray->length());
-    for (unsigned int i=0; i<theCharArray->length(); i++) {
-      cout << "[IOCharArray::execute] received char " << (*theCharArray)[i] << endl;
-      (*theReturnedArray)[theCharArray->length()-i-1] = (*theCharArray)[i] ;
-    }
-    return insert(theReturnedArray);
-  }
-  catch (CORBA::Exception &e)
+    try
     {
-      Tango::Except::print_exception(e);
-      throw ;
+        cout << "[IOCharArray::execute] entering " << endl;
+        const Tango::DevVarCharArray *theCharArray;
+        extract(in_any, theCharArray);
+        Tango::DevVarCharArray *theReturnedArray = new Tango::DevVarCharArray();
+        theReturnedArray->length(theCharArray->length());
+        for (unsigned int i = 0; i < theCharArray->length(); i++)
+        {
+            cout << "[IOCharArray::execute] received char " << (*theCharArray)[i] << endl;
+            (*theReturnedArray)[theCharArray->length() - i - 1] = (*theCharArray)[i];
+        }
+        return insert(theReturnedArray);
+    }
+    catch (CORBA::Exception &e)
+    {
+        Tango::Except::print_exception(e);
+        throw;
     }
 }
 
@@ -689,10 +697,10 @@ CORBA::Any *IOCharArray::execute(TANGO_UNUSED(Tango::DeviceImpl *device),const C
 //
 //-----------------------------------------------------------------------------
 
-IOShortArray::IOShortArray(const char *name,Tango::CmdArgType in,
-		   Tango::CmdArgType out,const char *in_desc,
-		   const char *out_desc)
-:Tango::Command(name,in,out,in_desc,out_desc)
+IOShortArray::IOShortArray(const char *name, Tango::CmdArgType in,
+                           Tango::CmdArgType out, const char *in_desc,
+                           const char *out_desc)
+    : Tango::Command(name, in, out, in_desc, out_desc)
 {
 }
 
@@ -704,31 +712,33 @@ bool IOShortArray::is_allowed(Tango::DeviceImpl *device, TANGO_UNUSED(const CORB
 // command allowed only if the device is on
 //
 
-	if (device->get_state() == Tango::ON)
-		return(true);
-	else
-		return(false);
+    if (device->get_state() == Tango::ON)
+        return (true);
+    else
+        return (false);
 }
 
 
 CORBA::Any *IOShortArray::execute(TANGO_UNUSED(Tango::DeviceImpl *device),const CORBA::Any &in_any)
 {
-  try {
-    const Tango::DevVarShortArray *theNumberArray;
-    extract(in_any,theNumberArray);
-    Tango::DevVarShortArray *theReturnedArray = new Tango::DevVarShortArray();
-    theReturnedArray->length(theNumberArray->length());
-    for (unsigned int i=0; i<theNumberArray->length(); i++) {
-      cout << "[IOShortArray::execute] received number " << (*theNumberArray)[i] << endl;
-      (*theReturnedArray)[i] = (*theNumberArray)[i] * 2;
-      cout << "[IOShortArray::execute] return number " << (*theReturnedArray)[i] << endl;
-    }
-    return insert(theReturnedArray);
-  }
-  catch (CORBA::Exception &e)
+    try
     {
-      Tango::Except::print_exception(e);
-      throw ;
+        const Tango::DevVarShortArray *theNumberArray;
+        extract(in_any, theNumberArray);
+        Tango::DevVarShortArray *theReturnedArray = new Tango::DevVarShortArray();
+        theReturnedArray->length(theNumberArray->length());
+        for (unsigned int i = 0; i < theNumberArray->length(); i++)
+        {
+            cout << "[IOShortArray::execute] received number " << (*theNumberArray)[i] << endl;
+            (*theReturnedArray)[i] = (*theNumberArray)[i] * 2;
+            cout << "[IOShortArray::execute] return number " << (*theReturnedArray)[i] << endl;
+        }
+        return insert(theReturnedArray);
+    }
+    catch (CORBA::Exception &e)
+    {
+        Tango::Except::print_exception(e);
+        throw;
     }
 }
 
@@ -748,10 +758,10 @@ CORBA::Any *IOShortArray::execute(TANGO_UNUSED(Tango::DeviceImpl *device),const 
 //
 //-----------------------------------------------------------------------------
 
-IOLongArray::IOLongArray(const char *name,Tango::CmdArgType in,
-		   Tango::CmdArgType out,const char *in_desc,
-		   const char *out_desc)
-:Tango::Command(name,in,out,in_desc,out_desc)
+IOLongArray::IOLongArray(const char *name, Tango::CmdArgType in,
+                         Tango::CmdArgType out, const char *in_desc,
+                         const char *out_desc)
+    : Tango::Command(name, in, out, in_desc, out_desc)
 {
 }
 
@@ -763,31 +773,33 @@ bool IOLongArray::is_allowed(Tango::DeviceImpl *device, TANGO_UNUSED(const CORBA
 // command allowed only if the device is on
 //
 
-	if (device->get_state() == Tango::ON)
-		return(true);
-	else
-		return(false);
+    if (device->get_state() == Tango::ON)
+        return (true);
+    else
+        return (false);
 }
 
 
 CORBA::Any *IOLongArray::execute(TANGO_UNUSED(Tango::DeviceImpl *device),const CORBA::Any &in_any)
 {
-  try {
-    const Tango::DevVarLongArray *theNumberArray;
-    extract(in_any,theNumberArray);
-    Tango::DevVarLongArray *theReturnedArray = new Tango::DevVarLongArray();
-    theReturnedArray->length(theNumberArray->length());
-    for (unsigned int i=0; i<theNumberArray->length(); i++) {
-      cout << "[IOLongArray::execute] received number " << (*theNumberArray)[i] << endl;
-      (*theReturnedArray)[i] = (*theNumberArray)[i] * 2;
-      cout << "[IOLongArray::execute] return number " << (*theReturnedArray)[i] << endl;
-    }
-    return insert(theReturnedArray);
-  }
-  catch (CORBA::Exception &e)
+    try
     {
-      Tango::Except::print_exception(e);
-      throw ;
+        const Tango::DevVarLongArray *theNumberArray;
+        extract(in_any, theNumberArray);
+        Tango::DevVarLongArray *theReturnedArray = new Tango::DevVarLongArray();
+        theReturnedArray->length(theNumberArray->length());
+        for (unsigned int i = 0; i < theNumberArray->length(); i++)
+        {
+            cout << "[IOLongArray::execute] received number " << (*theNumberArray)[i] << endl;
+            (*theReturnedArray)[i] = (*theNumberArray)[i] * 2;
+            cout << "[IOLongArray::execute] return number " << (*theReturnedArray)[i] << endl;
+        }
+        return insert(theReturnedArray);
+    }
+    catch (CORBA::Exception &e)
+    {
+        Tango::Except::print_exception(e);
+        throw;
     }
 }
 
@@ -807,10 +819,10 @@ CORBA::Any *IOLongArray::execute(TANGO_UNUSED(Tango::DeviceImpl *device),const C
 //
 //-----------------------------------------------------------------------------
 
-IOFloatArray::IOFloatArray(const char *name,Tango::CmdArgType in,
-		   Tango::CmdArgType out,const char *in_desc,
-		   const char *out_desc)
-:Tango::Command(name,in,out,in_desc,out_desc)
+IOFloatArray::IOFloatArray(const char *name, Tango::CmdArgType in,
+                           Tango::CmdArgType out, const char *in_desc,
+                           const char *out_desc)
+    : Tango::Command(name, in, out, in_desc, out_desc)
 {
 }
 
@@ -822,31 +834,33 @@ bool IOFloatArray::is_allowed(Tango::DeviceImpl *device, TANGO_UNUSED(const CORB
 // command allowed only if the device is on
 //
 
-	if (device->get_state() == Tango::ON)
-		return(true);
-	else
-		return(false);
+    if (device->get_state() == Tango::ON)
+        return (true);
+    else
+        return (false);
 }
 
 
 CORBA::Any *IOFloatArray::execute(TANGO_UNUSED(Tango::DeviceImpl *device),const CORBA::Any &in_any)
 {
-  try {
-    const Tango::DevVarFloatArray *theNumberArray;
-    extract(in_any,theNumberArray);
-    Tango::DevVarFloatArray *theReturnedArray = new Tango::DevVarFloatArray();
-    theReturnedArray->length(theNumberArray->length());
-    for (unsigned int i=0; i<theNumberArray->length(); i++) {
-      cout << "[IOFloatArray::execute] received number " << (*theNumberArray)[i] << endl;
-      (*theReturnedArray)[i] = (*theNumberArray)[i] * 2;
-      cout << "[IOFloatArray::execute] return number " << (*theReturnedArray)[i] << endl;
-    }
-    return insert(theReturnedArray);
-  }
-  catch (CORBA::Exception &e)
+    try
     {
-      Tango::Except::print_exception(e);
-      throw ;
+        const Tango::DevVarFloatArray *theNumberArray;
+        extract(in_any, theNumberArray);
+        Tango::DevVarFloatArray *theReturnedArray = new Tango::DevVarFloatArray();
+        theReturnedArray->length(theNumberArray->length());
+        for (unsigned int i = 0; i < theNumberArray->length(); i++)
+        {
+            cout << "[IOFloatArray::execute] received number " << (*theNumberArray)[i] << endl;
+            (*theReturnedArray)[i] = (*theNumberArray)[i] * 2;
+            cout << "[IOFloatArray::execute] return number " << (*theReturnedArray)[i] << endl;
+        }
+        return insert(theReturnedArray);
+    }
+    catch (CORBA::Exception &e)
+    {
+        Tango::Except::print_exception(e);
+        throw;
     }
 }
 
@@ -865,10 +879,10 @@ CORBA::Any *IOFloatArray::execute(TANGO_UNUSED(Tango::DeviceImpl *device),const 
 //
 //-----------------------------------------------------------------------------
 
-IODoubleArray::IODoubleArray(const char *name,Tango::CmdArgType in,
-		   Tango::CmdArgType out,const char *in_desc,
-		   const char *out_desc)
-:Command(name,in,out,in_desc,out_desc)
+IODoubleArray::IODoubleArray(const char *name, Tango::CmdArgType in,
+                             Tango::CmdArgType out, const char *in_desc,
+                             const char *out_desc)
+    : Command(name, in, out, in_desc, out_desc)
 {
 }
 
@@ -880,31 +894,33 @@ bool IODoubleArray::is_allowed(Tango::DeviceImpl *device, TANGO_UNUSED(const COR
 // command allowed only if the device is on
 //
 
-	if (device->get_state() == Tango::ON)
-		return(true);
-	else
-		return(false);
+    if (device->get_state() == Tango::ON)
+        return (true);
+    else
+        return (false);
 }
 
 
 CORBA::Any *IODoubleArray::execute(TANGO_UNUSED(Tango::DeviceImpl *device),const CORBA::Any &in_any)
 {
-  try {
-    const Tango::DevVarDoubleArray *theNumberArray;
-    extract(in_any,theNumberArray);
-    Tango::DevVarDoubleArray *theReturnedArray = new Tango::DevVarDoubleArray();
-    theReturnedArray->length(theNumberArray->length());
-    for (unsigned int i=0; i<theNumberArray->length(); i++) {
-      cout << "[IODoubleArray::execute] received number " << (*theNumberArray)[i] << endl;
-      (*theReturnedArray)[i] = (*theNumberArray)[i] * 2;
-      cout << "[IODoubleArray::execute] return number " << (*theReturnedArray)[i] << endl;
-    }
-    return insert(theReturnedArray);
-  }
-  catch (CORBA::Exception &e)
+    try
     {
-      Tango::Except::print_exception(e);
-      throw ;
+        const Tango::DevVarDoubleArray *theNumberArray;
+        extract(in_any, theNumberArray);
+        Tango::DevVarDoubleArray *theReturnedArray = new Tango::DevVarDoubleArray();
+        theReturnedArray->length(theNumberArray->length());
+        for (unsigned int i = 0; i < theNumberArray->length(); i++)
+        {
+            cout << "[IODoubleArray::execute] received number " << (*theNumberArray)[i] << endl;
+            (*theReturnedArray)[i] = (*theNumberArray)[i] * 2;
+            cout << "[IODoubleArray::execute] return number " << (*theReturnedArray)[i] << endl;
+        }
+        return insert(theReturnedArray);
+    }
+    catch (CORBA::Exception &e)
+    {
+        Tango::Except::print_exception(e);
+        throw;
     }
 }
 
@@ -924,10 +940,10 @@ CORBA::Any *IODoubleArray::execute(TANGO_UNUSED(Tango::DeviceImpl *device),const
 //
 //-----------------------------------------------------------------------------
 
-IOUShortArray::IOUShortArray(const char *name,Tango::CmdArgType in,
-		   Tango::CmdArgType out,const char *in_desc,
-		   const char *out_desc)
-:Tango::Command(name,in,out,in_desc,out_desc)
+IOUShortArray::IOUShortArray(const char *name, Tango::CmdArgType in,
+                             Tango::CmdArgType out, const char *in_desc,
+                             const char *out_desc)
+    : Tango::Command(name, in, out, in_desc, out_desc)
 {
 }
 
@@ -939,31 +955,33 @@ bool IOUShortArray::is_allowed(Tango::DeviceImpl *device, TANGO_UNUSED(const COR
 // command allowed only if the device is on
 //
 
-	if (device->get_state() == Tango::ON)
-		return(true);
-	else
-		return(false);
+    if (device->get_state() == Tango::ON)
+        return (true);
+    else
+        return (false);
 }
 
 
 CORBA::Any *IOUShortArray::execute(TANGO_UNUSED(Tango::DeviceImpl *device),const CORBA::Any &in_any)
 {
-  try {
-    const Tango::DevVarUShortArray *theNumberArray;
-    extract(in_any,theNumberArray);
-    Tango::DevVarUShortArray *theReturnedArray = new Tango::DevVarUShortArray();
-    theReturnedArray->length(theNumberArray->length());
-    for (unsigned int i=0; i<theNumberArray->length(); i++) {
-      cout << "[IOUShortArray::execute] received number " << (*theNumberArray)[i] << endl;
-      (*theReturnedArray)[i] = (*theNumberArray)[i] * 2;
-      cout << "[IOUShortArray::execute] return number " << (*theReturnedArray)[i] << endl;
-    }
-    return insert(theReturnedArray);
-  }
-  catch (CORBA::Exception &e)
+    try
     {
-      Tango::Except::print_exception(e);
-      throw ;
+        const Tango::DevVarUShortArray *theNumberArray;
+        extract(in_any, theNumberArray);
+        Tango::DevVarUShortArray *theReturnedArray = new Tango::DevVarUShortArray();
+        theReturnedArray->length(theNumberArray->length());
+        for (unsigned int i = 0; i < theNumberArray->length(); i++)
+        {
+            cout << "[IOUShortArray::execute] received number " << (*theNumberArray)[i] << endl;
+            (*theReturnedArray)[i] = (*theNumberArray)[i] * 2;
+            cout << "[IOUShortArray::execute] return number " << (*theReturnedArray)[i] << endl;
+        }
+        return insert(theReturnedArray);
+    }
+    catch (CORBA::Exception &e)
+    {
+        Tango::Except::print_exception(e);
+        throw;
     }
 }
 
@@ -983,10 +1001,10 @@ CORBA::Any *IOUShortArray::execute(TANGO_UNUSED(Tango::DeviceImpl *device),const
 //
 //-----------------------------------------------------------------------------
 
-IOULongArray::IOULongArray(const char *name,Tango::CmdArgType in,
-		   Tango::CmdArgType out,const char *in_desc,
-		   const char *out_desc)
-:Tango::Command(name,in,out,in_desc,out_desc)
+IOULongArray::IOULongArray(const char *name, Tango::CmdArgType in,
+                           Tango::CmdArgType out, const char *in_desc,
+                           const char *out_desc)
+    : Tango::Command(name, in, out, in_desc, out_desc)
 {
 }
 
@@ -998,31 +1016,33 @@ bool IOULongArray::is_allowed(Tango::DeviceImpl *device, TANGO_UNUSED(const CORB
 // command allowed only if the device is on
 //
 
-	if (device->get_state() == Tango::ON)
-		return(true);
-	else
-		return(false);
+    if (device->get_state() == Tango::ON)
+        return (true);
+    else
+        return (false);
 }
 
 
 CORBA::Any *IOULongArray::execute(TANGO_UNUSED(Tango::DeviceImpl *device),const CORBA::Any &in_any)
 {
-  try {
-    const Tango::DevVarULongArray *theNumberArray;
-    extract(in_any,theNumberArray);
-    Tango::DevVarULongArray *theReturnedArray = new Tango::DevVarULongArray();
-    theReturnedArray->length(theNumberArray->length());
-    for (unsigned int i=0; i<theNumberArray->length(); i++) {
-      cout << "[IOULongArray::execute] received number " << (*theNumberArray)[i] << endl;
-      (*theReturnedArray)[i] = (*theNumberArray)[i] * 2;
-      cout << "[IOULongArray::execute] return number " << (*theReturnedArray)[i] << endl;
-    }
-    return insert(theReturnedArray);
-  }
-  catch (CORBA::Exception &e)
+    try
     {
-      Tango::Except::print_exception(e);
-      throw ;
+        const Tango::DevVarULongArray *theNumberArray;
+        extract(in_any, theNumberArray);
+        Tango::DevVarULongArray *theReturnedArray = new Tango::DevVarULongArray();
+        theReturnedArray->length(theNumberArray->length());
+        for (unsigned int i = 0; i < theNumberArray->length(); i++)
+        {
+            cout << "[IOULongArray::execute] received number " << (*theNumberArray)[i] << endl;
+            (*theReturnedArray)[i] = (*theNumberArray)[i] * 2;
+            cout << "[IOULongArray::execute] return number " << (*theReturnedArray)[i] << endl;
+        }
+        return insert(theReturnedArray);
+    }
+    catch (CORBA::Exception &e)
+    {
+        Tango::Except::print_exception(e);
+        throw;
     }
 }
 
@@ -1042,10 +1062,10 @@ CORBA::Any *IOULongArray::execute(TANGO_UNUSED(Tango::DeviceImpl *device),const 
 //
 //-----------------------------------------------------------------------------
 
-IOStringArray::IOStringArray(const char *name,Tango::CmdArgType in,
-		   Tango::CmdArgType out,const char *in_desc,
-		   const char *out_desc)
-:Command(name,in,out,in_desc,out_desc)
+IOStringArray::IOStringArray(const char *name, Tango::CmdArgType in,
+                             Tango::CmdArgType out, const char *in_desc,
+                             const char *out_desc)
+    : Command(name, in, out, in_desc, out_desc)
 {
 }
 
@@ -1056,31 +1076,33 @@ bool IOStringArray::is_allowed(Tango::DeviceImpl *device, TANGO_UNUSED(const COR
 // command allowed only if the device is on
 //
 
-	if (device->get_state() == Tango::ON)
-		return(true);
-	else
-		return(false);
+    if (device->get_state() == Tango::ON)
+        return (true);
+    else
+        return (false);
 }
 
 
 CORBA::Any *IOStringArray::execute(TANGO_UNUSED(Tango::DeviceImpl *device),const CORBA::Any &in_any)
 {
-  try {
-    const Tango::DevVarStringArray *theStringArray;
-    extract(in_any,theStringArray);
-    Tango::DevVarStringArray *theReturnedArray = new Tango::DevVarStringArray();
-    theReturnedArray->length(theStringArray->length());
-    for (unsigned int i=0; i<theStringArray->length(); i++) {
-      cout << "[IOStringArray::execute] received String " << (*theStringArray)[i].in() << endl;
-      (*theReturnedArray)[theStringArray->length()-i-1] = (*theStringArray)[i] ;
-      cout << "[IOStringArray::execute] return String " << (*theReturnedArray)[i].in() << endl;
-    }
-    return insert(theReturnedArray);
-  }
-  catch (CORBA::Exception &e)
+    try
     {
-      Tango::Except::print_exception(e);
-      throw ;
+        const Tango::DevVarStringArray *theStringArray;
+        extract(in_any, theStringArray);
+        Tango::DevVarStringArray *theReturnedArray = new Tango::DevVarStringArray();
+        theReturnedArray->length(theStringArray->length());
+        for (unsigned int i = 0; i < theStringArray->length(); i++)
+        {
+            cout << "[IOStringArray::execute] received String " << (*theStringArray)[i].in() << endl;
+            (*theReturnedArray)[theStringArray->length() - i - 1] = (*theStringArray)[i];
+            cout << "[IOStringArray::execute] return String " << (*theReturnedArray)[i].in() << endl;
+        }
+        return insert(theReturnedArray);
+    }
+    catch (CORBA::Exception &e)
+    {
+        Tango::Except::print_exception(e);
+        throw;
     }
 }
 
@@ -1100,10 +1122,10 @@ CORBA::Any *IOStringArray::execute(TANGO_UNUSED(Tango::DeviceImpl *device),const
 //
 //-----------------------------------------------------------------------------
 
-IOLongString::IOLongString(const char *name,Tango::CmdArgType in,
-		   Tango::CmdArgType out,const char *in_desc,
-		   const char *out_desc)
-:Tango::Command(name,in,out,in_desc,out_desc)
+IOLongString::IOLongString(const char *name, Tango::CmdArgType in,
+                           Tango::CmdArgType out, const char *in_desc,
+                           const char *out_desc)
+    : Tango::Command(name, in, out, in_desc, out_desc)
 {
 }
 
@@ -1115,39 +1137,42 @@ bool IOLongString::is_allowed(Tango::DeviceImpl *device, TANGO_UNUSED(const CORB
 // command allowed only if the device is on
 //
 
-	if (device->get_state() == Tango::ON)
-		return(true);
-	else
-		return(false);
+    if (device->get_state() == Tango::ON)
+        return (true);
+    else
+        return (false);
 }
 
 
 CORBA::Any *IOLongString::execute(TANGO_UNUSED(Tango::DeviceImpl *device),const CORBA::Any &in_any)
 {
-  try {
-    const Tango::DevVarLongStringArray *theReceived;
-    extract(in_any,theReceived);
-    Tango::DevVarLongStringArray *theReturned = new Tango::DevVarLongStringArray;
-    unsigned int i;
-
-    ((*theReturned).lvalue).length(((*theReceived).lvalue).length());
-    for (i=0; i<((*theReceived).lvalue).length(); i++) {
-      cout << "[IOLongString::execute] received number " << (*theReceived).lvalue[i] << endl;
-      (*theReturned).lvalue[i] = (*theReceived).lvalue[i] * 2;
-      cout << "[IOLongString::execute] return number " << (*theReturned).lvalue[i] << endl;
-    }
-    ((*theReturned).svalue).length(((*theReceived).svalue).length());
-    for (i=0; i<((*theReceived).svalue).length(); i++) {
-      cout << "[IOLongString::execute] received string " << (*theReceived).svalue[i].in() << endl;
-      (*theReturned).svalue[i] = CORBA::string_dup((*theReceived).svalue[i]);
-      cout << "[IOLongString::execute] return string " << (*theReturned).svalue[i].in() << endl;
-    }
-    return insert(theReturned);
-  }
-  catch (CORBA::Exception &e)
+    try
     {
-      Tango::Except::print_exception(e);
-      throw ;
+        const Tango::DevVarLongStringArray *theReceived;
+        extract(in_any, theReceived);
+        Tango::DevVarLongStringArray *theReturned = new Tango::DevVarLongStringArray;
+        unsigned int i;
+
+        ((*theReturned).lvalue).length(((*theReceived).lvalue).length());
+        for (i = 0; i < ((*theReceived).lvalue).length(); i++)
+        {
+            cout << "[IOLongString::execute] received number " << (*theReceived).lvalue[i] << endl;
+            (*theReturned).lvalue[i] = (*theReceived).lvalue[i] * 2;
+            cout << "[IOLongString::execute] return number " << (*theReturned).lvalue[i] << endl;
+        }
+        ((*theReturned).svalue).length(((*theReceived).svalue).length());
+        for (i = 0; i < ((*theReceived).svalue).length(); i++)
+        {
+            cout << "[IOLongString::execute] received string " << (*theReceived).svalue[i].in() << endl;
+            (*theReturned).svalue[i] = CORBA::string_dup((*theReceived).svalue[i]);
+            cout << "[IOLongString::execute] return string " << (*theReturned).svalue[i].in() << endl;
+        }
+        return insert(theReturned);
+    }
+    catch (CORBA::Exception &e)
+    {
+        Tango::Except::print_exception(e);
+        throw;
     }
 }
 
@@ -1167,10 +1192,10 @@ CORBA::Any *IOLongString::execute(TANGO_UNUSED(Tango::DeviceImpl *device),const 
 //
 //-----------------------------------------------------------------------------
 
-IODoubleString::IODoubleString(const char *name,Tango::CmdArgType in,
-		   Tango::CmdArgType out,const char *in_desc,
-		   const char *out_desc)
-:Tango::Command(name,in,out,in_desc,out_desc)
+IODoubleString::IODoubleString(const char *name, Tango::CmdArgType in,
+                               Tango::CmdArgType out, const char *in_desc,
+                               const char *out_desc)
+    : Tango::Command(name, in, out, in_desc, out_desc)
 {
 }
 
@@ -1183,39 +1208,42 @@ bool IODoubleString::is_allowed(Tango::DeviceImpl *device, TANGO_UNUSED(const CO
 // command allowed only if the device is on
 //
 
-	if (device->get_state() == Tango::ON)
-		return(true);
-	else
-		return(false);
+    if (device->get_state() == Tango::ON)
+        return (true);
+    else
+        return (false);
 }
 
 
 CORBA::Any *IODoubleString::execute(TANGO_UNUSED(Tango::DeviceImpl *device),const CORBA::Any &in_any)
 {
-  try {
-    const Tango::DevVarDoubleStringArray *theReceived;
-    Tango::DevVarDoubleStringArray *theReturned = new Tango::DevVarDoubleStringArray();
-    unsigned int i;
-
-    extract(in_any,theReceived);
-    ((*theReturned).dvalue).length(((*theReceived).dvalue).length());
-    for (i=0; i<((*theReceived).dvalue).length(); i++) {
-      cout << "[IODoubleString::execute] received number " << (*theReceived).dvalue[i] << endl;
-      (*theReturned).dvalue[i] = (*theReceived).dvalue[i] * 2;
-      cout << "[IODoubleString::execute] return number " << (*theReturned).dvalue[i] << endl;
-    }
-    ((*theReturned).svalue).length(((*theReceived).svalue).length());
-    for (i=0; i<((*theReceived).svalue).length(); i++) {
-      cout << "[IODoubleString::execute] received string " << (*theReceived).svalue[i].in() << endl;
-      (*theReturned).svalue[i] = (*theReceived).svalue[i];
-      cout << "[IODoubleString::execute] return string " << (*theReturned).svalue[i].in() << endl;
-    }
-    return insert(theReturned);
-  }
-  catch (CORBA::Exception &e)
+    try
     {
-      Tango::Except::print_exception(e);
-      throw ;
+        const Tango::DevVarDoubleStringArray *theReceived;
+        Tango::DevVarDoubleStringArray *theReturned = new Tango::DevVarDoubleStringArray();
+        unsigned int i;
+
+        extract(in_any, theReceived);
+        ((*theReturned).dvalue).length(((*theReceived).dvalue).length());
+        for (i = 0; i < ((*theReceived).dvalue).length(); i++)
+        {
+            cout << "[IODoubleString::execute] received number " << (*theReceived).dvalue[i] << endl;
+            (*theReturned).dvalue[i] = (*theReceived).dvalue[i] * 2;
+            cout << "[IODoubleString::execute] return number " << (*theReturned).dvalue[i] << endl;
+        }
+        ((*theReturned).svalue).length(((*theReceived).svalue).length());
+        for (i = 0; i < ((*theReceived).svalue).length(); i++)
+        {
+            cout << "[IODoubleString::execute] received string " << (*theReceived).svalue[i].in() << endl;
+            (*theReturned).svalue[i] = (*theReceived).svalue[i];
+            cout << "[IODoubleString::execute] return string " << (*theReturned).svalue[i].in() << endl;
+        }
+        return insert(theReturned);
+    }
+    catch (CORBA::Exception &e)
+    {
+        Tango::Except::print_exception(e);
+        throw;
     }
 }
 
@@ -1293,10 +1321,10 @@ CORBA::Any *IOBooleanArray::execute(TANGO_UNUSED(Tango::DeviceImpl *device),cons
 //
 //-----------------------------------------------------------------------------
 
-OLong::OLong(const char *name,Tango::CmdArgType in,
-		   Tango::CmdArgType out,const char *in_desc,
-		   const char *out_desc)
-:Tango::Command(name,in,out,in_desc,out_desc)
+OLong::OLong(const char *name, Tango::CmdArgType in,
+             Tango::CmdArgType out, const char *in_desc,
+             const char *out_desc)
+    : Tango::Command(name, in, out, in_desc, out_desc)
 {
 }
 
@@ -1308,25 +1336,26 @@ bool OLong::is_allowed(Tango::DeviceImpl *device, TANGO_UNUSED(const CORBA::Any 
 // command allowed only if the device is on
 //
 
-	if (device->get_state() == Tango::ON)
-		return(true);
-	else
-		return(false);
+    if (device->get_state() == Tango::ON)
+        return (true);
+    else
+        return (false);
 }
 
 
 CORBA::Any *OLong::execute(Tango::DeviceImpl *device,TANGO_UNUSED(const CORBA::Any &in_any))
 {
-  try {
-    long theNumber = 22;
-    cout << "[OLong::execute] return number " << theNumber << endl;
-    DEV_DEBUG_STREAM(device) << "[OLong::execute] return number " << theNumber << endl;
-    return insert(theNumber);
-  }
-  catch (CORBA::Exception &e)
+    try
     {
-      Tango::Except::print_exception(e);
-      throw ;
+        long theNumber = 22;
+        cout << "[OLong::execute] return number " << theNumber << endl;
+        DEV_DEBUG_STREAM(device) << "[OLong::execute] return number " << theNumber << endl;
+        return insert(theNumber);
+    }
+    catch (CORBA::Exception &e)
+    {
+        Tango::Except::print_exception(e);
+        throw;
     }
 }
 
@@ -1346,10 +1375,10 @@ CORBA::Any *OLong::execute(Tango::DeviceImpl *device,TANGO_UNUSED(const CORBA::A
 //
 //-----------------------------------------------------------------------------
 
-OULong::OULong(const char *name,Tango::CmdArgType in,
-		   Tango::CmdArgType out,const char *in_desc,
-		   const char *out_desc)
-:Tango::Command(name,in,out,in_desc,out_desc)
+OULong::OULong(const char *name, Tango::CmdArgType in,
+               Tango::CmdArgType out, const char *in_desc,
+               const char *out_desc)
+    : Tango::Command(name, in, out, in_desc, out_desc)
 {
 }
 
@@ -1361,24 +1390,25 @@ bool OULong::is_allowed(Tango::DeviceImpl *device, TANGO_UNUSED(const CORBA::Any
 // command allowed only if the device is on
 //
 
-	if (device->get_state() == Tango::ON)
-		return(true);
-	else
-		return(false);
+    if (device->get_state() == Tango::ON)
+        return (true);
+    else
+        return (false);
 }
 
 
 CORBA::Any *OULong::execute(TANGO_UNUSED(Tango::DeviceImpl *device),TANGO_UNUSED(const CORBA::Any &in_any))
 {
-  try {
-    unsigned long theNumber = 333;
-    cout << "[OULong::execute] return number " << theNumber << endl;
-    return insert(theNumber);
-  }
-  catch (CORBA::Exception &e)
+    try
     {
-      Tango::Except::print_exception(e);
-      throw ;
+        unsigned long theNumber = 333;
+        cout << "[OULong::execute] return number " << theNumber << endl;
+        return insert(theNumber);
+    }
+    catch (CORBA::Exception &e)
+    {
+        Tango::Except::print_exception(e);
+        throw;
     }
 }
 
@@ -1398,10 +1428,10 @@ CORBA::Any *OULong::execute(TANGO_UNUSED(Tango::DeviceImpl *device),TANGO_UNUSED
 //
 //-----------------------------------------------------------------------------
 
-OLongArray::OLongArray(const char *name,Tango::CmdArgType in,
-		   Tango::CmdArgType out,const char *in_desc,
-		   const char *out_desc)
-:Tango::Command(name,in,out,in_desc,out_desc)
+OLongArray::OLongArray(const char *name, Tango::CmdArgType in,
+                       Tango::CmdArgType out, const char *in_desc,
+                       const char *out_desc)
+    : Tango::Command(name, in, out, in_desc, out_desc)
 {
 }
 
@@ -1413,28 +1443,30 @@ bool OLongArray::is_allowed(Tango::DeviceImpl *device, TANGO_UNUSED(const CORBA:
 // command allowed only if the device is on
 //
 
-	if (device->get_state() == Tango::ON)
-		return(true);
-	else
-		return(false);
+    if (device->get_state() == Tango::ON)
+        return (true);
+    else
+        return (false);
 }
 
 
 CORBA::Any *OLongArray::execute(TANGO_UNUSED(Tango::DeviceImpl *device),TANGO_UNUSED(const CORBA::Any &in_any))
 {
-  try {
-    Tango::DevVarLongArray *theReturnedArray = new Tango::DevVarLongArray();
-    theReturnedArray->length(4);
-    for (int i=0; i<4; i++) {
-      (*theReturnedArray)[i] = 555 + i;
-      cout << "[OLongArray::execute] return number " << (*theReturnedArray)[i] << endl;
-    }
-    return insert(theReturnedArray);
-  }
-  catch (CORBA::Exception &e)
+    try
     {
-      Tango::Except::print_exception(e);
-      throw ;
+        Tango::DevVarLongArray *theReturnedArray = new Tango::DevVarLongArray();
+        theReturnedArray->length(4);
+        for (int i = 0; i < 4; i++)
+        {
+            (*theReturnedArray)[i] = 555 + i;
+            cout << "[OLongArray::execute] return number " << (*theReturnedArray)[i] << endl;
+        }
+        return insert(theReturnedArray);
+    }
+    catch (CORBA::Exception &e)
+    {
+        Tango::Except::print_exception(e);
+        throw;
     }
 }
 
@@ -1454,10 +1486,10 @@ CORBA::Any *OLongArray::execute(TANGO_UNUSED(Tango::DeviceImpl *device),TANGO_UN
 //
 //-----------------------------------------------------------------------------
 
-OULongArray::OULongArray(const char *name,Tango::CmdArgType in,
-		   Tango::CmdArgType out,const char *in_desc,
-		   const char *out_desc)
-:Tango::Command(name,in,out,in_desc,out_desc)
+OULongArray::OULongArray(const char *name, Tango::CmdArgType in,
+                         Tango::CmdArgType out, const char *in_desc,
+                         const char *out_desc)
+    : Tango::Command(name, in, out, in_desc, out_desc)
 {
 }
 
@@ -1469,28 +1501,30 @@ bool OULongArray::is_allowed(Tango::DeviceImpl *device, TANGO_UNUSED(const CORBA
 // command allowed only if the device is on
 //
 
-	if (device->get_state() == Tango::ON)
-		return(true);
-	else
-		return(false);
+    if (device->get_state() == Tango::ON)
+        return (true);
+    else
+        return (false);
 }
 
 
 CORBA::Any *OULongArray::execute(TANGO_UNUSED(Tango::DeviceImpl *device),TANGO_UNUSED(const CORBA::Any &in_any))
 {
-  try {
-    Tango::DevVarULongArray *theReturnedArray = new Tango::DevVarULongArray();
-    theReturnedArray->length(3);
-    for (int i=0; i<3; i++) {
-      (*theReturnedArray)[i] = 777 + i;
-      cout << "[OULongArray::execute] return number " << (*theReturnedArray)[i] << endl;
-    }
-    return insert(theReturnedArray);
-  }
-  catch (CORBA::Exception &e)
+    try
     {
-      Tango::Except::print_exception(e);
-      throw ;
+        Tango::DevVarULongArray *theReturnedArray = new Tango::DevVarULongArray();
+        theReturnedArray->length(3);
+        for (int i = 0; i < 3; i++)
+        {
+            (*theReturnedArray)[i] = 777 + i;
+            cout << "[OULongArray::execute] return number " << (*theReturnedArray)[i] << endl;
+        }
+        return insert(theReturnedArray);
+    }
+    catch (CORBA::Exception &e)
+    {
+        Tango::Except::print_exception(e);
+        throw;
     }
 }
 
@@ -1510,10 +1544,10 @@ CORBA::Any *OULongArray::execute(TANGO_UNUSED(Tango::DeviceImpl *device),TANGO_U
 //
 //-----------------------------------------------------------------------------
 
-OLongString::OLongString(const char *name,Tango::CmdArgType in,
-		   Tango::CmdArgType out,const char *in_desc,
-		   const char *out_desc)
-:Tango::Command(name,in,out,in_desc,out_desc)
+OLongString::OLongString(const char *name, Tango::CmdArgType in,
+                         Tango::CmdArgType out, const char *in_desc,
+                         const char *out_desc)
+    : Tango::Command(name, in, out, in_desc, out_desc)
 {
 }
 
@@ -1525,35 +1559,38 @@ bool OLongString::is_allowed(Tango::DeviceImpl *device, TANGO_UNUSED(const CORBA
 // command allowed only if the device is on
 //
 
-	if (device->get_state() == Tango::ON)
-		return(true);
-	else
-		return(false);
+    if (device->get_state() == Tango::ON)
+        return (true);
+    else
+        return (false);
 }
 
 
 CORBA::Any *OLongString::execute(TANGO_UNUSED(Tango::DeviceImpl *device),TANGO_UNUSED(const CORBA::Any &in_any))
 {
-  try {
-    Tango::DevVarLongStringArray *theReturned = new Tango::DevVarLongStringArray();
-    int i;
-
-    ((*theReturned).lvalue).length(6);
-    for (i=0; i<6; i++) {
-      (*theReturned).lvalue[i] = 999 + i;
-      cout << "[OLongString::execute] return number " << (*theReturned).lvalue[i] << endl;
-    }
-    ((*theReturned).svalue).length(1);
-    for (i=0; i<1; i++) {
-      (*theReturned).svalue[i] = Tango::string_dup("Hola todos");
-      cout << "[OLongString::execute] return string " << (*theReturned).svalue[i].in() << endl;
-    }
-    return insert(theReturned);
-  }
-  catch (CORBA::Exception &e)
+    try
     {
-      Tango::Except::print_exception(e);
-      throw ;
+        Tango::DevVarLongStringArray *theReturned = new Tango::DevVarLongStringArray();
+        int i;
+
+        ((*theReturned).lvalue).length(6);
+        for (i = 0; i < 6; i++)
+        {
+            (*theReturned).lvalue[i] = 999 + i;
+            cout << "[OLongString::execute] return number " << (*theReturned).lvalue[i] << endl;
+        }
+        ((*theReturned).svalue).length(1);
+        for (i = 0; i < 1; i++)
+        {
+            (*theReturned).svalue[i] = Tango::string_dup("Hola todos");
+            cout << "[OLongString::execute] return string " << (*theReturned).svalue[i].in() << endl;
+        }
+        return insert(theReturned);
+    }
+    catch (CORBA::Exception &e)
+    {
+        Tango::Except::print_exception(e);
+        throw;
     }
 }
 
@@ -1573,10 +1610,10 @@ CORBA::Any *OLongString::execute(TANGO_UNUSED(Tango::DeviceImpl *device),TANGO_U
 //-----------------------------------------------------------------------------
 
 #ifndef COMPAT
-IOEncoded::IOEncoded(const char *name,Tango::CmdArgType in,
-		   Tango::CmdArgType out,const char *in_desc,
-		   const char *out_desc)
-:Tango::Command(name,in,out,in_desc,out_desc)
+IOEncoded::IOEncoded(const char *name, Tango::CmdArgType in,
+                     Tango::CmdArgType out, const char *in_desc,
+                     const char *out_desc)
+    : Tango::Command(name, in, out, in_desc, out_desc)
 {
 }
 
@@ -1588,33 +1625,35 @@ bool IOEncoded::is_allowed(Tango::DeviceImpl *device, TANGO_UNUSED(const CORBA::
 // command allowed only if the device is on
 //
 
-	if (device->get_state() == Tango::ON)
-		return(true);
-	else
-		return(false);
+    if (device->get_state() == Tango::ON)
+        return (true);
+    else
+        return (false);
 }
 
 
 CORBA::Any *IOEncoded::execute(TANGO_UNUSED(Tango::DeviceImpl *device),const CORBA::Any &in_any)
 {
-  try {
-    const Tango::DevEncoded *the_enc;
-    extract(in_any,the_enc);
-    Tango::DevEncoded *theReturned_enc = new Tango::DevEncoded();
-    theReturned_enc->encoded_data.length(the_enc->encoded_data.length());
-    cout << "[IOEncoded::execute] received string " << the_enc->encoded_format << endl;
-    for (unsigned int i=0; i<the_enc->encoded_data.length(); i++) {
-      cout << "[IOEncoded::execute] received number " << (int)the_enc->encoded_data[i] << endl;
-      theReturned_enc->encoded_data[i] = the_enc->encoded_data[i] * 2;
-      cout << "[IOEncoded::execute] returned number " << (int)theReturned_enc->encoded_data[i] << endl;
-    }
-    theReturned_enc->encoded_format = CORBA::string_dup("Returned string");
-    return insert(theReturned_enc);
-  }
-  catch (CORBA::Exception &e)
+    try
     {
-      Tango::Except::print_exception(e);
-      throw ;
+        const Tango::DevEncoded *the_enc;
+        extract(in_any, the_enc);
+        Tango::DevEncoded *theReturned_enc = new Tango::DevEncoded();
+        theReturned_enc->encoded_data.length(the_enc->encoded_data.length());
+        cout << "[IOEncoded::execute] received string " << the_enc->encoded_format << endl;
+        for (unsigned int i = 0; i < the_enc->encoded_data.length(); i++)
+        {
+            cout << "[IOEncoded::execute] received number " << (int) the_enc->encoded_data[i] << endl;
+            theReturned_enc->encoded_data[i] = the_enc->encoded_data[i] * 2;
+            cout << "[IOEncoded::execute] returned number " << (int) theReturned_enc->encoded_data[i] << endl;
+        }
+        theReturned_enc->encoded_format = CORBA::string_dup("Returned string");
+        return insert(theReturned_enc);
+    }
+    catch (CORBA::Exception &e)
+    {
+        Tango::Except::print_exception(e);
+        throw;
     }
 }
 
@@ -1633,10 +1672,10 @@ CORBA::Any *IOEncoded::execute(TANGO_UNUSED(Tango::DeviceImpl *device),const COR
 //
 //-----------------------------------------------------------------------------
 
-OEncoded::OEncoded(const char *name,Tango::CmdArgType in,
-		   Tango::CmdArgType out,const char *in_desc,
-		   const char *out_desc)
-:Tango::Command(name,in,out,in_desc,out_desc)
+OEncoded::OEncoded(const char *name, Tango::CmdArgType in,
+                   Tango::CmdArgType out, const char *in_desc,
+                   const char *out_desc)
+    : Tango::Command(name, in, out, in_desc, out_desc)
 {
     encoded_cmd_ctr = 0;
 }
@@ -1649,41 +1688,68 @@ bool OEncoded::is_allowed(Tango::DeviceImpl *device, TANGO_UNUSED(const CORBA::A
 // command allowed only if the device is on
 //
 
-	if (device->get_state() == Tango::ON)
-		return(true);
-	else
-		return(false);
+    if (device->get_state() == Tango::ON)
+        return (true);
+    else
+        return (false);
 }
 
 
 CORBA::Any *OEncoded::execute(TANGO_UNUSED(Tango::DeviceImpl *device),TANGO_UNUSED(const CORBA::Any &in_any))
 {
-  try {
-    Tango::DevEncoded *theReturned = new Tango::DevEncoded();
+    try
+    {
+        Tango::DevEncoded *theReturned = new Tango::DevEncoded();
 
-    encoded_cmd_ctr++;
-    if ((encoded_cmd_ctr % 2) == 0)
-    {
-        theReturned->encoded_format = CORBA::string_dup("Odd - OEncoded format");
-        theReturned->encoded_data.length(2);
-        theReturned->encoded_data[0] = 11;
-        theReturned->encoded_data[1] = 21;
+        encoded_cmd_ctr++;
+        if ((encoded_cmd_ctr % 2) == 0)
+        {
+            theReturned->encoded_format = CORBA::string_dup("Odd - OEncoded format");
+            theReturned->encoded_data.length(2);
+            theReturned->encoded_data[0] = 11;
+            theReturned->encoded_data[1] = 21;
+        }
+        else
+        {
+            theReturned->encoded_format = CORBA::string_dup("Even - OEncoded format");
+            theReturned->encoded_data.length(4);
+            theReturned->encoded_data[0] = 10;
+            theReturned->encoded_data[1] = 20;
+            theReturned->encoded_data[2] = 30;
+            theReturned->encoded_data[3] = 40;
+        }
+        return insert(theReturned);
     }
-    else
+    catch (CORBA::Exception &e)
     {
-        theReturned->encoded_format = CORBA::string_dup("Even - OEncoded format");
-        theReturned->encoded_data.length(4);
-        theReturned->encoded_data[0] = 10;
-        theReturned->encoded_data[1] = 20;
-        theReturned->encoded_data[2] = 30;
-        theReturned->encoded_data[3] = 40;
-    }
-    return insert(theReturned);
-  }
-  catch (CORBA::Exception &e)
-    {
-      Tango::Except::print_exception(e);
-      throw ;
+        Tango::Except::print_exception(e);
+        throw;
     }
 }
 #endif
+
+IOPipeBlob::IOPipeBlob()
+    :
+    Command("IOPipeBlob",
+            Tango::CmdArgType::DEV_PIPE_BLOB,
+            Tango::CmdArgType::DEV_PIPE_BLOB,
+            "DevPipeBlob",
+            "DevPipeBlob")
+{}
+bool IOPipeBlob::is_allowed(Tango::DeviceImpl *dev, const CORBA::Any &in_any)
+{
+    return true;
+}
+CORBA::Any *IOPipeBlob::execute(Tango::DeviceImpl *dev, const CORBA::Any &in_any)
+{
+    Tango::DevPipeBlob *in_blob = nullptr;
+
+    extract(in_any, in_blob);
+
+    Tango::DevPipeBlob *out_blob = new Tango::DevPipeBlob{};
+
+    out_blob->name = in_blob->name;
+    out_blob->blob_data = in_blob->blob_data;
+
+    return insert(out_blob);
+}

--- a/cpp_test_suite/cpp_test_ds/TypeCmds.h
+++ b/cpp_test_suite/cpp_test_ds/TypeCmds.h
@@ -313,3 +313,12 @@ public:
 
 	Tango::DevLong encoded_cmd_ctr;
 };
+
+struct IOPipeBlob: public Tango::Command
+{
+    IOPipeBlob();
+    virtual ~IOPipeBlob()
+    {}
+    bool is_allowed(Tango::DeviceImpl *dev, const CORBA::Any &in_any) override;
+    CORBA::Any *execute(Tango::DeviceImpl *dev, const CORBA::Any &in_any) override;
+};

--- a/cpp_test_suite/new_tests/cxx_cmd_query.cpp
+++ b/cpp_test_suite/new_tests/cxx_cmd_query.cpp
@@ -545,8 +545,16 @@ public:
             "Lg[0] = Tango lib release - Lg[1] = Device IDL release\n"
             "Lg[2] = Subscriber HWM - Lg[3] = Multicast rate\n"
             "Lg[4] = Multicast IVL - Lg[5] = ZMQ release");
-	}
+    }
 
+    void test_command_IOPipeBlob_query(void)
+    {
+        CommandInfo info;
+        TS_ASSERT_THROWS_NOTHING(info = device1->command_query("IOPipeBlob"));
+
+        TS_ASSERT_EQUALS(Tango::DEV_PIPE_BLOB, info.in_type);
+        TS_ASSERT_EQUALS(Tango::DEV_PIPE_BLOB, info.out_type);
+    }
 };
 #undef cout
 #endif // CmdQueryTestSuite_h

--- a/cppapi/client/DeviceData.h
+++ b/cppapi/client/DeviceData.h
@@ -38,6 +38,7 @@
  * 																						*
  ***************************************************************************************/
 
+#include "DevicePipe.h"
 
 /**
  * Fundamental type for sending and receiving data from device commands

--- a/cppapi/client/DeviceProxy.h
+++ b/cppapi/client/DeviceProxy.h
@@ -96,6 +96,7 @@ private :
 
 	friend class AttributeProxy;
 
+DevPipeData createDevPipeData(DevicePipe &dev_pipe) const;
 protected :
 /// @privatesection
 	virtual string get_corba_name(bool);
@@ -123,14 +124,15 @@ private:
     class DeviceProxyExt
     {
     public:
-        DeviceProxyExt() {};
+        DeviceProxyExt()
+        {};
 
         bool            nethost_alias;
         string          orig_tango_host;
     };
 
 #ifdef HAS_UNIQUE_PTR
-    unique_ptr<DeviceProxyExt>  ext_proxy;
+    unique_ptr<DeviceProxyExt> ext_proxy;
 #else
 	DeviceProxyExt		        *ext_proxy;		// Class extension
 #endif
@@ -482,7 +484,7 @@ public :
  * @throws NonSupportedFeature, ConnectionFailed, CommunicationFailed, DevFailed from device
  */
 	virtual vector<DeviceDataHistory> *command_history(const char *cmd_name,int depth)
-			{string str(cmd_name);return command_history(str,depth);}
+    {string str(cmd_name);return command_history(str,depth);}
 //@}
 
 /** @name Synchronous attribute related methods */
@@ -822,7 +824,7 @@ public :
  * @throws NonSupportedFeature, ConnectionFailed, CommunicationFailed, DevFailed from device
  */
 	virtual vector<DeviceAttributeHistory> *attribute_history(const char *att_name,int depth)
-			{string str(att_name);return attribute_history(str,depth);}
+    {string str(att_name);return attribute_history(str,depth);}
 //@}
 
 /** @name Pipe related methods */
@@ -1164,7 +1166,7 @@ public :
  * @return Pending asynchronous request number
  */
 	virtual long pending_asynch_call(asyn_req_type req)
-			{if (req == POLLING)return pasyn_ctr;
+    {if (req == POLLING)return pasyn_ctr;
 			else if (req==CALL_BACK) return pasyn_cb_ctr;
 			else return (pasyn_ctr + pasyn_cb_ctr);}
 //@}
@@ -1225,7 +1227,7 @@ public :
  * @return The command polling period
  */
 	virtual int get_command_poll_period(const char *cmd_name)
-			{string tmp(cmd_name);return get_command_poll_period(tmp);}
+    {string tmp(cmd_name);return get_command_poll_period(tmp);}
 /**
  * Get attribute polling period
  *
@@ -1244,7 +1246,7 @@ public :
  * @return The attribute polling period
  */
 	virtual int get_attribute_poll_period(const char *att_name)
-			{string tmp(att_name);return get_attribute_poll_period(tmp);}
+    {string tmp(att_name);return get_attribute_poll_period(tmp);}
 /**
  * Get polling status
  *

--- a/cppapi/server/command.cpp
+++ b/cppapi/server/command.cpp
@@ -295,6 +295,14 @@ namespace Tango {
             throw_bad_type("DevEncoded");
     }
 
+void Command::extract(const CORBA::Any &in, Tango::DevPipeBlob *&data)
+{
+    if ((in >>= data) == false)
+    {
+        throw_bad_type("DevPipeBlob");
+    }
+}
+
 //+----------------------------------------------------------------------------
 //
 // method : 		Command::insert()
@@ -663,6 +671,17 @@ namespace Tango {
 
         return out_any;
     }
+
+CORBA::Any *Command::insert(Tango::DevPipeBlob *data)
+{
+    CORBA::Any *out_any;
+    alloc_any(out_any);
+
+    (*out_any) <<= (*data);
+    delete data;
+
+    return out_any;
+}
 
 //+-------------------------------------------------------------------------
 //

--- a/cppapi/server/command.h
+++ b/cppapi/server/command.h
@@ -701,6 +701,16 @@ public:
  * <b>DevFailed</b> exception specification
  */
 	void extract(const CORBA::Any &in,const Tango::DevEncoded *&data);
+
+    /**
+     * Extracts DevPipeBlob from a CORBA Any object
+     *
+     * @param in the CORBA Any object
+     * @param data Reference to the extracted DevPipeBlob object
+     * @exception DevFailed If the Any object does not contains a data of the
+     * waited type.
+     */
+    void extract(const CORBA::Any &in, DevPipeBlob *&data);
 //@}
 
 /**@name Insert methods.
@@ -1193,6 +1203,14 @@ public:
  * <b>DevFailed</b> exception specification
  */
 	CORBA::Any *insert(Tango::DevEncoded *data);
+
+    /**
+     * Inserts data into a new CORBA::Any. data is being deleted
+     *
+     * @param data data to wrap up in CORBA::Any
+     * @return data wrapped up in a new CORBA::Any
+     */
+    CORBA::Any *insert(DevPipeBlob *data);
 //@}
 
 protected:


### PR DESCRIPTION
This PR backports #378 into tango-9-lts branch. Client may now use PipeBlob as command argument and server may return PipeBlob as command result.