### PR TITLE
Attempt to fix appveyor download links

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -122,14 +122,15 @@ init:
   - if %ARCH%==win32-msvc10 appveyor DownloadFile https://github.com/tango-controls/omniorb-windows-ci/releases/download/4.2.1.2/omniorb-4.2.1_%ARCH%_py33.zip
   - if %ARCH%==x64-msvc10 appveyor DownloadFile https://github.com/tango-controls/omniorb-windows-ci/releases/download/4.2.1.2/omniorb-4.2.1_%ARCH%_py33.zip
   - if %ARCH%==x64-msvc12 appveyor DownloadFile https://github.com/tango-controls/omniorb-windows-ci/releases/download/4.2.1.2/omniorb-4.2.1_%ARCH%_py33.zip
-  - if %ARCH%==x64-msvc14 appveyor DownloadFile https://github.com/tango-controls/omniorb-windows-ci/releases/download/4.2.1.2/omniorb-4.2.1_%ARCH%_py35.zip
+  - if %ARCH%==x64-msvc14 appveyor DownloadFile https://github.com/tango-controls/omniorb-windows-ci/releases/download/4.2.1.2/omniorb-4.2.1_%ARCH%_py36.zip
   - cmd: if %ARCH%==win32-msvc9 7z -y x omniorb-4.2.1_%ARCH%_py27.zip -oC:\projects\omniorb\
   - cmd: if %ARCH%==x64-msvc9 7z -y x omniorb-4.2.1_%ARCH%_py27.zip -oC:\projects\omniorb\
   - cmd: if %ARCH%==win32-msvc10 7z -y x omniorb-4.2.1_%ARCH%_py33.zip -oC:\projects\omniorb\
   - cmd: if %ARCH%==x64-msvc10 7z -y x omniorb-4.2.1_%ARCH%_py33.zip -oC:\projects\omniorb\
   - cmd: if %ARCH%==x64-msvc12 7z -y x omniorb-4.2.1_%ARCH%_py33.zip -oC:\projects\omniorb\
-  - cmd: if %ARCH%==x64-msvc14 7z -y x omniorb-4.2.1_%ARCH%_py35.zip -oC:\projects\omniorb\
+  - cmd: if %ARCH%==x64-msvc14 7z -y x omniorb-4.2.1_%ARCH%_py36.zip -oC:\projects\omniorb\
   # Lines added just for tests
+  - cmd: if %ARCH%==x64-msvc14 set Path=C:\Python36-x64;%Path%
   - cmd: echo %Path%
   - cmd: C:\projects\omniorb\bin\x86_win32\omniidl.exe -V
   #Pthread-Win32

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -110,35 +110,30 @@ init:
   - cmd: cd "C:\projects\"
   - cmd: md zeromq
   - cmd: cd "C:\projects\"
-  - if %ARCH%==win32-msvc9 appveyor DownloadFile https://ci.appveyor.com/api/buildjobs/kif9t1ni9dorv7ai/artifacts/zmq-4.0.5_%ARCH%.zip
-  - if %ARCH%==x64-msvc9 appveyor DownloadFile https://ci.appveyor.com/api/buildjobs/v08rh5ojx3uljbm0/artifacts/zmq-4.0.5_%ARCH%.zip
-  - if %ARCH%==win32-msvc10 appveyor DownloadFile https://ci.appveyor.com/api/buildjobs/bfw1w51dmwb4t1s8/artifacts/zmq-4.0.5_%ARCH%.zip
-  - if %ARCH%==x64-msvc10 appveyor DownloadFile https://ci.appveyor.com/api/buildjobs/dv6koti648n78wru/artifacts/zmq-4.0.5_%ARCH%.zip
-  - if %ARCH%==x64-msvc12 appveyor DownloadFile https://ci.appveyor.com/api/buildjobs/92i5i0466vrsf8uf/artifacts/zmq-4.0.5_%ARCH%.zip
-  - if %ARCH%==x64-msvc14 appveyor DownloadFile https://ci.appveyor.com/api/buildjobs/jlsd4d38c425kumq/artifacts/zmq-4.0.5_%ARCH%.zip
+  - appveyor DownloadFile https://github.com/tango-controls/zmq-windows-ci/releases/download/4.0.5/zmq-4.0.5_%ARCH%.zip
   - cmd: 7z -y x zmq-4.0.5_%ARCH%.zip -oC:\projects\zeromq\
   #- cmd: move C:\projects\zeromq\lib\Release\libzmq*mt-4*.lib C:\projects\zeromq\lib\Release\libzmq.lib
   # OmniOrb
   - cmd: cd "C:\projects\"
   - cmd: md omniorb
   - cmd: cd "C:\projects\"
-  - if %ARCH%==win32-msvc9 appveyor DownloadFile https://ci.appveyor.com/api/buildjobs/b3j87c59nps33ga8/artifacts/omniorb-4.2.1_%ARCH%.zip
-  - if %ARCH%==x64-msvc9 appveyor DownloadFile https://ci.appveyor.com/api/buildjobs/t0c9a59fr0ixb6to/artifacts/omniorb-4.2.1_%ARCH%.zip
-  - if %ARCH%==win32-msvc10 appveyor DownloadFile https://ci.appveyor.com/api/buildjobs/0ywhsy2wnmfw99ia/artifacts/omniorb-4.2.1_%ARCH%.zip
-  - if %ARCH%==x64-msvc10 appveyor DownloadFile https://ci.appveyor.com/api/buildjobs/x2sr2c1i0f7hy1cg/artifacts/omniorb-4.2.1_%ARCH%.zip
-  - if %ARCH%==x64-msvc12 appveyor DownloadFile https://ci.appveyor.com/api/buildjobs/2e8wjs2aalg6cryl/artifacts/omniorb-4.2.1_%ARCH%.zip
-  - if %ARCH%==x64-msvc14 appveyor DownloadFile https://ci.appveyor.com/api/buildjobs/ry9yevfyjddf6j2e/artifacts/omniorb-4.2.1_%ARCH%.zip
-  - cmd: 7z -y x omniorb-4.2.1_%ARCH%.zip -oC:\projects\omniorb\
+  - if %ARCH%==win32-msvc9 appveyor DownloadFile https://github.com/tango-controls/omniorb-windows-ci/releases/download/4.2.1.2/omniorb-4.2.1_%ARCH%_py27.zip
+  - if %ARCH%==x64-msvc9 appveyor DownloadFile https://github.com/tango-controls/omniorb-windows-ci/releases/download/4.2.1.2/omniorb-4.2.1_%ARCH%_py27.zip
+  - if %ARCH%==win32-msvc10 appveyor DownloadFile https://github.com/tango-controls/omniorb-windows-ci/releases/download/4.2.1.2/omniorb-4.2.1_%ARCH%_py33.zip
+  - if %ARCH%==x64-msvc10 appveyor DownloadFile https://github.com/tango-controls/omniorb-windows-ci/releases/download/4.2.1.2/omniorb-4.2.1_%ARCH%_py33.zip
+  - if %ARCH%==x64-msvc12 appveyor DownloadFile https://github.com/tango-controls/omniorb-windows-ci/releases/download/4.2.1.2/omniorb-4.2.1_%ARCH%_py33.zip
+  - if %ARCH%==x64-msvc14 appveyor DownloadFile https://github.com/tango-controls/omniorb-windows-ci/releases/download/4.2.1.2/omniorb-4.2.1_%ARCH%_py36.zip
+  - cmd: if %ARCH%==win32-msvc9 7z -y x omniorb-4.2.1_%ARCH%_py27.zip -oC:\projects\omniorb\
+  - cmd: if %ARCH%==x64-msvc9 7z -y x omniorb-4.2.1_%ARCH%_py27.zip -oC:\projects\omniorb\
+  - cmd: if %ARCH%==win32-msvc10 7z -y x omniorb-4.2.1_%ARCH%_py33.zip -oC:\projects\omniorb\
+  - cmd: if %ARCH%==x64-msvc10 7z -y x omniorb-4.2.1_%ARCH%_py33.zip -oC:\projects\omniorb\
+  - cmd: if %ARCH%==x64-msvc12 7z -y x omniorb-4.2.1_%ARCH%_py33.zip -oC:\projects\omniorb\
+  - cmd: if %ARCH%==x64-msvc14 7z -y x omniorb-4.2.1_%ARCH%_py36.zip -oC:\projects\omniorb\
   #Pthread-Win32
   - cmd: cd "C:\projects\"
   - cmd: md pthreads-win32
   - cmd: cd "C:\projects\"
-  - if %ARCH%==win32-msvc9 appveyor DownloadFile https://ci.appveyor.com/api/buildjobs/7aj99tp6e6fvron0/artifacts/pthreads-win32-2.9.1_win32-msvc9.zip
-  - if %ARCH%==x64-msvc9 appveyor DownloadFile https://ci.appveyor.com/api/buildjobs/pgefsid2t7ma16j6/artifacts/pthreads-win32-2.9.1_x64-msvc9.zip
-  - if %ARCH%==win32-msvc10 appveyor DownloadFile https://ci.appveyor.com/api/buildjobs/3hhh3rfhif1lgw0f/artifacts/pthreads-win32-2.9.1_win32-msvc10.zip
-  - if %ARCH%==x64-msvc10 appveyor DownloadFile https://ci.appveyor.com/api/buildjobs/g6g73i5paldagoc4/artifacts/pthreads-win32-2.9.1_x64-msvc10.zip
-  - if %ARCH%==x64-msvc12 appveyor DownloadFile https://ci.appveyor.com/api/buildjobs/w4vojpste8j6l823/artifacts/pthreads-win32-2.9.1_x64-msvc12.zip
-  - if %ARCH%==x64-msvc14 appveyor DownloadFile https://ci.appveyor.com/api/buildjobs/6tson2rjxm3vgwra/artifacts/pthreads-win32-2.9.1_x64-msvc14.zip
+  - appveyor DownloadFile https://github.com/tango-controls/Pthread_WIN32/releases/download/2.9.1/pthreads-win32-2.9.1_%ARCH%.zip
   - cmd: 7z -y x pthreads-win32-2.9.1_%ARCH%.zip -oC:\projects\pthreads-win32\
   #VS2008 patch
   - cmd: cd "C:\projects\"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,78 +7,78 @@ image: Visual Studio 2015
 
 environment:
   matrix:
-#    - platform: win32
-#      ARCH: win32-msvc9
-#      configuration: Release
-#      CMAKE_GENERATOR: "Visual Studio 9 2008"
-#      MSVCVERSION: v90
-#      MSVCYEAR: "vs2008"
-#      MSVCABR: "9"
-#      VC_VER: 9.0
-#      PYTHONPATHOMNI: "/cygdrive/c/Python27/python"
-#      BOOST_ROOT: C:\Libraries\boost_1_63_0
-#      ZMQ_BASE: C:\projects\libzmq
-#      IDL_BASE: C:\projects\tangoidl
-#      IDL_BIN: C:\Program Files (x86)\tangoidl
-#      OMNI_BASE: C:\projects\omniORB-4.2.1
-#    - platform: x64
-#      ARCH: x64-msvc9
-#      configuration: Release
-#      CMAKE_GENERATOR: "Visual Studio 9 2008 Win64"
-#      MSVCVERSION: v90
-#      MSVCYEAR: "vs2008"
-#      MSVCABR: "9"
-#      VC_VER: 9.0
-#      PYTHONPATHOMNI: "/cygdrive/c/Python27/python"
-#      BOOST_ROOT: C:\Libraries\boost_1_63_0
-#      ZMQ_BASE: C:\projects\libzmq
-#      IDL_BASE: C:\projects\tangoidl
-#      IDL_BIN: C:\Program Files\tangoidl
-#      OMNI_BASE: C:\projects\omniORB-4.2.1
-#    - platform: win32
-#      ARCH: win32-msvc10
-#      configuration: Release
-#      CMAKE_GENERATOR: "Visual Studio 10 2010"
-#      MSVCVERSION: v100
-#      MSVCYEAR: "vs2010"
-#      MSVCABR: "10"
-#      VC_VER: 10.0
-#      PYTHONPATH: c:\Python33\
-#      PYTHONPATHOMNI: "/cygdrive/c/Python33/python"
-#      BOOST_ROOT: C:\Libraries\boost_1_63_0
-#      ZMQ_BASE: C:\projects\libzmq
-#      IDL_BASE: C:\projects\tangoidl
-#      IDL_BIN: C:\Program Files (x86)\tangoidl
-#      OMNI_BASE: C:\projects\omniORB-4.2.1
-#    - platform: x64
-#      ARCH: x64-msvc10
-#      configuration: Release
-#      CMAKE_GENERATOR: "Visual Studio 10 2010 Win64"
-#      MSVCVERSION: v100
-#      MSVCYEAR: "vs2010"
-#      MSVCABR: "10"
-#      VC_VER: 10.0
-#      PYTHONPATH: c:\Python33-x64\
-#      PYTHONPATHOMNI: "/cygdrive/c/Python33-x64/python"
-#      BOOST_ROOT: C:\Libraries\boost_1_63_0
-#      ZMQ_BASE: C:\projects\libzmq
-#      IDL_BASE: C:\projects\tangoidl
-#      IDL_BIN: C:\Program Files\tangoidl
-#      OMNI_BASE: C:\projects\omniORB-4.2.1
-#    - platform: x64
-#      ARCH: x64-msvc12
-#      configuration: Release
-#      CMAKE_GENERATOR: "Visual Studio 12 2013 Win64"
-#      MSVCVERSION: v120
-#      MSVCYEAR: "vs2013"
-#      MSVCABR: "13"
-#      VC_VER: 13.0
-#      PYTHONPATHOMNI: "/cygdrive/c/Python33-x64/python"
-#      BOOST_ROOT: C:\Libraries\boost_1_63_0
-#      ZMQ_BASE: C:\projects\libzmq
-#      IDL_BASE: C:\projects\tangoidl
-#      IDL_BIN: C:\Program Files\tangoidl
-#      OMNI_BASE: C:\projects\omniORB-4.2.1
+    - platform: win32
+      ARCH: win32-msvc9
+      configuration: Release
+      CMAKE_GENERATOR: "Visual Studio 9 2008"
+      MSVCVERSION: v90
+      MSVCYEAR: "vs2008"
+      MSVCABR: "9"
+      VC_VER: 9.0
+      PYTHONPATHOMNI: "/cygdrive/c/Python27/python"
+      BOOST_ROOT: C:\Libraries\boost_1_63_0
+      ZMQ_BASE: C:\projects\libzmq
+      IDL_BASE: C:\projects\tangoidl
+      IDL_BIN: C:\Program Files (x86)\tangoidl
+      OMNI_BASE: C:\projects\omniORB-4.2.1
+    - platform: x64
+      ARCH: x64-msvc9
+      configuration: Release
+      CMAKE_GENERATOR: "Visual Studio 9 2008 Win64"
+      MSVCVERSION: v90
+      MSVCYEAR: "vs2008"
+      MSVCABR: "9"
+      VC_VER: 9.0
+      PYTHONPATHOMNI: "/cygdrive/c/Python27/python"
+      BOOST_ROOT: C:\Libraries\boost_1_63_0
+      ZMQ_BASE: C:\projects\libzmq
+      IDL_BASE: C:\projects\tangoidl
+      IDL_BIN: C:\Program Files\tangoidl
+      OMNI_BASE: C:\projects\omniORB-4.2.1
+    - platform: win32
+      ARCH: win32-msvc10
+      configuration: Release
+      CMAKE_GENERATOR: "Visual Studio 10 2010"
+      MSVCVERSION: v100
+      MSVCYEAR: "vs2010"
+      MSVCABR: "10"
+      VC_VER: 10.0
+      PYTHONPATH: c:\Python33\
+      PYTHONPATHOMNI: "/cygdrive/c/Python33/python"
+      BOOST_ROOT: C:\Libraries\boost_1_63_0
+      ZMQ_BASE: C:\projects\libzmq
+      IDL_BASE: C:\projects\tangoidl
+      IDL_BIN: C:\Program Files (x86)\tangoidl
+      OMNI_BASE: C:\projects\omniORB-4.2.1
+    - platform: x64
+      ARCH: x64-msvc10
+      configuration: Release
+      CMAKE_GENERATOR: "Visual Studio 10 2010 Win64"
+      MSVCVERSION: v100
+      MSVCYEAR: "vs2010"
+      MSVCABR: "10"
+      VC_VER: 10.0
+      PYTHONPATH: c:\Python33-x64\
+      PYTHONPATHOMNI: "/cygdrive/c/Python33-x64/python"
+      BOOST_ROOT: C:\Libraries\boost_1_63_0
+      ZMQ_BASE: C:\projects\libzmq
+      IDL_BASE: C:\projects\tangoidl
+      IDL_BIN: C:\Program Files\tangoidl
+      OMNI_BASE: C:\projects\omniORB-4.2.1
+    - platform: x64
+      ARCH: x64-msvc12
+      configuration: Release
+      CMAKE_GENERATOR: "Visual Studio 12 2013 Win64"
+      MSVCVERSION: v120
+      MSVCYEAR: "vs2013"
+      MSVCABR: "13"
+      VC_VER: 13.0
+      PYTHONPATHOMNI: "/cygdrive/c/Python33-x64/python"
+      BOOST_ROOT: C:\Libraries\boost_1_63_0
+      ZMQ_BASE: C:\projects\libzmq
+      IDL_BASE: C:\projects\tangoidl
+      IDL_BIN: C:\Program Files\tangoidl
+      OMNI_BASE: C:\projects\omniORB-4.2.1
     - platform: x64
       ARCH: x64-msvc14
       configuration: Release

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,78 +7,78 @@ image: Visual Studio 2015
 
 environment:
   matrix:
-    - platform: win32
-      ARCH: win32-msvc9
-      configuration: Release
-      CMAKE_GENERATOR: "Visual Studio 9 2008"
-      MSVCVERSION: v90
-      MSVCYEAR: "vs2008"
-      MSVCABR: "9"
-      VC_VER: 9.0
-      PYTHONPATHOMNI: "/cygdrive/c/Python27/python"
-      BOOST_ROOT: C:\Libraries\boost_1_63_0
-      ZMQ_BASE: C:\projects\libzmq
-      IDL_BASE: C:\projects\tangoidl
-      IDL_BIN: C:\Program Files (x86)\tangoidl
-      OMNI_BASE: C:\projects\omniORB-4.2.1
-    - platform: x64
-      ARCH: x64-msvc9
-      configuration: Release
-      CMAKE_GENERATOR: "Visual Studio 9 2008 Win64"
-      MSVCVERSION: v90
-      MSVCYEAR: "vs2008"
-      MSVCABR: "9"
-      VC_VER: 9.0
-      PYTHONPATHOMNI: "/cygdrive/c/Python27/python"
-      BOOST_ROOT: C:\Libraries\boost_1_63_0
-      ZMQ_BASE: C:\projects\libzmq
-      IDL_BASE: C:\projects\tangoidl
-      IDL_BIN: C:\Program Files\tangoidl
-      OMNI_BASE: C:\projects\omniORB-4.2.1
-    - platform: win32
-      ARCH: win32-msvc10
-      configuration: Release
-      CMAKE_GENERATOR: "Visual Studio 10 2010"
-      MSVCVERSION: v100
-      MSVCYEAR: "vs2010"
-      MSVCABR: "10"
-      VC_VER: 10.0
-      PYTHONPATH: c:\Python33\
-      PYTHONPATHOMNI: "/cygdrive/c/Python33/python"
-      BOOST_ROOT: C:\Libraries\boost_1_63_0
-      ZMQ_BASE: C:\projects\libzmq
-      IDL_BASE: C:\projects\tangoidl
-      IDL_BIN: C:\Program Files (x86)\tangoidl
-      OMNI_BASE: C:\projects\omniORB-4.2.1
-    - platform: x64
-      ARCH: x64-msvc10
-      configuration: Release
-      CMAKE_GENERATOR: "Visual Studio 10 2010 Win64"
-      MSVCVERSION: v100
-      MSVCYEAR: "vs2010"
-      MSVCABR: "10"
-      VC_VER: 10.0
-      PYTHONPATH: c:\Python33-x64\
-      PYTHONPATHOMNI: "/cygdrive/c/Python33-x64/python"
-      BOOST_ROOT: C:\Libraries\boost_1_63_0
-      ZMQ_BASE: C:\projects\libzmq
-      IDL_BASE: C:\projects\tangoidl
-      IDL_BIN: C:\Program Files\tangoidl
-      OMNI_BASE: C:\projects\omniORB-4.2.1
-    - platform: x64
-      ARCH: x64-msvc12
-      configuration: Release
-      CMAKE_GENERATOR: "Visual Studio 12 2013 Win64"
-      MSVCVERSION: v120
-      MSVCYEAR: "vs2013"
-      MSVCABR: "13"
-      VC_VER: 13.0
-      PYTHONPATHOMNI: "/cygdrive/c/Python33-x64/python"
-      BOOST_ROOT: C:\Libraries\boost_1_63_0
-      ZMQ_BASE: C:\projects\libzmq
-      IDL_BASE: C:\projects\tangoidl
-      IDL_BIN: C:\Program Files\tangoidl
-      OMNI_BASE: C:\projects\omniORB-4.2.1
+#    - platform: win32
+#      ARCH: win32-msvc9
+#      configuration: Release
+#      CMAKE_GENERATOR: "Visual Studio 9 2008"
+#      MSVCVERSION: v90
+#      MSVCYEAR: "vs2008"
+#      MSVCABR: "9"
+#      VC_VER: 9.0
+#      PYTHONPATHOMNI: "/cygdrive/c/Python27/python"
+#      BOOST_ROOT: C:\Libraries\boost_1_63_0
+#      ZMQ_BASE: C:\projects\libzmq
+#      IDL_BASE: C:\projects\tangoidl
+#      IDL_BIN: C:\Program Files (x86)\tangoidl
+#      OMNI_BASE: C:\projects\omniORB-4.2.1
+#    - platform: x64
+#      ARCH: x64-msvc9
+#      configuration: Release
+#      CMAKE_GENERATOR: "Visual Studio 9 2008 Win64"
+#      MSVCVERSION: v90
+#      MSVCYEAR: "vs2008"
+#      MSVCABR: "9"
+#      VC_VER: 9.0
+#      PYTHONPATHOMNI: "/cygdrive/c/Python27/python"
+#      BOOST_ROOT: C:\Libraries\boost_1_63_0
+#      ZMQ_BASE: C:\projects\libzmq
+#      IDL_BASE: C:\projects\tangoidl
+#      IDL_BIN: C:\Program Files\tangoidl
+#      OMNI_BASE: C:\projects\omniORB-4.2.1
+#    - platform: win32
+#      ARCH: win32-msvc10
+#      configuration: Release
+#      CMAKE_GENERATOR: "Visual Studio 10 2010"
+#      MSVCVERSION: v100
+#      MSVCYEAR: "vs2010"
+#      MSVCABR: "10"
+#      VC_VER: 10.0
+#      PYTHONPATH: c:\Python33\
+#      PYTHONPATHOMNI: "/cygdrive/c/Python33/python"
+#      BOOST_ROOT: C:\Libraries\boost_1_63_0
+#      ZMQ_BASE: C:\projects\libzmq
+#      IDL_BASE: C:\projects\tangoidl
+#      IDL_BIN: C:\Program Files (x86)\tangoidl
+#      OMNI_BASE: C:\projects\omniORB-4.2.1
+#    - platform: x64
+#      ARCH: x64-msvc10
+#      configuration: Release
+#      CMAKE_GENERATOR: "Visual Studio 10 2010 Win64"
+#      MSVCVERSION: v100
+#      MSVCYEAR: "vs2010"
+#      MSVCABR: "10"
+#      VC_VER: 10.0
+#      PYTHONPATH: c:\Python33-x64\
+#      PYTHONPATHOMNI: "/cygdrive/c/Python33-x64/python"
+#      BOOST_ROOT: C:\Libraries\boost_1_63_0
+#      ZMQ_BASE: C:\projects\libzmq
+#      IDL_BASE: C:\projects\tangoidl
+#      IDL_BIN: C:\Program Files\tangoidl
+#      OMNI_BASE: C:\projects\omniORB-4.2.1
+#    - platform: x64
+#      ARCH: x64-msvc12
+#      configuration: Release
+#      CMAKE_GENERATOR: "Visual Studio 12 2013 Win64"
+#      MSVCVERSION: v120
+#      MSVCYEAR: "vs2013"
+#      MSVCABR: "13"
+#      VC_VER: 13.0
+#      PYTHONPATHOMNI: "/cygdrive/c/Python33-x64/python"
+#      BOOST_ROOT: C:\Libraries\boost_1_63_0
+#      ZMQ_BASE: C:\projects\libzmq
+#      IDL_BASE: C:\projects\tangoidl
+#      IDL_BIN: C:\Program Files\tangoidl
+#      OMNI_BASE: C:\projects\omniORB-4.2.1
     - platform: x64
       ARCH: x64-msvc14
       configuration: Release
@@ -129,6 +129,8 @@ init:
   - cmd: if %ARCH%==x64-msvc10 7z -y x omniorb-4.2.1_%ARCH%_py33.zip -oC:\projects\omniorb\
   - cmd: if %ARCH%==x64-msvc12 7z -y x omniorb-4.2.1_%ARCH%_py33.zip -oC:\projects\omniorb\
   - cmd: if %ARCH%==x64-msvc14 7z -y x omniorb-4.2.1_%ARCH%_py36.zip -oC:\projects\omniorb\
+  # Line added just for tests
+  - cmd: C:\projects\omniorb\bin\x86_win32\omniidl.exe -V
   #Pthread-Win32
   - cmd: cd "C:\projects\"
   - cmd: md pthreads-win32

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -122,14 +122,15 @@ init:
   - if %ARCH%==win32-msvc10 appveyor DownloadFile https://github.com/tango-controls/omniorb-windows-ci/releases/download/4.2.1.2/omniorb-4.2.1_%ARCH%_py33.zip
   - if %ARCH%==x64-msvc10 appveyor DownloadFile https://github.com/tango-controls/omniorb-windows-ci/releases/download/4.2.1.2/omniorb-4.2.1_%ARCH%_py33.zip
   - if %ARCH%==x64-msvc12 appveyor DownloadFile https://github.com/tango-controls/omniorb-windows-ci/releases/download/4.2.1.2/omniorb-4.2.1_%ARCH%_py33.zip
-  - if %ARCH%==x64-msvc14 appveyor DownloadFile https://github.com/tango-controls/omniorb-windows-ci/releases/download/4.2.1.2/omniorb-4.2.1_%ARCH%_py36.zip
+  - if %ARCH%==x64-msvc14 appveyor DownloadFile https://github.com/tango-controls/omniorb-windows-ci/releases/download/4.2.1.2/omniorb-4.2.1_%ARCH%_py35.zip
   - cmd: if %ARCH%==win32-msvc9 7z -y x omniorb-4.2.1_%ARCH%_py27.zip -oC:\projects\omniorb\
   - cmd: if %ARCH%==x64-msvc9 7z -y x omniorb-4.2.1_%ARCH%_py27.zip -oC:\projects\omniorb\
   - cmd: if %ARCH%==win32-msvc10 7z -y x omniorb-4.2.1_%ARCH%_py33.zip -oC:\projects\omniorb\
   - cmd: if %ARCH%==x64-msvc10 7z -y x omniorb-4.2.1_%ARCH%_py33.zip -oC:\projects\omniorb\
   - cmd: if %ARCH%==x64-msvc12 7z -y x omniorb-4.2.1_%ARCH%_py33.zip -oC:\projects\omniorb\
-  - cmd: if %ARCH%==x64-msvc14 7z -y x omniorb-4.2.1_%ARCH%_py36.zip -oC:\projects\omniorb\
-  # Line added just for tests
+  - cmd: if %ARCH%==x64-msvc14 7z -y x omniorb-4.2.1_%ARCH%_py35.zip -oC:\projects\omniorb\
+  # Lines added just for tests
+  - cmd: echo %Path%
   - cmd: C:\projects\omniorb\bin\x86_win32\omniidl.exe -V
   #Pthread-Win32
   - cmd: cd "C:\projects\"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -87,8 +87,8 @@ environment:
       MSVCYEAR: "vs2015"
       MSVCABR: "14"
       VC_VER: 14.0
-      PYTHONPATH: c:\Python35-x64\
-      PYTHONPATHOMNI: "/cygdrive/c/Python35-x64/python"
+      PYTHONPATH: c:\Python36-x64\
+      PYTHONPATHOMNI: "/cygdrive/c/Python36-x64/python"
       BOOST_ROOT: C:\Libraries\boost_1_63_0
       ZMQ_BASE: C:\projects\libzmq
       IDL_BASE: C:\projects\tangoidl
@@ -129,10 +129,6 @@ init:
   - cmd: if %ARCH%==x64-msvc10 7z -y x omniorb-4.2.1_%ARCH%_py33.zip -oC:\projects\omniorb\
   - cmd: if %ARCH%==x64-msvc12 7z -y x omniorb-4.2.1_%ARCH%_py33.zip -oC:\projects\omniorb\
   - cmd: if %ARCH%==x64-msvc14 7z -y x omniorb-4.2.1_%ARCH%_py36.zip -oC:\projects\omniorb\
-  # Lines added just for tests
-  - cmd: if %ARCH%==x64-msvc14 set Path=C:\Python36-x64;%Path%
-  - cmd: echo %Path%
-  - cmd: C:\projects\omniorb\bin\x86_win32\omniidl.exe -V
   #Pthread-Win32
   - cmd: cd "C:\projects\"
   - cmd: md pthreads-win32
@@ -179,7 +175,7 @@ install:
   - cmd: set IDL_BASE=%IDL_BIN%
   - cmd: set OMNI_BASE=C:/projects/omniorb/
   - cmd: set PTHREAD_WIN=C:/projects/pthreads-win32/
-  - cmd: if %ARCH%==x64-msvc14 set path=%path%;%PYTHONPATH%
+  - cmd: if %ARCH%==x64-msvc14 set path=%PYTHONPATH%;%path%
   #- cmd: cmake -G "%CMAKE_GENERATOR%" -DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=TRUE -DBUILD_SHARED_LIBS=TRUE
   #- cmd: cmake -G "%CMAKE_GENERATOR%" -DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=TRUE
   - cmd: cmake -G "%CMAKE_GENERATOR%" -DCMAKE_WINDOWS_EXPORT_ALL_SYMBOLS=TRUE -DIDL_BASE="%IDL_BASE%" -DOMNI_BASE="%OMNI_BASE%" -DZMQ_BASE="%ZMQ_BASE%" -DPTHREAD_WIN=%PTHREAD_WIN%


### PR DESCRIPTION
Due to appveyor artifacts retention policy (artifacts kept only 6 months), the appveyor builds got broken. This is an attempt to fix appveyor download links after the work done by @NexeyaSGara which was done to generate permanent release files for zmq, omniorb and PThread-Win32 for Windows.