### PR TITLE
Fix event name passed to client's Callback after Tango 9 reconnection

### DIFF
--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -6,7 +6,8 @@
 4. Fix some event compatibility issues with device server <= Tango 8 (#456)
 5. Fix event field in EventData structure passed to user's callback (broken in Tango 9.3.0 and 9.3.1)
 6. Fix attribute name in EventData structure passed to user's callback for Attribute Config events
-7. Fix a bug occurring when an event is pushed at the same time as an event (re)subscription occurs (#484)
+7. Fix a bug occurring when an event is pushed at the same time as an event (re)subscription occurs (#484, #485)
+8. Fix event name (EventData.event) passed to client's Callback after Tango 9 attribute reconnection (#486)
 
 9.3.1
 =====

--- a/cppapi/client/eventkeepalive.cpp
+++ b/cppapi/client/eventkeepalive.cpp
@@ -1469,7 +1469,7 @@ void EventConsumerKeepAliveThread::re_subscribe_after_reconnect(ZmqEventConsumer
 
 					event_data = new FwdEventData(epos->second.device,
 									domain_name,
-									epos->second.event_name,
+									ev_name,
 									da_copy,
 									err);
 				}
@@ -1477,7 +1477,7 @@ void EventConsumerKeepAliveThread::re_subscribe_after_reconnect(ZmqEventConsumer
 				{
 					event_data = new FwdEventData(epos->second.device,
 									domain_name,
-									epos->second.event_name,
+									ev_name,
 									da,
 									err);
 				}


### PR DESCRIPTION
(EventData.event:  idl5_<_event_type_> => <_event_type_>)