### PR TITLE
Fix memory leak on get_device_property() #439

### DIFF
--- a/cppapi/client/dbapi_datum.cpp
+++ b/cppapi/client/dbapi_datum.cpp
@@ -78,9 +78,7 @@ DbDatum::DbDatum():ext(Tango_nullptr)
 DbDatum::~DbDatum()
 {
 #ifndef HAS_UNIQUE_PTR
-	#ifndef _TG_WINDOWS_
     delete ext;
-    #endif
 #endif
 }
 


### PR DESCRIPTION
This memory leak was present only on Windows and only when compiling with a
compiler version MSVC++ <= MSVC++10.0 (Visual Studio 10)