### PR TITLE
Fix cxx_fwd_att.cpp:749 occasional test failure (#384,#428)

### DIFF
--- a/cpp_test_suite/new_tests/cxx_fwd_att.cpp
+++ b/cpp_test_suite/new_tests/cxx_fwd_att.cpp
@@ -714,7 +714,7 @@ public:
 		EventCallBack cb(this);
 		cb.cb_executed = 0;
 		cb.cb_err = 0;
-
+		fwd_device->set_source(CACHE_DEV);
 		try
 		{
 			fwd_device->subscribe_event("fwd_short_rw",Tango::PERIODIC_EVENT,&cb);
@@ -741,7 +741,6 @@ public:
 		attr_poll.svalue[2] = "short_attr_rw";
 		din << attr_poll;
 		TS_ASSERT_THROWS_NOTHING(root_admin->command_inout("AddObjPolling", din));
-		Tango_sleep(1);
 		TS_ASSERT_THROWS_NOTHING(eve_id = fwd_device->subscribe_event("fwd_short_rw",Tango::PERIODIC_EVENT,&cb));
 
 		Tango_sleep(3);

--- a/cpp_test_suite/new_tests/cxx_fwd_att.cpp
+++ b/cpp_test_suite/new_tests/cxx_fwd_att.cpp
@@ -741,12 +741,12 @@ public:
 		attr_poll.svalue[2] = "short_attr_rw";
 		din << attr_poll;
 		TS_ASSERT_THROWS_NOTHING(root_admin->command_inout("AddObjPolling", din));
-
+		Tango_sleep(1);
 		TS_ASSERT_THROWS_NOTHING(eve_id = fwd_device->subscribe_event("fwd_short_rw",Tango::PERIODIC_EVENT,&cb));
 
 		Tango_sleep(3);
 
-		TS_ASSERT(cb.cb_err == 1);
+		TS_ASSERT(cb.cb_err == 0);
 		TS_ASSERT(cb.cb_executed >= 3);
 
 		string at_name = fwd_device_name + "/fwd_short_rw";


### PR DESCRIPTION
Added a sleep time after sending AddObjPolling command to the root device and before subscribing event on the forwarded device to give some time for the polling to start up correctly and changed the assertion cb.cb_err == 1 into cb.cb_err == 0.

The test failures we were experiencing before were due to the fact that sometimes (most of the times) an error event was sent with the following exception:
```
Severity = ERROR 
Error reason = API_NoDataYet
Desc : No data available in cache for attribute short_attr_rw
Origin : Device_3Impl::read_attributes_from_cache

Severity = ERROR 
Error reason = API_AttributeFailed
Desc : Failed to read_attribute on device test/debian8/10, attribute short_attr_rw
Origin : DeviceProxy::read_attribute()
```

And sometimes, no error event was sent because the polling had enough time to start up correctly on the root device. So there was already a value available in the cache.
So the assertion (cb.cb_err == 1) was wrong in this last case because cb.cb_err was equal to 0.