### PR TITLE
- Fix client crash in case of asynchronous write_attribute

### DIFF
--- a/cpp_test_suite/cpp_test_ds/DevTest.cpp
+++ b/cpp_test_suite/cpp_test_ds/DevTest.cpp
@@ -112,6 +112,7 @@ void DevTest::init_device()
 	attr_state_rw = Tango::FAULT;
 	PollLong_attr_num = 0;
 	PollString_spec_attr_num = 0;
+	attr_asyn_write_val = 42;
 
 	Short_attr_except = false;
 	if (tg->is_svr_starting() == true || tg->is_device_restarting(device_name) == true)
@@ -867,8 +868,16 @@ void DevTest::write_attr_asyn_write(Tango::WAttribute &att)
 
 	Tango::DevLong lg;
 	att.get_write_value(lg);
+	attr_asyn_write_val = lg;
 	cout << "Attribute value = " << lg << endl;
 	Tango_sleep(2);
+}
+
+void DevTest::read_attr_asyn_write(Tango::Attribute &att)
+{
+	cout << "In read_attr_asyn_write for attribute " << att.get_name() << endl;
+	Tango_sleep(2);
+	att.set_value(&attr_asyn_write_val);
 }
 
 void DevTest::write_attr_asyn_write_to(Tango::WAttribute &att)

--- a/cpp_test_suite/cpp_test_ds/DevTest.h
+++ b/cpp_test_suite/cpp_test_ds/DevTest.h
@@ -155,6 +155,7 @@ public :
 	void read_Enum_spec_attr_rw(Tango::Attribute &att);
 	void read_DynEnum_attr(Tango::Attribute &att);
 	void read_ReynaldPoll_attr(Tango::Attribute &att);
+	void read_attr_asyn_write(Tango::Attribute &att);
 
 	void write_Short_attr_rw(Tango::WAttribute &att);
 	void write_Long64_attr_rw(Tango::WAttribute &att);
@@ -360,6 +361,8 @@ protected :
 
     int                                     Reynald_ctr;
     double                                  Reynald_val;
+
+    Tango::DevLong                          attr_asyn_write_val;
 };
 
 #endif

--- a/cpp_test_suite/cpp_test_ds/DevTestClass.h
+++ b/cpp_test_suite/cpp_test_ds/DevTestClass.h
@@ -580,11 +580,13 @@ public:
 class attr_asyn_writeAttr: public Tango::Attr
 {
 public:
-	attr_asyn_writeAttr():Attr("attr_asyn_write",Tango::DEV_LONG, Tango::WRITE) {};
+	attr_asyn_writeAttr():Attr("attr_asyn_write",Tango::DEV_LONG, Tango::READ_WRITE) {};
 	~attr_asyn_writeAttr() {};
 
 	virtual void write(Tango::DeviceImpl *dev,Tango::WAttribute &att)
 	{(static_cast<DevTest *>(dev))->write_attr_asyn_write(att);}
+	virtual void read(Tango::DeviceImpl *dev,Tango::Attribute &att)
+	{(static_cast<DevTest *>(dev))->read_attr_asyn_write(att);}
 };
 
 class attr_asyn_write_toAttr: public Tango::Attr

--- a/cpp_test_suite/cxxtest/CMakeLists.txt
+++ b/cpp_test_suite/cxxtest/CMakeLists.txt
@@ -78,6 +78,7 @@ CXX_GENERATE_TEST(cxx_server_event)
 CXX_GENERATE_TEST(cxx_reconnection_zmq)
 CXX_GENERATE_TEST(cxx_stateless_subscription)
 CXX_GENERATE_TEST(cxx_nan_inf_in_prop)
+CXX_GENERATE_TEST(cxx_asyn_reconnection)
 
 #utilities
 configure_file(bin/start_server.sh.cmake    ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/start_server.sh @ONLY)

--- a/cpp_test_suite/new_tests/cxx_asyn_reconnection.cpp
+++ b/cpp_test_suite/new_tests/cxx_asyn_reconnection.cpp
@@ -1,0 +1,250 @@
+#ifndef AsynReconnectionTestSuite_h
+#define AsynReconnectionTestSuite_h
+
+#include <cxxtest/TestSuite.h>
+#include <cxxtest/TangoPrinter.h>
+#include <tango.h>
+#include <iostream>
+
+using namespace Tango;
+using namespace std;
+
+#define cout cout << "\t"
+#define    coutv    if (verbose == true) cout
+
+#undef SUITE_NAME
+#define SUITE_NAME AsynReconnectionTestSuite
+
+class AsynReconnectionTestSuite: public CxxTest::TestSuite
+{
+protected:
+	DeviceProxy *device1;
+	string device1_name;
+	string device1_instance_name;
+	bool verbose;
+
+public:
+	SUITE_NAME() :
+	device1_instance_name{"test"} //TODO pass via cl
+	{
+
+//
+// Arguments check -------------------------------------------------
+//
+
+		// locally defined (test suite scope) mandatory parameters
+		//localparam = CxxTest::TangoPrinter::get_param_loc("localparam","description of what localparam is");
+
+		// predefined mandatory parameters
+		device1_name = CxxTest::TangoPrinter::get_param("device1");
+
+		// predefined optional parameters
+		//CxxTest::TangoPrinter::get_param_opt("loop"); // loop parameter is then managed by the CXX framework itself
+		// or
+		verbose = CxxTest::TangoPrinter::is_param_opt_set("verbose");
+
+		// always add this line, otherwise arguments will not be parsed correctly
+		CxxTest::TangoPrinter::validate_args();
+
+
+//
+// Initialization --------------------------------------------------
+//
+
+		try
+		{
+			device1 = new DeviceProxy(device1_name);
+			device1->ping();
+		}
+		catch (CORBA::Exception &e)
+		{
+			Except::print_exception(e);
+			exit(-1);
+		}
+
+	}
+
+	virtual ~SUITE_NAME()
+	{
+
+//
+// Clean up --------------------------------------------------------
+//
+
+		// clean up in case test suite terminates before Server_Killed is restored to defaults
+		if(CxxTest::TangoPrinter::is_restore_set("Server_Killed"))
+		{
+			try
+			{
+                CxxTest::TangoPrinter::start_server(device1_instance_name);
+			}
+			catch(DevFailed &e)
+			{
+				cout << endl << "Exception in suite tearDown():" << endl;
+				Except::print_exception(e);
+			}
+		}
+
+		// delete dynamically allocated objects
+		delete device1;
+	}
+
+	static SUITE_NAME *createSuite()
+	{
+		return new SUITE_NAME();
+	}
+
+	static void destroySuite(SUITE_NAME *suite)
+	{
+		delete suite;
+	}
+
+//
+// Tests -------------------------------------------------------
+//
+
+// Test TestNormalWriteAttributeAsync
+
+	void test_TestNormalWriteAttributeAsynch()
+	{
+		try
+		{
+			// Write one attribute
+			long id;
+			DeviceAttribute send;
+
+			send.set_name("attr_asyn_write");
+			DevLong lg = 222;
+			TS_ASSERT_THROWS_NOTHING(send << lg);
+
+			TS_ASSERT_THROWS_NOTHING(id = device1->write_attribute_asynch(send));
+
+			bool finish = false;
+			long nb_not_arrived = 0;
+			while (finish == false)
+			{
+				try
+				{
+					device1->write_attribute_reply(id);
+					finish = true;
+				}
+				catch (AsynReplyNotArrived)
+				{
+					finish = false;
+					coutv << "Attribute not yet written" << endl;
+					nb_not_arrived++;
+				}
+				if (finish == false)
+					Tango_sleep(1);
+			}
+
+			assert(nb_not_arrived >= 1);
+
+			cout << "   Asynchronous write_attribute in polling mode --> OK" << endl;
+		}
+		catch(const Tango::DevFailed &e)
+		{
+			Tango::Except::print_exception(e);
+			exit(-1);
+		}
+		catch (CORBA::Exception &ex)
+		{
+			Except::print_exception(ex);
+			exit(-1);
+		}
+	}
+
+
+// Test TestWriteAttributeAsynchAfterReconnection
+
+    void test_TestWriteAttributeAsynchAfterReconnection()
+    {
+        CxxTest::TangoPrinter::kill_server();
+        CxxTest::TangoPrinter::restore_set("Server_Killed");
+        Tango_sleep(1);
+        CxxTest::TangoPrinter::start_server(device1_instance_name);
+        Tango_sleep(1);
+        CxxTest::TangoPrinter::restore_unset("Server_Killed");
+        try
+        {
+			// Write one attribute
+            long id;
+            DeviceAttribute send;
+
+            send.set_name("attr_asyn_write");
+            DevLong lg = 444;
+            TS_ASSERT_THROWS_NOTHING(send << lg);
+
+            TS_ASSERT_THROWS_NOTHING(id = device1->write_attribute_asynch(send));
+
+            bool finish = false;
+            long nb_not_arrived = 0;
+            while (finish == false)
+            {
+                try
+                {
+                    device1->write_attribute_reply(id);
+                    finish = true;
+                }
+                catch (AsynReplyNotArrived)
+                {
+                    finish = false;
+                    coutv << "Attribute not yet written" << endl;
+                    nb_not_arrived++;
+                }
+                if (finish == false)
+                    Tango_sleep(1);
+            }
+
+            assert(nb_not_arrived >= 1);
+
+            // Read the attribute
+			long read_id;
+			DeviceAttribute *received;
+
+			read_id = device1->read_attribute_asynch("attr_asyn_write");
+
+			finish = false;
+			nb_not_arrived = 0;
+			while (finish == false)
+			{
+				try
+				{
+					received = device1->read_attribute_reply(read_id);
+					Tango::DevLong val;
+					*received >> val;
+					coutv << "attr_asyn_write attribute value = " << val << endl;
+					assert( val == 444 );
+					finish = true;
+				}
+				catch (AsynReplyNotArrived )
+				{
+					finish = false;
+					coutv << "Attribute not yet read" << endl;
+					nb_not_arrived++;
+				}
+				if (finish == false)
+					Tango_sleep(1);
+			}
+			delete received;
+
+			assert ( nb_not_arrived >= 1);
+
+			coutv << "   Asynchronous read_attribute in polling mode --> OK" << endl;
+
+            cout << "   Asynchronous write_attribute in polling mode after reconnection--> OK" << endl;
+        }
+        catch(const Tango::DevFailed &e)
+        {
+            Tango::Except::print_exception(e);
+            exit(-1);
+        }
+        catch (CORBA::Exception &ex)
+        {
+            Except::print_exception(ex);
+            exit(-1);
+        }
+    }
+};
+#undef cout
+#endif // AsynReconnectionTestSuite_h

--- a/cppapi/client/proxy_asyn.cpp
+++ b/cppapi/client/proxy_asyn.cpp
@@ -2866,12 +2866,17 @@ void DeviceProxy::redo_synch_write_call(TgRequest &req)
 //
 
 	const Tango::AttributeValueList *att;
+	const Tango::AttributeValueList_4 *att_4;
+
 	try
 	{
 		CORBA::NVList_ptr args_ptr = req.request->arguments();
 		CORBA::NamedValue_ptr arg_ptr = args_ptr->item(0);
 		CORBA::Any *arg_val = arg_ptr->value();
-		(*arg_val) >>= att;
+		if(version < 4)
+			(*arg_val) >>= att;
+		else
+			(*arg_val) >>= att_4;
 	}
 	catch (CORBA::SystemException &e)
 	{
@@ -2891,7 +2896,10 @@ void DeviceProxy::redo_synch_write_call(TgRequest &req)
 // Redo the write_attributes but synchronously
 //
 
-	return write_attribute(*att);
+	if (version < 4)
+		return write_attribute(*att);
+	else
+		return write_attribute(*att_4);
 }
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
… when the

DS hosting the connected device is restarted and the write_attribute_asynch()
is the first call executed after the DS restart