### PR TITLE
Switch to Travis Xenial Linux infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: trusty
+dist: xenial
 
 language: cpp
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 dist: trusty
-sudo: false
 
 language: cpp
 


### PR DESCRIPTION
Following recommendations from Travis documentation:
https://docs.travis-ci.com/user/reference/overview/#deprecated-virtualization-environments
after Travis Trusty Container-based environment being deprecated.
Removed deprecated sudo:false line in .travis.yml
https://changelog.travis-ci.com/the-container-based-build-environment-is-fully-deprecated-84517