### PR TITLE
Install log4tango include files under <prefix>/include/tango/log4tango

### DIFF
--- a/log4tango/include/log4tango/CMakeLists.txt
+++ b/log4tango/include/log4tango/CMakeLists.txt
@@ -24,6 +24,6 @@ set(HEADER_FILES
 add_subdirectory(threading)
 
 install(FILES ${HEADER_FILES}
-        DESTINATION ${CMAKE_INSTALL_FULL_INCLUDEDIR}/log4tango)
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/config.h DESTINATION ${CMAKE_INSTALL_FULL_INCLUDEDIR}/log4tango)
+        DESTINATION ${CMAKE_INSTALL_FULL_INCLUDEDIR}/tango/log4tango)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/config.h DESTINATION ${CMAKE_INSTALL_FULL_INCLUDEDIR}/tango/log4tango)
 #TODO if windows 32 install config-win32.h

--- a/log4tango/include/log4tango/threading/CMakeLists.txt
+++ b/log4tango/include/log4tango/threading/CMakeLists.txt
@@ -5,4 +5,4 @@ set(HEADER_FILES
                 Threading.hh)
 
 install(FILES ${HEADER_FILES}
-        DESTINATION ${CMAKE_INSTALL_FULL_INCLUDEDIR}/log4tango/threading)
+        DESTINATION ${CMAKE_INSTALL_FULL_INCLUDEDIR}/tango/log4tango/threading)


### PR DESCRIPTION
... instead of \<prefix\>/include/log4tango directory since log4tango is now part of
tango library.
This also fixes an issue with the current tango.pc Cflags because \<prefix\>/include
directory is not listed in the list of include directories and it no longer needs to, now.
Thanks @taurel for reporting this issue.