### PR TITLE
Ignore ENOENT during zmq_disconnect call (fixes #514)

### DIFF
--- a/cppapi/client/eventconsumer.h
+++ b/cppapi/client/eventconsumer.h
@@ -666,6 +666,7 @@ private :
 	void set_ctrl_sock_bound() {sock_bound_mutex.lock();ctrl_socket_bound=true;sock_bound_mutex.unlock();}
 	bool is_ctrl_sock_bound() {bool _b;sock_bound_mutex.lock();_b=ctrl_socket_bound;sock_bound_mutex.unlock();return _b;}
 	void set_socket_hwm(int hwm);
+	static void disconnect_socket(zmq::socket_t&, const char*);
 
     bool check_zmq_endpoint(const string &);
 

--- a/cppapi/client/zmqeventconsumer.cpp
+++ b/cppapi/client/zmqeventconsumer.cpp
@@ -833,7 +833,7 @@ bool ZmqEventConsumer::process_ctrl(zmq::message_t &received_ctrl,zmq::pollitem_
 			if (pos != connected_heartbeat.end())
 				connected_heartbeat.erase(pos);
 
-			heartbeat_sub_sock->disconnect(endpoint);
+			disconnect_socket(*heartbeat_sub_sock, endpoint);
 
 //
 // Remove the event endpoint from the already connected event and disconnect the event socket
@@ -843,7 +843,7 @@ bool ZmqEventConsumer::process_ctrl(zmq::message_t &received_ctrl,zmq::pollitem_
 			if (pos != connected_pub.end())
 			{
 				connected_pub.erase(pos);
-				event_sub_sock->disconnect(endpoint_event);
+				disconnect_socket(*event_sub_sock, endpoint_event);
 			}
 #endif
         }
@@ -3544,6 +3544,22 @@ ReceivedFromAdmin ZmqEventConsumer::initialize_received_from_admin(const Tango::
     }
     cout4 << "received_from_admin.channel_name = " << result.channel_name << endl;
     return result;
+}
+
+void ZmqEventConsumer::disconnect_socket(zmq::socket_t& socket, const char* endpoint)
+{
+    try
+    {
+        socket.disconnect(endpoint);
+    }
+    catch (const zmq::error_t& e)
+    {
+        // Silently ignore ENOENT as it indicates that endpoint is already disconnected.
+        if (e.num() != ENOENT)
+        {
+            throw;
+        }
+    }
 }
 
 //--------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
A change in ZMQ 4.2.3 breaks one of Tango tests (`cxx_stateless_subscription`, see #514 for details). 

Since zeromq/libzmq@edb4ca1023ff9001b545e827b227402b76a2b55d, peer disconnection triggers `zmq_disconnect` on a zmq socket. Further `zmq_disconnect` calls for such socket and endpoint will fail with errno set to `ENOENT`. This patch silently ignores such failure.

I'm not adding any new testcases. I don't think it is possible to have a reliable reproduction with ZMQ older than v4.2.3.