### PR TITLE
Prevent exceptions from unsubscribe_event leaving DeviceProxy destructor

### DIFF
--- a/cppapi/client/DeviceProxy.h
+++ b/cppapi/client/DeviceProxy.h
@@ -78,6 +78,7 @@ private :
 	void write_attribute(const AttributeValueList_4 &);
 	void create_locking_thread(ApiUtil *,DevLong);
 	void local_import(string &);
+	void unsubscribe_all_events();
 
 	enum read_attr_type
 	{


### PR DESCRIPTION
Per @bourtemb suggestion from #514 let's handle `unsubscribe_event` failures in `~DeviceProxy` to prevent exceptions being thrown out of a destructor.