### PR TITLE
Use python2 (if available) to run cxxtestgen

### DIFF
--- a/cpp_test_suite/cxxtest/CMakeLists.txt
+++ b/cpp_test_suite/cxxtest/CMakeLists.txt
@@ -1,8 +1,10 @@
 find_package (Threads REQUIRED)
+find_program(PYTHON_INTERPRETER NAMES python2 python)
 
 macro(CXX_GENERATE_TEST name)
     message("Generate ${name}.cpp")
-    execute_process(COMMAND python cxxtestgen.py --template=${CMAKE_CURRENT_SOURCE_DIR}/template/tango_template.tpl
+    execute_process(COMMAND "${PYTHON_INTERPRETER}" cxxtestgen.py
+            --template=${CMAKE_CURRENT_SOURCE_DIR}/template/tango_template.tpl
             -o ${CMAKE_CURRENT_SOURCE_DIR}/${name}.cpp
             ../../new_tests/${name}.cpp
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/bin)


### PR DESCRIPTION
As python 2.x is reaching EOL soon (PEP 373) and some distros already switched to use python 3.x as a default python interpreter, I propose to follow PEP 394 and use `python2` command/link instead of `python` when invoking cxxtestgen.

If `python2` is missing, CMake will fall-back to using `python` (if it's on `$PATH`).