### PR TITLE
CMake: Add compile check to test for correct ZeroMQ C++ headers

### DIFF
--- a/configure/CMakeLists.txt
+++ b/configure/CMakeLists.txt
@@ -151,6 +151,16 @@ Please install cppzmq (https://github.com/zeromq/cppzmq) on your system and/or u
 <OMNI_BASE>/include and system include directories).")
 endif()
 
+TRY_COMPILE(HAS_COMPATIBLE_ZMQ_HPP_VERSION
+  ${CMAKE_BINARY_DIR}/configure
+  SOURCES ${CMAKE_SOURCE_DIR}/configure/test_zmq_hpp.cpp
+  CMAKE_FLAGS "-I ${CPPZMQ_BASE}/include -I ${ZMQ_PKG_INCLUDE_DIRS}/include"
+  LINK_LIBRARIES ${ZMQ_PKG_LIBRARIES})
+
+IF(NOT HAS_COMPATIBLE_ZMQ_HPP_VERSION)
+  message(FATAL_ERROR "Please use a compatible version of cppzmq")
+ENDIF()
+
 message("Verifying ${OMNIIDL_PATH}omniidl")
 if(WIN32)
     execute_process(COMMAND ${OMNIIDL_PATH}omniidl.exe -V RESULT_VARIABLE FAILED)

--- a/configure/test_zmq_hpp.cpp
+++ b/configure/test_zmq_hpp.cpp
@@ -1,0 +1,10 @@
+#include <zmq.hpp>
+
+int main(int argc, char** argv)
+{
+  zmq::context_t c;
+  zmq::socket_t s(c, ZMQ_REQ);
+
+  // we require `operator void*()`
+  void *ptr = s;
+}


### PR DESCRIPTION
We are relying on the presence of convertability from zmq::socket_t to void *.

Add a cmake check so that we know that we have the correct version.

Close #273.

@Ingvord.