### PR TITLE
Fix events compatibilities issues (#492)...

### DIFF
--- a/cppapi/server/eventcmds.cpp
+++ b/cppapi/server/eventcmds.cpp
@@ -698,7 +698,7 @@ DevVarLongStringArray *DServer::zmq_event_subscription_change(const Tango::DevVa
         ret_data->svalue.length(2);
 
         ret_data->lvalue.length(1);
-        ret_data->lvalue[0] = (Tango::DevLong)tg->get_tango_lib_release();;
+        ret_data->lvalue[0] = (Tango::DevLong)tg->get_tango_lib_release();
 
         ZmqEventSupplier *ev;
         if ((ev = tg->get_zmq_event_supplier()) != NULL)
@@ -1073,8 +1073,22 @@ DevVarLongStringArray *DServer::zmq_event_subscription_change(const Tango::DevVa
         size_t size = ret_data->svalue.length();
         ret_data->svalue.length(size + 2);
 
-        string event_topic =
-            ev->create_full_event_name(dev, EVENT_COMPAT_IDL5 + event, obj_name_lower, intr_change);
+        string event_topic = "";
+        bool add_compat_info = false;
+        if ((event != EventName[PIPE_EVENT]) &&
+            (event != EventName[INTERFACE_CHANGE_EVENT]) &&
+            (event != EventName[DATA_READY_EVENT]))
+        {
+            add_compat_info = true;
+        }
+        if(client_release >= 5 && add_compat_info) // client_release here is the minimum of the client release and dev IDL version
+        {
+            event_topic = ev->create_full_event_name(dev, EVENT_COMPAT_IDL5 + event, obj_name_lower, intr_change);
+        }
+        else
+        {
+            event_topic = ev->create_full_event_name(dev, event, obj_name_lower, intr_change);
+        }
         assert(!(event_topic.empty()));
         cout4 << "Sending event_topic = " << event_topic << endl;
         ret_data->svalue[size] = Tango::string_dup(event_topic.c_str());

--- a/cppapi/server/eventsupplier.cpp
+++ b/cppapi/server/eventsupplier.cpp
@@ -2405,7 +2405,6 @@ EventSupplier::push_att_data_ready_event(DeviceImpl *device_impl, const string &
     vector<long> filterable_data_lg;
 
     string ev_type(DATA_READY_TYPE_EVENT);
-    ev_type = EVENT_COMPAT_IDL5 + ev_type;
 
     AttDataReady dat_ready;
     dat_ready.name = attr_name.c_str();
@@ -2560,7 +2559,6 @@ void EventSupplier::push_dev_intr_change_event(DeviceImpl *device_impl,
     vector<long> filterable_data_lg;
 
     string ev_type(EventName[INTERFACE_CHANGE_EVENT]);
-    ev_type = EVENT_COMPAT_IDL5 + ev_type;
     time_t now, dev_intr_subscription;
 
 //

--- a/cppapi/server/pipe.cpp
+++ b/cppapi/server/pipe.cpp
@@ -756,7 +756,6 @@ void Pipe::fire_event(DeviceImpl *dev,DevFailed *except)
 	vector<long> f_data_lg;
 
 	string event_type("pipe");
-	event_type = EVENT_COMPAT_IDL5 + event_type;
 	event_supplier_zmq->push_event(dev, event_type, f_names, f_data, f_names_lg, f_data_lg, ad, name, except, true);
 }
 
@@ -858,7 +857,6 @@ void Pipe::fire_event(DeviceImpl *dev,DevicePipeBlob *p_data,struct timeval &t,b
 	vector<long> f_data_lg;
 
 	string event_type("pipe");
-	event_type = EVENT_COMPAT_IDL5 + event_type;
 	event_supplier_zmq->push_event(dev, event_type, f_names, f_data, f_names_lg, f_data_lg, ad, name, NULL, true);
 
 	if (reuse_it == false)


### PR DESCRIPTION
... with device server exporting Device_4 devices.
Fix bug with with Pipe, Data Ready and Device Interface Change events.
ZmqEventSubscriptionChange was returning a wrong "event name used by this server as zmq topic to send events" in these different cases.