### PR TITLE
Replace CORBA::string_free with Tango::string_free

### DIFF
--- a/cpp_test_suite/new_tests/cxx_encoded.cpp
+++ b/cpp_test_suite/new_tests/cxx_encoded.cpp
@@ -184,7 +184,7 @@ public:
 		da_out = device1->read_attribute("Encoded_attr");
 		da_out.extract(att_read_ptr,att_read_data_ptr,att_data_length);
 
-		CORBA::string_free(att_read_ptr);
+		Tango::string_free(att_read_ptr);
 		delete [] att_read_data_ptr;
 
 //-------

--- a/cppapi/client/devapi_base.cpp
+++ b/cppapi/client/devapi_base.cpp
@@ -10126,7 +10126,7 @@ void DeviceProxy::local_import(string &local_ior)
                 local_ior = s;
 
                 CORBA::release(orb_ptr);
-                CORBA::string_free(s);
+                Tango::string_free(s);
 
                 return;
             }

--- a/cppapi/client/proxy_asyn.cpp
+++ b/cppapi/client/proxy_asyn.cpp
@@ -363,7 +363,7 @@ DeviceData Connection::command_inout_reply(long id)
                     TangoSys_OMemStream desc;
                     desc << "Timeout (" << timeout << " mS) exceeded on device " << dev_name();
                     desc << ", command " << tmp << ends;
-                    CORBA::string_free(tmp);
+                    Tango::string_free(tmp);
 
                     remove_asyn_request(id);
 
@@ -409,7 +409,7 @@ DeviceData Connection::command_inout_reply(long id)
 			TangoSys_OMemStream desc;
 			desc << "Failed to execute command_inout_asynch on device " << dev_name();
 			desc << ", command " << tmp << ends;
-			CORBA::string_free(tmp);
+			Tango::string_free(tmp);
 
 			remove_asyn_request(id);
 
@@ -459,7 +459,7 @@ DeviceData Connection::command_inout_reply(long id)
 // Remove request from request global table.
 //
 
-					CORBA::string_free(tmp);
+					Tango::string_free(tmp);
 
 					remove_asyn_request(id);
 
@@ -472,7 +472,7 @@ DeviceData Connection::command_inout_reply(long id)
 			TangoSys_OMemStream desc;
 			desc << "Failed to execute command_inout_asynch on device " << dev_name();
 			desc << ", command " << tmp << ends;
-			CORBA::string_free(tmp);
+			Tango::string_free(tmp);
 
 			remove_asyn_request(id);
 
@@ -689,7 +689,7 @@ DeviceData Connection::command_inout_reply(long id,long call_timeout)
                     TangoSys_OMemStream desc;
                     desc << "Timeout (" << timeout << " mS) exceeded on device " << dev_name();
                     desc << ", command " << tmp << ends;
-                    CORBA::string_free(tmp);
+                    Tango::string_free(tmp);
 
                     remove_asyn_request(id);
 
@@ -735,7 +735,7 @@ DeviceData Connection::command_inout_reply(long id,long call_timeout)
 			TangoSys_OMemStream desc;
 			desc << "Failed to execute command_inout_asynch on device " << dev_name();
 			desc << ", command " << tmp << ends;
-			CORBA::string_free(tmp);
+			Tango::string_free(tmp);
 
 			remove_asyn_request(id);;
 
@@ -783,7 +783,7 @@ DeviceData Connection::command_inout_reply(long id,long call_timeout)
 // Remove request from request global table.
 //
 
-					CORBA::string_free(tmp);
+					Tango::string_free(tmp);
 
 					remove_asyn_request(id);
 
@@ -796,7 +796,7 @@ DeviceData Connection::command_inout_reply(long id,long call_timeout)
 			TangoSys_OMemStream desc;
 			desc << "Failed to execute command_inout_asynch on device " << dev_name();
 			desc << ", command " << tmp << ends;
-			CORBA::string_free(tmp);
+			Tango::string_free(tmp);
 
 			remove_asyn_request(id);
 

--- a/cppapi/client/proxy_asyn_cb.cpp
+++ b/cppapi/client/proxy_asyn_cb.cpp
@@ -328,7 +328,7 @@ void Connection::Cb_Cmd_Request(CORBA::Request_ptr req,Tango::CallBack *cb_ptr)
 				TangoSys_OMemStream desc;
 				desc << "Timeout (" << timeout << " mS) exceeded on device " << dev_name();
 				desc << ", command " << tmp << ends;
-				CORBA::string_free(tmp);
+				Tango::string_free(tmp);
 
 				errors.length(2);
 				errors[0].desc = Tango::string_dup(cb_excep_mess);
@@ -362,7 +362,7 @@ void Connection::Cb_Cmd_Request(CORBA::Request_ptr req,Tango::CallBack *cb_ptr)
 			TangoSys_OMemStream desc;
 			desc << "Failed to execute command_inout_asynch on device " << dev_name();
 			desc << ", command " << tmp << ends;
-			CORBA::string_free(tmp);
+			Tango::string_free(tmp);
 
 			long nb_err = errors.length();
 			errors.length(nb_err + 1);
@@ -391,7 +391,7 @@ void Connection::Cb_Cmd_Request(CORBA::Request_ptr req,Tango::CallBack *cb_ptr)
 			TangoSys_OMemStream desc;
 			desc << "Failed to execute command_inout_asynch on device " << dev_name();
 			desc << ", command " << cmd << ends;
-			CORBA::string_free(tmp);
+			Tango::string_free(tmp);
 
 			errors.length(2);
 			errors[0].desc = Tango::string_dup(cb_excep_mess);

--- a/cppapi/server/deviceclass.cpp
+++ b/cppapi/server/deviceclass.cpp
@@ -1098,12 +1098,12 @@ void DeviceClass::export_device(DeviceImpl *dev,const char *corba_obj_name)
 		{
 			cerr << "CommunicationFailed while exporting device " << dev->get_name() << endl;
 			CORBA::release(orb_ptr);
-			CORBA::string_free(s);
+			Tango::string_free(s);
 			throw;
 		}
 
 		CORBA::release(orb_ptr);
-		CORBA::string_free(s);
+		Tango::string_free(s);
 	}
 
 //

--- a/cppapi/server/notifdeventsupplier.cpp
+++ b/cppapi/server/notifdeventsupplier.cpp
@@ -516,7 +516,7 @@ void NotifdEventSupplier::connect_to_notifd(NotifService &ns,CORBA::ORB_var &_or
 				}
 				catch (Tango::DevFailed &e) {}
 			}
-			CORBA::string_free(_ior);
+			Tango::string_free(_ior);
 		}
 		catch(const CosNotification::UnsupportedQoS&)
 		{

--- a/cppapi/server/w_attribute.cpp
+++ b/cppapi/server/w_attribute.cpp
@@ -170,10 +170,10 @@ WAttribute::~WAttribute()
 #ifndef HAS_UNIQUE_PTR
     delete w_ext;
 #endif
-    CORBA::string_free(str_val);
-    CORBA::string_free(old_str_val);
-//	CORBA::string_free(encoded_val.encoded_format);
-//	CORBA::string_free(old_encoded_val.encoded_format);
+    Tango::string_free(str_val);
+    Tango::string_free(old_str_val);
+//	Tango::string_free(encoded_val.encoded_format);
+//	Tango::string_free(old_encoded_val.encoded_format);
 }
 
 
@@ -713,9 +713,9 @@ void WAttribute::check_written_value(const CORBA::Any &any, unsigned long x, uns
 
             if (data_format == Tango::SCALAR)
             {
-                CORBA::string_free(old_str_val);
+                Tango::string_free(old_str_val);
                 old_str_val = CORBA::string_dup(str_val);
-                CORBA::string_free(str_val);
+                Tango::string_free(str_val);
 
                 str_val = CORBA::string_dup((*string_ptr)[0]);
                 w_dim_x = 1;
@@ -1498,9 +1498,9 @@ void WAttribute::check_written_value(const Tango::AttrValUnion &att_union, unsig
 
             if (data_format == Tango::SCALAR)
             {
-                CORBA::string_free(old_str_val);
+                Tango::string_free(old_str_val);
                 old_str_val = CORBA::string_dup(str_val);
-                CORBA::string_free(str_val);
+                Tango::string_free(str_val);
 
                 str_val = CORBA::string_dup(string_seq[0]);
                 w_dim_x = 1;
@@ -2631,7 +2631,7 @@ void WAttribute::rollback()
             break;
 
         case Tango::DEV_STRING :
-            CORBA::string_free(str_val);
+            Tango::string_free(str_val);
             str_val = CORBA::string_dup(old_str_val);
             break;
 
@@ -2648,7 +2648,7 @@ void WAttribute::rollback()
             break;
 
         case Tango::DEV_UCHAR :
-            CORBA::string_free(str_val);
+            Tango::string_free(str_val);
             break;
 
         case Tango::DEV_ULONG :


### PR DESCRIPTION
Since we recently added Tango::string_free() method to hide CORBA::string_free(), let's use it in cppTango code.