### PR TITLE
Fix crash during alarm state evaluation if attribute value is not set (#330)

### DIFF
--- a/cpp_test_suite/cpp_test_ds/DevTest.cpp
+++ b/cpp_test_suite/cpp_test_ds/DevTest.cpp
@@ -117,6 +117,7 @@ void DevTest::init_device()
 	Short_attr_except = false;
 	if (tg->is_svr_starting() == true || tg->is_device_restarting(device_name) == true)
 		Short_attr_w_except = false;
+	Long_attr_except = false;
 	event_change_attr_except = false;
 	event_quality_attr_except = false;
 	event_throw_out_of_sync = false;
@@ -1281,8 +1282,15 @@ void DevTest::read_Short_attr(Tango::Attribute &att)
 
 void DevTest::read_Long_attr(Tango::Attribute &att)
 {
-      	cout << "[DevTest::read_attr] attribute name Long_attr" << std::endl;
-      	att.set_value(&attr_long);
+    cout << "[DevTest::read_attr] attribute name Long_attr" << std::endl;
+    if (Long_attr_except)
+    {
+        Tango::Except::throw_exception(
+            "Long_attr_except",
+            "Test exception is enabled for this attribute",
+            "DevTest::read_Long_attr");
+    }
+    att.set_value(&attr_long);
 }
 
 void DevTest::read_Long64_attr(Tango::Attribute &att)

--- a/cpp_test_suite/cpp_test_ds/DevTest.h
+++ b/cpp_test_suite/cpp_test_ds/DevTest.h
@@ -289,6 +289,7 @@ protected :
 
 	bool 				Short_attr_except;
 	bool 				Short_attr_w_except;
+	bool 				Long_attr_except;
 	bool 				event_change_attr_except;
 	bool 				event_quality_attr_except;
 	bool 				event_throw_out_of_sync;

--- a/cpp_test_suite/cpp_test_ds/IOMisc.cpp
+++ b/cpp_test_suite/cpp_test_ds/IOMisc.cpp
@@ -665,41 +665,23 @@ CORBA::Any *IOAttrThrowEx::execute(Tango::DeviceImpl *device, const CORBA::Any &
 	const Tango::DevVarShortArray *in;
 	extract(in_any, in);
 
-	if ((*in)[0] == 0)
-	{
-		if ((*in)[1] == 0)
-			(static_cast<DevTest *>(device))->Short_attr_except = false;
-		else
-			(static_cast<DevTest *>(device))->Short_attr_except = true;
-	}
-	else if ((*in)[0] == 1)
-	{
-		if ((*in)[1] == 0)
-			(static_cast<DevTest *>(device))->event_change_attr_except = false;
-		else
-			(static_cast<DevTest *>(device))->event_change_attr_except = true;
-	}
-	else if ((*in)[0] == 2)
-	{
-		if ((*in)[1] == 0)
-			(static_cast<DevTest *>(device))->event_quality_attr_except = false;
-		else
-			(static_cast<DevTest *>(device))->event_quality_attr_except = true;
-	}
-	else if ((*in)[0] == 3)
-	{
-		if ((*in)[1] == 0)
-			(static_cast<DevTest *>(device))->event_throw_out_of_sync = false;
-		else
-			(static_cast<DevTest *>(device))->event_throw_out_of_sync = true;
-	}
-	else if ((*in)[0] == 4)
-	{
-		if ((*in)[1] == 0)
-			(static_cast<DevTest *>(device))->Short_attr_w_except = false;
-		else
-			(static_cast<DevTest *>(device))->Short_attr_w_except = true;
-	}
+	DevTest& dev = static_cast<DevTest&>(*device);
+
+	const int flag_disc = (*in)[0];
+	const bool flag_value = (*in)[1];
+	bool default_flag = false;
+
+	bool& flag =
+		(flag_disc == 0) ? dev.Short_attr_except :
+		(flag_disc == 1) ? dev.event_change_attr_except :
+		(flag_disc == 2) ? dev.event_quality_attr_except :
+		(flag_disc == 3) ? dev.event_throw_out_of_sync :
+		(flag_disc == 4) ? dev.Short_attr_w_except :
+		(flag_disc == 5) ? dev.Long_attr_except :
+		default_flag;
+
+	flag = flag_value;
+
 	return insert();
 }
 

--- a/cpp_test_suite/cpp_test_ds/TypeCmds.cpp
+++ b/cpp_test_suite/cpp_test_ds/TypeCmds.cpp
@@ -1,9 +1,5 @@
 #include "TypeCmds.h"
 
-#define DEV_DEBUG_STREAM(dev) \
-  if (dev->get_logger()->is_debug_enabled())\
-    dev->get_logger()->debug_stream()
-
 //+----------------------------------------------------------------------------
 //
 // method : 		IOVoid::IOVoid()

--- a/cpp_test_suite/new_tests/cxx_attr_misc.cpp
+++ b/cpp_test_suite/new_tests/cxx_attr_misc.cpp
@@ -1021,6 +1021,54 @@ cout << "status = " << status << endl;
 		dout >> status;
 		TS_ASSERT(strcmp(status,"The device is in ON state.") == 0);
 	}
+
+	void set_attribute_exception_flag(short attribute_disc, bool enabled)
+	{
+		std::vector<short> flags(2);
+		flags[0] = attribute_disc;
+		flags[1] = enabled ? 1 : 0;
+		DeviceData data;
+		data << flags;
+		TS_ASSERT_THROWS_NOTHING(device1->command_inout("IOAttrThrowEx", data));
+	}
+
+	void __assert_dev_state(DevState expected, const char* file, const char* line)
+	{
+		std::string message = std::string("Called from ") + file + ":" + line;
+
+		DevState state;
+		DeviceData data;
+		TSM_ASSERT_THROWS_NOTHING(message, data = device1->command_inout("State"));
+		data >> state;
+		TSM_ASSERT_EQUALS(message, expected, state);
+	}
+
+#define __QUOTE(x) #x
+#define QUOTE(x) __QUOTE(x)
+#define assert_dev_state(expected) __assert_dev_state(expected, __FILE__, QUOTE(__LINE__))
+
+// Verifies that device state is set correctly when alarm is configured for an attribute
+// but no value is provided for this attribute in user callback (e.g. an exception is thrown).
+
+	void test_alarm_on_attribute_exception_during_read(void)
+	{
+		const short EXCEPTION_IN_Long_attr = 5;
+
+		assert_dev_state(Tango::ON);
+
+		set_attribute_exception_flag(EXCEPTION_IN_Long_attr, true);
+
+		assert_dev_state(Tango::ON);
+
+		set_attribute_exception_flag(EXCEPTION_IN_Long_attr, false);
+
+		assert_dev_state(Tango::ON);
+	}
+
+#undef assert_dev_state
+#undef QUOTE
+#undef __QUOTE
+
 };
 #undef cout
 #endif // AttrMiscTestSuite_h

--- a/cpp_test_suite/new_tests/cxx_attr_misc.cpp
+++ b/cpp_test_suite/new_tests/cxx_attr_misc.cpp
@@ -1022,6 +1022,13 @@ cout << "status = " << status << endl;
 		TS_ASSERT(strcmp(status,"The device is in ON state.") == 0);
 	}
 
+	void set_Long_attr_value(DevLong value)
+	{
+		DeviceData input;
+		input << value;
+		TS_ASSERT_THROWS_NOTHING(device1->command_inout("IOSetAttr", input));
+	}
+
 	void set_attribute_exception_flag(short attribute_disc, bool enabled)
 	{
 		std::vector<short> flags(2);
@@ -1054,14 +1061,16 @@ cout << "status = " << status << endl;
 	{
 		const short EXCEPTION_IN_Long_attr = 5;
 
-		assert_dev_state(Tango::ON);
+		set_Long_attr_value(2000);
+		assert_dev_state(Tango::ALARM);
 
 		set_attribute_exception_flag(EXCEPTION_IN_Long_attr, true);
-
 		assert_dev_state(Tango::ON);
 
 		set_attribute_exception_flag(EXCEPTION_IN_Long_attr, false);
+		assert_dev_state(Tango::ALARM);
 
+		set_Long_attr_value(1200);
 		assert_dev_state(Tango::ON);
 	}
 

--- a/cppapi/server/attribute.cpp
+++ b/cppapi/server/attribute.cpp
@@ -5368,22 +5368,19 @@ void Attribute::log_quality()
             switch(quality)
             {
                 case ATTR_INVALID:
-                if (dev->get_logger()->is_error_enabled())
-                    dev->get_logger()->error_stream() << log4tango::LogInitiator::_begin_log << "INVALID quality for attribute " << name << std::endl;
-                break;
+                    DEV_ERROR_STREAM(dev) << "INVALID quality for attribute " << get_name() << std::endl;
+                    break;
 
                 case ATTR_CHANGING:
-                if (dev->get_logger()->is_info_enabled())
-                    dev->get_logger()->info_stream() << log4tango::LogInitiator::_begin_log << "CHANGING quality for attribute " << name << std::endl;
-                break;
+                    DEV_INFO_STREAM(dev) << "CHANGING quality for attribute " << get_name() << std::endl;
+                    break;
 
                 case ATTR_VALID:
-                if (dev->get_logger()->is_info_enabled())
-                    dev->get_logger()->info_stream() << log4tango::LogInitiator::_begin_log << "VALID quality for attribute " << name << std::endl;
-                break;
+                    DEV_INFO_STREAM(dev) << "INFO quality for attribute " << get_name() << std::endl;
+                    break;
 
                 default:
-                break;
+                    break;
             }
         }
         else
@@ -5395,28 +5392,23 @@ void Attribute::log_quality()
 
             if (alarm[min_level] == true)
             {
-                if (dev->get_logger()->is_error_enabled())
-                    dev->get_logger()->error_stream() << log4tango::LogInitiator::_begin_log << "MIN ALARM for attribute " << name << std::endl;
+                DEV_ERROR_STREAM(dev) << "MIN ALARM for attribute " << get_name() << std::endl;
             }
             else if (alarm[max_level] == true)
             {
-                if (dev->get_logger()->is_error_enabled())
-                    dev->get_logger()->error_stream() << log4tango::LogInitiator::_begin_log << "MAX ALARM for attribute " << name << std::endl;
+                DEV_ERROR_STREAM(dev) << "MAX ALARM for attribute " << get_name() << std::endl;
             }
             else if (alarm[rds] == true)
             {
-                if (dev->get_logger()->is_warn_enabled())
-                    dev->get_logger()->warn_stream() << log4tango::LogInitiator::_begin_log << "RDS (Read Different Set) ALARM for attribute " << name << std::endl;
+                DEV_WARN_STREAM(dev) << "RDS (Read Different Set) ALARM for attribute " << get_name() << std::endl;
             }
             else if (alarm[min_warn] == true)
             {
-               if (dev->get_logger()->is_warn_enabled())
-                    dev->get_logger()->warn_stream() << log4tango::LogInitiator::_begin_log << "MIN WARNING for attribute " << name << std::endl;
+                DEV_WARN_STREAM(dev) << "MIN WARNING for attribute " << get_name() << std::endl;
             }
             else if (alarm[max_warn] == true)
             {
-               if (dev->get_logger()->is_warn_enabled())
-                    dev->get_logger()->warn_stream() << log4tango::LogInitiator::_begin_log << "MAX WARNING for attribute " << name << std::endl;
+                DEV_WARN_STREAM(dev) << "MAX WARNING for attribute " << get_name() << std::endl;
             }
         }
     }
@@ -5431,28 +5423,23 @@ void Attribute::log_quality()
         {
             if (alarm[min_level] == true)
             {
-                if (dev->get_logger()->is_error_enabled())
-                    dev->get_logger()->error_stream() << log4tango::LogInitiator::_begin_log << "MIN ALARM for attribute " << name << std::endl;
+                DEV_ERROR_STREAM(dev) << "MIN ALARM for attribute " << get_name() << std::endl;
             }
             else if (alarm[max_level] == true)
             {
-                if (dev->get_logger()->is_error_enabled())
-                    dev->get_logger()->error_stream() << log4tango::LogInitiator::_begin_log << "MAX ALARM for attribute " << name << std::endl;
+                DEV_ERROR_STREAM(dev) << "MAX ALARM for attribute " << get_name() << std::endl;
             }
             else if (alarm[rds] == true)
             {
-                if (dev->get_logger()->is_warn_enabled())
-                    dev->get_logger()->warn_stream() << log4tango::LogInitiator::_begin_log << "RDS (Read Different Set) ALARM for attribute " << name << std::endl;
+                DEV_WARN_STREAM(dev) << "RDS (Read Different Set) ALARM for attribute " << get_name() << std::endl;
             }
             else if (alarm[min_warn] == true)
             {
-               if (dev->get_logger()->is_warn_enabled())
-                    dev->get_logger()->warn_stream() << log4tango::LogInitiator::_begin_log << "MIN WARNING for attribute " << name << std::endl;
+                DEV_WARN_STREAM(dev) << "MIN WARNING for attribute " << get_name() << std::endl;
             }
             else if (alarm[max_warn] == true)
             {
-               if (dev->get_logger()->is_warn_enabled())
-                    dev->get_logger()->warn_stream() << log4tango::LogInitiator::_begin_log << "MAX WARNING for attribute " << name << std::endl;
+                DEV_WARN_STREAM(dev) << "MAX WARNING for attribute " << get_name() << std::endl;
             }
         }
     }

--- a/cppapi/server/attribute.cpp
+++ b/cppapi/server/attribute.cpp
@@ -1680,14 +1680,6 @@ bool Attribute::check_alarm()
 		return returned;
 	}
 
-// Skip alarm evaluation if no value for this attribute was provided during last read.
-
-	if (!get_value_flag())
-	{
-		DEV_WARN_STREAM(dev) << "Attribute has no value, skipping alarm evaluation for: " << get_name() << std::endl;
-		return false;
-	}
-
 //
 // Get the monitor protecting device att config
 //

--- a/cppapi/server/attribute.cpp
+++ b/cppapi/server/attribute.cpp
@@ -1680,6 +1680,14 @@ bool Attribute::check_alarm()
 		return returned;
 	}
 
+// Skip alarm evaluation if no value for this attribute was provided during last read.
+
+	if (!get_value_flag())
+	{
+		DEV_WARN_STREAM(dev) << "Attribute has no value, skipping alarm evaluation for: " << get_name() << std::endl;
+		return false;
+	}
+
 //
 // Get the monitor protecting device att config
 //

--- a/cppapi/server/attribute.cpp
+++ b/cppapi/server/attribute.cpp
@@ -5352,96 +5352,64 @@ void Attribute::log_quality()
         dev = tg->get_device_by_name(d_name);
     }
 
-//
-// Log something if the new quality is different than the old one
-//
+    const bool has_quality_changed = quality != old_quality;
+    const bool has_alarm_changed = alarm != old_alarm;
+    const bool is_alarm_set = alarm.any();
 
-    if (quality != old_quality)
+    if (has_quality_changed)
     {
-        if (alarm.any() == false)
+        if (! is_alarm_set)
         {
-
-//
-// No alarm detected
-//
-
-            switch(quality)
+            switch (quality)
             {
-                case ATTR_INVALID:
-                    DEV_ERROR_STREAM(dev) << "INVALID quality for attribute " << get_name() << std::endl;
-                    break;
+            case ATTR_INVALID:
+                DEV_ERROR_STREAM(dev) << "INVALID quality for attribute " << name << std::endl;
+                break;
 
-                case ATTR_CHANGING:
-                    DEV_INFO_STREAM(dev) << "CHANGING quality for attribute " << get_name() << std::endl;
-                    break;
+            case ATTR_CHANGING:
+                DEV_INFO_STREAM(dev) << "CHANGING quality for attribute " << name << std::endl;
+                break;
 
-                case ATTR_VALID:
-                    DEV_INFO_STREAM(dev) << "INFO quality for attribute " << get_name() << std::endl;
-                    break;
+            case ATTR_VALID:
+                DEV_INFO_STREAM(dev) << "INFO quality for attribute " << name << std::endl;
+                break;
 
-                default:
-                    break;
+            default:
+                break;
             }
         }
         else
         {
-
-//
-// Different log according to which alarm is set
-//
-
-            if (alarm[min_level] == true)
-            {
-                DEV_ERROR_STREAM(dev) << "MIN ALARM for attribute " << get_name() << std::endl;
-            }
-            else if (alarm[max_level] == true)
-            {
-                DEV_ERROR_STREAM(dev) << "MAX ALARM for attribute " << get_name() << std::endl;
-            }
-            else if (alarm[rds] == true)
-            {
-                DEV_WARN_STREAM(dev) << "RDS (Read Different Set) ALARM for attribute " << get_name() << std::endl;
-            }
-            else if (alarm[min_warn] == true)
-            {
-                DEV_WARN_STREAM(dev) << "MIN WARNING for attribute " << get_name() << std::endl;
-            }
-            else if (alarm[max_warn] == true)
-            {
-                DEV_WARN_STREAM(dev) << "MAX WARNING for attribute " << get_name() << std::endl;
-            }
+            log_alarm_quality();
         }
     }
-    else
+    else if (has_alarm_changed)
     {
+        log_alarm_quality();
+    }
+}
 
-//
-// The quality is the same but may be the alarm has changed
-//
-
-        if (alarm != old_alarm)
-        {
-            if (alarm[min_level] == true)
-            {
-                DEV_ERROR_STREAM(dev) << "MIN ALARM for attribute " << get_name() << std::endl;
-            }
-            else if (alarm[max_level] == true)
-            {
-                DEV_ERROR_STREAM(dev) << "MAX ALARM for attribute " << get_name() << std::endl;
-            }
-            else if (alarm[rds] == true)
-            {
-                DEV_WARN_STREAM(dev) << "RDS (Read Different Set) ALARM for attribute " << get_name() << std::endl;
-            }
-            else if (alarm[min_warn] == true)
-            {
-                DEV_WARN_STREAM(dev) << "MIN WARNING for attribute " << get_name() << std::endl;
-            }
-            else if (alarm[max_warn] == true)
-            {
-                DEV_WARN_STREAM(dev) << "MAX WARNING for attribute " << get_name() << std::endl;
-            }
-        }
+void Attribute::log_alarm_quality() const
+{
+    if (alarm[min_level])
+    {
+        DEV_ERROR_STREAM(dev) << "MIN ALARM for attribute " << name << std::endl;
+    }
+    else if (alarm[max_level])
+    {
+        DEV_ERROR_STREAM(dev) << "MAX ALARM for attribute " << name << std::endl;
+    }
+    else if (alarm[rds])
+    {
+        DEV_WARN_STREAM(dev) << "RDS (Read Different Set) ALARM for attribute " << name << std::endl;
+    }
+    else if (alarm[min_warn])
+    {
+        DEV_WARN_STREAM(dev) << "MIN WARNING for attribute " << name << std::endl;
+    }
+    else if (alarm[max_warn])
+    {
+        DEV_WARN_STREAM(dev) << "MAX WARNING for attribute " << name << std::endl;
     }
 }
 

--- a/cppapi/server/attribute.cpp
+++ b/cppapi/server/attribute.cpp
@@ -2864,54 +2864,67 @@ void Attribute::delete_seq()
 	case Tango::DEV_SHORT:
 	case Tango::DEV_ENUM:
 		delete value.sh_seq;
+		value.sh_seq = Tango_nullptr;
 		break;
 
 	case Tango::DEV_LONG:
 		delete value.lg_seq;
+		value.lg_seq = Tango_nullptr;
 		break;
 
 	case Tango::DEV_LONG64:
 		delete value.lg64_seq;
+		value.lg64_seq = Tango_nullptr;
 		break;
 
 	case Tango::DEV_DOUBLE:
 		delete value.db_seq;
+		value.db_seq = Tango_nullptr;
 		break;
 
 	case Tango::DEV_STRING:
 		delete value.str_seq;
+		value.str_seq = Tango_nullptr;
 		break;
 
 	case Tango::DEV_FLOAT:
 		delete value.fl_seq;
+		value.fl_seq = Tango_nullptr;
 		break;
 
 	case Tango::DEV_USHORT:
 		delete value.ush_seq;
+		value.ush_seq = Tango_nullptr;
 		break;
 
 	case Tango::DEV_UCHAR:
 		delete value.cha_seq;
+		value.cha_seq = Tango_nullptr;
 		break;
 
 	case Tango::DEV_BOOLEAN:
 		delete value.boo_seq;
+		value.boo_seq = Tango_nullptr;
 		break;
 
 	case Tango::DEV_ULONG:
 		delete value.ulg_seq;
+		value.ulg_seq = Tango_nullptr;
 		break;
 
 	case Tango::DEV_ULONG64:
 		delete value.ulg64_seq;
+		value.ulg64_seq = Tango_nullptr;
 		break;
 
 	case Tango::DEV_STATE:
 		delete value.state_seq;
+		value.state_seq = Tango_nullptr;
 		break;
 
 	case Tango::DEV_ENCODED:
 		delete value.enc_seq;
+		value.enc_seq = Tango_nullptr;
 		break;
 	}
 }

--- a/cppapi/server/attribute.h
+++ b/cppapi/server/attribute.h
@@ -2322,6 +2322,7 @@ private:
 	void set_data_size();
 	void throw_min_max_value(std::string &,std::string &,MinMaxValueCheck);
 	void log_quality();
+	void log_alarm_quality() const;
 
     inline void init_string_prop(std::vector<AttrProperty> &prop_list, std::string& attr, const char* attr_name)
     {

--- a/cppapi/server/device.cpp
+++ b/cppapi/server/device.cpp
@@ -1273,6 +1273,14 @@ Tango::DevState DeviceImpl::dev_state()
                     }
                     catch (Tango::DevFailed &)
                     {
+                        if (!att.get_value_flag())
+                        {
+                            WARN_STREAM
+                                << "Attribute has no value, forcing INVALID quality for: "
+                                << att.get_name() << std::endl;
+                            att.set_quality(Tango::ATTR_INVALID);
+                        }
+
                         for (j = 0; j < i; j++)
                         {
                             long idx;

--- a/cppapi/server/log4tango.h
+++ b/cppapi/server/log4tango.h
@@ -64,33 +64,39 @@
 #define LOG_DEBUG(X) \
     get_logger()->debug X
 
-#define FATAL_STREAM \
-  if (get_logger()->is_fatal_enabled()) \
-    get_logger()->fatal_stream() \
+#define DEV_FATAL_STREAM(device) \
+  if (device->get_logger()->is_fatal_enabled()) \
+    device->get_logger()->fatal_stream() \
       << log4tango::LogInitiator::_begin_log
 
-#define ERROR_STREAM \
-  if (get_logger()->is_error_enabled()) \
-    get_logger()->error_stream() \
+#define DEV_ERROR_STREAM(device) \
+  if (device->get_logger()->is_error_enabled()) \
+    device->get_logger()->error_stream() \
       << log4tango::LogInitiator::_begin_log
 
-#define WARN_STREAM \
-  if (get_logger()->is_warn_enabled()) \
-    get_logger()->warn_stream() \
+#define DEV_WARN_STREAM(device) \
+  if (device->get_logger()->is_warn_enabled()) \
+    device->get_logger()->warn_stream() \
       << log4tango::LogInitiator::_begin_log
 
-#define INFO_STREAM \
-  if (get_logger()->is_info_enabled()) \
-    get_logger()->info_stream() \
+#define DEV_INFO_STREAM(device) \
+  if (device->get_logger()->is_info_enabled()) \
+    device->get_logger()->info_stream() \
       << log4tango::LogInitiator::_begin_log
 
-#define DEBUG_STREAM \
-  if (get_logger()->is_debug_enabled()) \
-    get_logger()->debug_stream() \
+#define DEV_DEBUG_STREAM(device) \
+  if (device->get_logger()->is_debug_enabled()) \
+    device->get_logger()->debug_stream() \
       << log4tango::LogInitiator::_begin_log
 
 #define ENDLOG \
   log4tango::LogSeparator::_end_log
+
+#define FATAL_STREAM DEV_FATAL_STREAM(this)
+#define ERROR_STREAM DEV_ERROR_STREAM(this)
+#define WARN_STREAM DEV_WARN_STREAM(this)
+#define INFO_STREAM DEV_INFO_STREAM(this)
+#define DEBUG_STREAM DEV_DEBUG_STREAM(this)
 
 //-------------------------------------------------------------
 // A CLASS TO LOG IN THE NAME OF DEVICE (USING DEV'S LOGGER)


### PR DESCRIPTION
Fix for following scenario:
* there is an alarm configured for an attribute
* Device::dev_state is evaluated
* attribute's read callback throws DevFailed before calling set_value
* attempt to evaluate alarm fails (segfault during access to value which is not set)

Proposed correction is to silently skip such attribute during alarm evaluation (it will not contribute to device's ALARM state). @bourtemb, is this acceptable solution?

I have two other points I'd like to discuss:
* To simplify the reproduction, I had to reset attribute's value pointer after it was deleted. Otherwise something else was allocated in that memory and I was getting garbage read instead of a segfault. I propose to define an action to reset all the pointers after corresponding memory is deleted (applies only to pointers that can be reused, e.g. global or member variables). We may find some new issues that way.
* There is a lot of duplicated code in `attribute.cpp` and in `attrsetval.cpp` for different data types. It could be easily removed and replaced with template code. Maybe we should define an action to remove duplications (for now I've re-set only `value.lg_seq` - see previous point).

BTW all commits are failed on appveyor because MSVC don't like `not` operator. I've fixed this just now.