### PR TITLE
Be compatible with all in-use cppzmq versions.

### DIFF
--- a/cppapi/client/zmqeventconsumer.cpp
+++ b/cppapi/client/zmqeventconsumer.cpp
@@ -3546,6 +3546,7 @@ ReceivedFromAdmin ZmqEventConsumer::initialize_received_from_admin(const Tango::
     return result;
 }
 
+#ifdef ZMQ_HAS_DISCONNECT
 void ZmqEventConsumer::disconnect_socket(zmq::socket_t& socket, const char* endpoint)
 {
     try
@@ -3561,6 +3562,11 @@ void ZmqEventConsumer::disconnect_socket(zmq::socket_t& socket, const char* endp
         }
     }
 }
+#else
+void ZmqEventConsumer::disconnect_socket(zmq::socket_t& TANGO_UNUSED(socket), const char* TANGO_UNUSED(endpoint))
+{
+}
+#endif
 
 //--------------------------------------------------------------------------------------------------------------------
 //

--- a/cppapi/client/zmqeventconsumer.cpp
+++ b/cppapi/client/zmqeventconsumer.cpp
@@ -181,9 +181,9 @@ void *ZmqEventConsumer::run_undetached(TANGO_UNUSED(void *arg))
 	zmq::pollitem_t *items = new zmq::pollitem_t [MAX_SOCKET_SUB];
 	int nb_poll_item = 3;
 
-	items[0].socket = *control_sock;
-	items[1].socket = *heartbeat_sub_sock;
-	items[2].socket = *event_sub_sock;
+	items[0].socket = static_cast<void*>(*control_sock);
+	items[1].socket = static_cast<void*>(*heartbeat_sub_sock);
+	items[2].socket = static_cast<void*>(*event_sub_sock);
 
 	for (int loop = 0;loop < nb_poll_item;loop++)
 	{
@@ -1063,7 +1063,7 @@ bool ZmqEventConsumer::process_ctrl(zmq::message_t &received_ctrl,zmq::pollitem_
 // Update poll item list
 //
 
-                poll_list[old_poll_nb].socket = *tmp_sock;
+                poll_list[old_poll_nb].socket = static_cast<void*>(*tmp_sock);
                 poll_list[old_poll_nb].fd = 0;
                 poll_list[old_poll_nb].events = ZMQ_POLLIN;
                 poll_list[old_poll_nb].revents = 0;

--- a/cppapi/server/zmqeventsupplier.cpp
+++ b/cppapi/server/zmqeventsupplier.cpp
@@ -686,7 +686,7 @@ void ZmqEventSupplier::create_mcast_socket(std::string &mcast_data,int rate,Mcas
 // Bind the publisher socket to the specified port
 //
 
-    if (zmq_bind(*(ms.pub_socket),ms.endpoint.c_str()) != 0)
+    if (zmq_bind(static_cast<void*>(*ms.pub_socket),ms.endpoint.c_str()) != 0)
     {
         TangoSys_OMemStream o;
         o << "Can't bind ZMQ socket with endpoint ";


### PR DESCRIPTION
Follow up from #530.

Close #499.
Close #273.
Close #535.