### PR TITLE
Remove some compiler warnings

### DIFF
--- a/configure/CMakeLists.txt
+++ b/configure/CMakeLists.txt
@@ -191,8 +191,7 @@ if(NOT WIN32)
         message("The compiler ${CMAKE_CXX_COMPILER} has no C++11/14 support. You may not benefit from performance optimizations.")
     endif()
 
-    #setup for GNU CXX compiler
-    if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
         message("found GNU compiler ...")
         if(CMAKE_BUILD_TYPE MATCHES RELEASE)
             message("setup for release build ...")

--- a/cpp_test_suite/asyn/asyn_attr.cpp
+++ b/cpp_test_suite/asyn/asyn_attr.cpp
@@ -65,7 +65,7 @@ int main(int argc, char **argv)
 				assert( db == 5.55 );
 				finish = true;
 			}
-			catch (AsynReplyNotArrived )
+			catch (AsynReplyNotArrived&)
 			{
 				finish = false;
 				coutv << "Attribute not yet read" << std::endl;
@@ -103,7 +103,7 @@ int main(int argc, char **argv)
 				assert( enc_data.encoded_data.length() == 4 );
 				finish = true;
 			}
-			catch (AsynReplyNotArrived )
+			catch (AsynReplyNotArrived&)
 			{
 				finish = false;
 				coutv << "Attribute not yet read" << std::endl;
@@ -136,7 +136,7 @@ int main(int argc, char **argv)
 				assert( l == 5.55 );
 				finish = true;
 			}
-			catch (AsynReplyNotArrived )
+			catch (AsynReplyNotArrived&)
 			{
 				coutv << "Attribute not yet read" << std::endl;
 				nb_not_arrived++;
@@ -191,7 +191,7 @@ int main(int argc, char **argv)
 				finish = true;
 				delete received;
 			}
-			catch (AsynReplyNotArrived )
+			catch (AsynReplyNotArrived&)
 			{
 				finish = false;
 				nb_not_arrived++;
@@ -233,7 +233,7 @@ int main(int argc, char **argv)
 				finish = true;
 				delete received;
 			}
-			catch (AsynReplyNotArrived )
+			catch (AsynReplyNotArrived&)
 			{
 				coutv << "Attribute not yet read" << std::endl;
 				nb_not_arrived++;
@@ -313,7 +313,7 @@ int main(int argc, char **argv)
 				double db;
 				(*received) >> db;
 			}
-			catch (AsynReplyNotArrived )
+			catch (AsynReplyNotArrived&)
 			{
 				finish = false;
 				nb_not_arrived++;
@@ -357,7 +357,7 @@ int main(int argc, char **argv)
 				double db;
 				(*received) >> db;
 			}
-			catch (AsynReplyNotArrived )
+			catch (AsynReplyNotArrived&)
 			{
 				coutv << "Attribute not yet read" << std::endl;
 			}

--- a/cpp_test_suite/asyn/asyn_attr_cb.cpp
+++ b/cpp_test_suite/asyn/asyn_attr_cb.cpp
@@ -228,7 +228,7 @@ int main(int argc, char **argv)
 			{
 				device->get_asynch_replies(500);
 			}
-			catch (AsynReplyNotArrived )
+			catch (AsynReplyNotArrived&)
 			{
 				coutv << "Attribute not yet read" << std::endl;
 				nb_not_arrived++;
@@ -310,7 +310,7 @@ int main(int argc, char **argv)
 			{
 				device->get_asynch_replies(500);
 			}
-			catch (AsynReplyNotArrived )
+			catch (AsynReplyNotArrived&)
 			{
 				coutv << "Attribute not yet read" << std::endl;
 				nb_not_arrived++;

--- a/cpp_test_suite/asyn/asyn_attr_multi.cpp
+++ b/cpp_test_suite/asyn/asyn_attr_multi.cpp
@@ -73,7 +73,7 @@ int main(int argc, char **argv)
 				assert( sh == 12 );
 				finish = true;
 			}
-			catch (AsynReplyNotArrived )
+			catch (AsynReplyNotArrived&)
 			{
 				finish = false;
 				coutv << "Attribute not yet read" << std::endl;
@@ -110,7 +110,7 @@ int main(int argc, char **argv)
 				assert( s == 12 );
 				finish = true;
 			}
-			catch (AsynReplyNotArrived )
+			catch (AsynReplyNotArrived&)
 			{
 				coutv << "Attribute not yet read" << std::endl;
 				nb_not_arrived++;
@@ -169,7 +169,7 @@ int main(int argc, char **argv)
 				finish = true;
 				delete received;
 			}
-			catch (AsynReplyNotArrived )
+			catch (AsynReplyNotArrived&)
 			{
 				finish = false;
 				nb_not_arrived++;
@@ -211,7 +211,7 @@ int main(int argc, char **argv)
 				finish = true;
 				delete received;
 			}
-			catch (AsynReplyNotArrived )
+			catch (AsynReplyNotArrived&)
 			{
 				coutv << "Attributes not yet read" << std::endl;
 				nb_not_arrived++;
@@ -306,7 +306,7 @@ int main(int argc, char **argv)
 					(*received)[1] >> sh;
 				delete received;
 			}
-			catch (AsynReplyNotArrived )
+			catch (AsynReplyNotArrived&)
 			{
 				finish = false;
 				nb_not_arrived++;
@@ -341,7 +341,7 @@ int main(int argc, char **argv)
 				received = device->read_attributes_reply(id,500);
 				finish = true;
 			}
-			catch (AsynReplyNotArrived )
+			catch (AsynReplyNotArrived&)
 			{
 				coutv << "Attributes not yet read" << std::endl;
 			}

--- a/cpp_test_suite/asyn/asyn_cb2.cpp
+++ b/cpp_test_suite/asyn/asyn_cb2.cpp
@@ -144,7 +144,7 @@ int main(int argc, char **argv)
 			{
 				device->get_asynch_replies(300);
 			}
-			catch (AsynReplyNotArrived )
+			catch (AsynReplyNotArrived&)
 			{
 				nb_not_arrived++;
 				coutv << "Command not yet arrived" << std::endl;
@@ -233,7 +233,7 @@ int main(int argc, char **argv)
 			{
 				ApiUtil::instance()->get_asynch_replies(300);
 			}
-			catch (AsynReplyNotArrived )
+			catch (AsynReplyNotArrived&)
 			{
 				nb_not_arrived++;
 				coutv << "Command not yet arrived" << std::endl;

--- a/cpp_test_suite/asyn/asyn_cb_cmd.cpp
+++ b/cpp_test_suite/asyn/asyn_cb_cmd.cpp
@@ -136,7 +136,7 @@ int main(int argc, char **argv)
 			{
 				device->get_asynch_replies(200);
 			}
-			catch (AsynReplyNotArrived )
+			catch (AsynReplyNotArrived&)
 			{
 				coutv << "Command not yet arrived" << std::endl;
 				nb_not_arrived++;
@@ -216,7 +216,7 @@ int main(int argc, char **argv)
 			{
 				device->get_asynch_replies(500);
 			}
-			catch (AsynReplyNotArrived )
+			catch (AsynReplyNotArrived&)
 			{
 				coutv << "Command not yet arrived" << std::endl;
 				nb_not_arrived++;
@@ -300,7 +300,7 @@ int main(int argc, char **argv)
 			{
 				device->get_asynch_replies(500);
 			}
-			catch (AsynReplyNotArrived )
+			catch (AsynReplyNotArrived&)
 			{
 				coutv << "Command not yet arrived" << std::endl;
 				nb_not_arrived++;

--- a/cpp_test_suite/asyn/asyn_cmd.cpp
+++ b/cpp_test_suite/asyn/asyn_cmd.cpp
@@ -67,7 +67,7 @@ int main(int argc, char **argv)
 				assert( l == 8 );
 				finish = true;
 			}
-			catch (AsynReplyNotArrived)
+			catch (AsynReplyNotArrived&)
 			{
 				finish = false;
 				coutv << "Command not yet arrived" << std::endl;
@@ -99,7 +99,7 @@ int main(int argc, char **argv)
 				assert( l == 8 );
 				finish = true;
 			}
-			catch (AsynReplyNotArrived)
+			catch (AsynReplyNotArrived&)
 			{
 				coutv << "Command not yet arrived" << std::endl;
 				nb_not_arrived++;
@@ -154,7 +154,7 @@ int main(int argc, char **argv)
 				dout = device->command_inout_reply(id);
 				finish = true;
 			}
-			catch (AsynReplyNotArrived)
+			catch (AsynReplyNotArrived&)
 			{
 				finish = false;
 				nb_not_arrived++;
@@ -195,7 +195,7 @@ int main(int argc, char **argv)
 				dout = device->command_inout_reply(id,500);
 				finish = true;
 			}
-			catch (AsynReplyNotArrived)
+			catch (AsynReplyNotArrived&)
 			{
 				coutv << "Command not yet arrived" << std::endl;
 				nb_not_arrived++;
@@ -275,7 +275,7 @@ int main(int argc, char **argv)
 				dout = device->command_inout_reply(id);
 				finish = true;
 			}
-			catch (AsynReplyNotArrived )
+			catch (AsynReplyNotArrived&)
 			{
 				finish = false;
 				nb_not_arrived++;
@@ -315,7 +315,7 @@ int main(int argc, char **argv)
 				dout = device->command_inout_reply(id,500);
 				finish = true;
 			}
-			catch (AsynReplyNotArrived )
+			catch (AsynReplyNotArrived&)
 			{
 				coutv << "Command not yet arrived" << std::endl;
 			}

--- a/cpp_test_suite/asyn/asyn_write_attr.cpp
+++ b/cpp_test_suite/asyn/asyn_write_attr.cpp
@@ -66,7 +66,7 @@ int main(int argc, char **argv)
 				device->write_attribute_reply(id);
 				finish = true;
 			}
-			catch (AsynReplyNotArrived )
+			catch (AsynReplyNotArrived&)
 			{
 				finish = false;
 				coutv << "Attribute not yet written" << std::endl;
@@ -106,7 +106,7 @@ int main(int argc, char **argv)
 				device->write_attribute_reply(id);
 				finish = true;
 			}
-			catch (AsynReplyNotArrived )
+			catch (AsynReplyNotArrived&)
 			{
 				finish = false;
 				coutv << "Attribute not yet written" << std::endl;
@@ -135,7 +135,7 @@ int main(int argc, char **argv)
 				device->write_attribute_reply(id,200);
 				finish = true;
 			}
-			catch (AsynReplyNotArrived )
+			catch (AsynReplyNotArrived&)
 			{
 				coutv << "Attribute not yet written" << std::endl;
 				nb_not_arrived++;
@@ -184,7 +184,7 @@ int main(int argc, char **argv)
 				device->write_attribute_reply(id);
 				finish = true;
 			}
-			catch (AsynReplyNotArrived )
+			catch (AsynReplyNotArrived&)
 			{
 				finish = false;
 				nb_not_arrived++;
@@ -225,7 +225,7 @@ int main(int argc, char **argv)
 				device->write_attribute_reply(id,500);
 				finish = true;
 			}
-			catch (AsynReplyNotArrived )
+			catch (AsynReplyNotArrived&)
 			{
 				coutv << "Attribute not yet written" << std::endl;
 				nb_not_arrived++;
@@ -304,7 +304,7 @@ int main(int argc, char **argv)
 				device->write_attribute_reply(id);
 				finish = true;
 			}
-			catch (AsynReplyNotArrived )
+			catch (AsynReplyNotArrived&)
 			{
 				finish = false;
 				nb_not_arrived++;
@@ -345,7 +345,7 @@ int main(int argc, char **argv)
 				device->write_attribute_reply(id,200);
 				finish = true;
 			}
-			catch (AsynReplyNotArrived )
+			catch (AsynReplyNotArrived&)
 			{
 				coutv << "Attribute not yet written" << std::endl;
 			}

--- a/cpp_test_suite/asyn/asyn_write_attr_multi.cpp
+++ b/cpp_test_suite/asyn/asyn_write_attr_multi.cpp
@@ -75,7 +75,7 @@ int main(int argc, char **argv)
 				device->write_attributes_reply(id);
 				finish = true;
 			}
-			catch (AsynReplyNotArrived )
+			catch (AsynReplyNotArrived&)
 			{
 				finish = false;
 				coutv << "Attributes not yet written" << std::endl;
@@ -105,7 +105,7 @@ int main(int argc, char **argv)
 				device->write_attributes_reply(id,200);
 				finish = true;
 			}
-			catch (AsynReplyNotArrived )
+			catch (AsynReplyNotArrived&)
 			{
 				coutv << "Attributes not yet written" << std::endl;
 				nb_not_arrived++;
@@ -154,7 +154,7 @@ int main(int argc, char **argv)
 				device->write_attributes_reply(id);
 				finish = true;
 			}
-			catch (AsynReplyNotArrived )
+			catch (AsynReplyNotArrived&)
 			{
 				finish = false;
 				nb_not_arrived++;
@@ -195,7 +195,7 @@ int main(int argc, char **argv)
 				device->write_attributes_reply(id,200);
 				finish = true;
 			}
-			catch (AsynReplyNotArrived )
+			catch (AsynReplyNotArrived&)
 			{
 				coutv << "Attributes not yet written" << std::endl;
 				nb_not_arrived++;
@@ -276,7 +276,7 @@ int main(int argc, char **argv)
 				device->write_attributes_reply(id);
 				finish = true;
 			}
-			catch (AsynReplyNotArrived )
+			catch (AsynReplyNotArrived&)
 			{
 				finish = false;
 				nb_not_arrived++;
@@ -325,7 +325,7 @@ int main(int argc, char **argv)
 				device->write_attributes_reply(id,500);
 				finish = true;
 			}
-			catch (AsynReplyNotArrived )
+			catch (AsynReplyNotArrived&)
 			{
 				coutv << "Attribute not yet written" << std::endl;
 			}

--- a/cpp_test_suite/asyn/asyn_write_attr_multi.cpp
+++ b/cpp_test_suite/asyn/asyn_write_attr_multi.cpp
@@ -267,7 +267,8 @@ int main(int argc, char **argv)
 		finish = false;
 		bool failed = false;
 		nb_not_arrived = 0;
-		long nb_except,faulty_idx;
+		long nb_except = 0;
+		long faulty_idx = 0;
 		while (finish == false)
 		{
 			try

--- a/cpp_test_suite/asyn/asyn_write_cb.cpp
+++ b/cpp_test_suite/asyn/asyn_write_cb.cpp
@@ -160,7 +160,7 @@ int main(int argc, char **argv)
 			{
 				device->get_asynch_replies(200);
 			}
-			catch (AsynReplyNotArrived )
+			catch (AsynReplyNotArrived &)
 			{
 				coutv << "Attribute not yet written" << std::endl;
 				nb_not_arrived++;
@@ -248,7 +248,7 @@ int main(int argc, char **argv)
 			{
 				device->get_asynch_replies(500);
 			}
-			catch (AsynReplyNotArrived )
+			catch (AsynReplyNotArrived &)
 			{
 				coutv << "Attribute not yet written" << std::endl;
 				nb_not_arrived++;
@@ -339,7 +339,7 @@ int main(int argc, char **argv)
 			{
 				device->get_asynch_replies(500);
 			}
-			catch (AsynReplyNotArrived )
+			catch (AsynReplyNotArrived &)
 			{
 				coutv << "Attribute not yet written" << std::endl;
 				nb_not_arrived++;

--- a/cpp_test_suite/cpp_test_ds/DevTestClass.cpp
+++ b/cpp_test_suite/cpp_test_ds/DevTestClass.cpp
@@ -63,7 +63,7 @@ DevTestClass *DevTestClass::init(const char *name)
 			std::string s(name);
 			_instance = new DevTestClass(s);
 		}
-		catch (std::bad_alloc)
+		catch (std::bad_alloc&)
 		{
 			throw;
 		}

--- a/cpp_test_suite/cpp_test_ds/main.cpp
+++ b/cpp_test_suite/cpp_test_ds/main.cpp
@@ -36,7 +36,7 @@ int main(int argc,char *argv[])
 
 		tg->server_run();
 	}
-	catch (std::bad_alloc)
+	catch (std::bad_alloc&)
 	{
 		cout << "Can't allocate memory to store device object !!!" << std::endl;
 		cout << "Exiting" << std::endl;

--- a/cpp_test_suite/new_tests/cxx_asyn_reconnection.cpp
+++ b/cpp_test_suite/new_tests/cxx_asyn_reconnection.cpp
@@ -121,7 +121,7 @@ public:
 					device1->write_attribute_reply(id);
 					finish = true;
 				}
-				catch (AsynReplyNotArrived)
+				catch (AsynReplyNotArrived&)
 				{
 					finish = false;
 					coutv << "Attribute not yet written" << endl;
@@ -179,7 +179,7 @@ public:
                     device1->write_attribute_reply(id);
                     finish = true;
                 }
-                catch (AsynReplyNotArrived)
+                catch (AsynReplyNotArrived&)
                 {
                     finish = false;
                     coutv << "Attribute not yet written" << endl;
@@ -210,7 +210,7 @@ public:
 					assert( val == 444 );
 					finish = true;
 				}
-				catch (AsynReplyNotArrived )
+				catch (AsynReplyNotArrived&)
 				{
 					finish = false;
 					coutv << "Attribute not yet read" << endl;

--- a/cpp_test_suite/new_tests/cxx_old_poll.cpp
+++ b/cpp_test_suite/new_tests/cxx_old_poll.cpp
@@ -43,13 +43,14 @@ protected:
     int hist_depth;
 
 public:
-    SUITE_NAME() : hist_depth{10}, admin_dev_name{"dserver/"},
+    SUITE_NAME() : admin_dev_name{"dserver/"},
                    inst_name{"debian8"},//TODO pass from cmd
                    new_dev{"test/debian8/77"},
                    new_dev1_th2{"test/debian8/800"},
                    new_dev2_th2{"test/debian8/801"},
                    new_dev1_th3{"test/debian8/9000"},
-                   ref_polling_pool_conf{1, "test/debian8/10,test/debian8/11"} {
+                   ref_polling_pool_conf{1, "test/debian8/10,test/debian8/11"},
+                   hist_depth{10} {
 
 //
 // Arguments check -------------------------------------------------

--- a/cpp_test_suite/new_tests/cxx_stateless_subscription.cpp
+++ b/cpp_test_suite/new_tests/cxx_stateless_subscription.cpp
@@ -123,8 +123,7 @@ public:
 //
     void test_re_subscribe_and_check(void) {
         string att_name("event_change_tst");
-        int eventID;
-        TS_ASSERT_THROWS_NOTHING(eventID = device2->subscribe_event(att_name, Tango::CHANGE_EVENT, &eventCallback, true));
+        TS_ASSERT_THROWS_NOTHING(device2->subscribe_event(att_name, Tango::CHANGE_EVENT, &eventCallback, true));
 
 //
 // Wait for connection and event

--- a/cpp_test_suite/old_tests/locked_device.cpp
+++ b/cpp_test_suite/old_tests/locked_device.cpp
@@ -1,4 +1,4 @@
-/* 
+/*
  * Small utility program to help testing locking features.
  *
  * Possible return code:
@@ -22,7 +22,7 @@ using namespace std;
 int main(int argc, char **argv)
 {
 	DeviceProxy *device;
-	
+
 	if ((argc == 1) || (argc > 3))
 	{
 		cout << "usage: %s device [-v] " << endl;
@@ -30,14 +30,14 @@ int main(int argc, char **argv)
 	}
 
 	string device_name = argv[1];
-	
+
 	if (argc == 3)
 	{
 		if (strcmp(argv[2],"-v") == 0)
 			verbose = true;
-	}	
+	}
 
-	try 
+	try
 	{
 		device = new DeviceProxy(device_name);
 	}
@@ -66,7 +66,7 @@ int main(int argc, char **argv)
 
 	try
 	{
-		dout = device->command_inout("IOShort",din);					
+		dout = device->command_inout("IOShort",din);
 	}
 	catch (Tango::DevFailed &e)
 	{
@@ -88,7 +88,7 @@ int main(int argc, char **argv)
 			dout = device->command_inout_reply(id);
 			finish = true;
 		}
-		catch (AsynReplyNotArrived)
+		catch (AsynReplyNotArrived&)
 		{
 			finish = false;
 			coutv << "Command not yet arrived" << endl;
@@ -133,7 +133,7 @@ int main(int argc, char **argv)
 			device->write_attribute_reply(id);
 			finish = true;
 		}
-		catch (AsynReplyNotArrived)
+		catch (AsynReplyNotArrived&)
 		{
 			finish = false;
 			coutv << "Attribute not yet written" << endl;
@@ -171,7 +171,7 @@ int main(int argc, char **argv)
 			return 1;
 	}
 
-	delete device;		
+	delete device;
 	return 0;
-	
+
 }

--- a/cppapi/client/devapi_base.cpp
+++ b/cppapi/client/devapi_base.cpp
@@ -4104,7 +4104,7 @@ AttributeInfoList *DeviceProxy::get_attribute_config(std::vector<std::string> &a
                                               desc.str(),
                                               (const char *) "DeviceProxy::get_attribute_config()");
         }
-        catch (Tango::DevFailed)
+        catch (Tango::DevFailed&)
         {
             delete dev_attr_config;
             throw;
@@ -4334,7 +4334,7 @@ AttributeInfoListEx *DeviceProxy::get_attribute_config_ex(std::vector<std::strin
                                               desc.str(),
                                               (const char *) "DeviceProxy::get_attribute_config()");
         }
-        catch (Tango::DevFailed)
+        catch (Tango::DevFailed&)
         {
             delete dev_attr_config;
             throw;
@@ -5087,7 +5087,7 @@ PipeInfoList *DeviceProxy::get_pipe_config(std::vector<std::string> &pipe_string
             ApiCommExcept::re_throw_exception(ce, "API_CommunicationFailed",
                                               desc.str(), "DeviceProxy::get_pipe_config()");
         }
-        catch (Tango::DevFailed)
+        catch (Tango::DevFailed&)
         {
             delete dev_pipe_config;
             throw;

--- a/cppapi/client/filedatabase.cpp
+++ b/cppapi/client/filedatabase.cpp
@@ -717,7 +717,11 @@ std::string FileDatabase::parse_res_file(const std::string &file_name)
 		    	 			break;
 
 	           			default:
-                     				return "COLON or -> expected at line " + StartLine;
+						{
+							TangoSys_MemStream desc;
+							desc << "COLON or -> expected at line " << StartLine;
+							return desc.str();
+						}
 
 	         			}
 	         			break;
@@ -795,7 +799,11 @@ std::string FileDatabase::parse_res_file(const std::string &file_name)
 		 			break;
 
 	       			default:
-                 			return "SLASH or -> expected at line " + StartLine;
+					{
+						TangoSys_MemStream desc;
+						desc << "SLASH or -> expected at line " << StartLine;
+						return desc.str();
+					}
 
 	     			}
 	     			break;
@@ -848,13 +856,21 @@ std::string FileDatabase::parse_res_file(const std::string &file_name)
 	     			break;
 
 	   		default:
-             			return "SLASH or -> expected at line " + StartLine;
+				{
+					TangoSys_MemStream desc;
+					desc << "SLASH or -> expected at line " << StartLine;
+					return desc.str();
+				}
 			}
 			break;
 
       		default:
-        		return "Invalid resource name get  instead of STRING al line " + StartLine;
-      		}
+			{
+				TangoSys_MemStream desc;
+				desc << "Invalid resource name get  instead of STRING al line " << StartLine;
+				return desc.str();
+			}
+		}
 
       		eof=(word == lexical_word_null);
      		}

--- a/cppapi/client/filedatabase.cpp
+++ b/cppapi/client/filedatabase.cpp
@@ -233,6 +233,7 @@ FileDatabaseExt::~FileDatabaseExt() {}
 
 
 FileDatabase::FileDatabase(const std::string& file_name)
+  :ext(new FileDatabaseExt)
 {
 	cout4 << "FILEDATABASE: FileDatabase constructor" << endl;
 	filename = file_name;
@@ -286,6 +287,9 @@ FileDatabase::~FileDatabase()
 		delete (*j);
 	}
 
+#ifndef HAS_UNIQUE_PTR
+	delete ext;
+#endif
 }
 
 // ****************************************************

--- a/cppapi/client/filedatabase.h
+++ b/cppapi/client/filedatabase.h
@@ -209,7 +209,11 @@ private:
   	bool 			DELETE_ENTRY;
   	std::string 			word;
 
-	FileDatabaseExt	*ext;
+#ifdef HAS_UNIQUE_PTR
+    std::unique_ptr<FileDatabaseExt> ext;
+#else
+    FileDatabaseExt	*ext;
+#endif
 };
 
 } // end namespace Tango

--- a/cppapi/client/filedatabase.h
+++ b/cppapi/client/filedatabase.h
@@ -198,15 +198,11 @@ private:
 	static int ReadBufferSize;
 	static int MaxWordLength;
 
-
-	int 			length_buf;
-  	int 			pos_buf;
   	int 			CrtLine;
   	int 			StartLine;
   	char 			CurrentChar;
   	char 			NextChar;
 
-  	bool 			DELETE_ENTRY;
   	std::string 			word;
 
 #ifdef HAS_UNIQUE_PTR

--- a/cppapi/client/group.cpp
+++ b/cppapi/client/group.cpp
@@ -198,16 +198,7 @@ GroupReply::GroupReply ()
 {
 
 }
-//-----------------------------------------------------------------------------
-GroupReply::GroupReply (const GroupReply& _src)
- : dev_name_m(_src.dev_name_m),
-   obj_name_m(_src.obj_name_m),
-   has_failed_m(_src.has_failed_m),
-   group_element_enabled_m(_src.group_element_enabled_m),
-   exception_m(_src.exception_m)
-{
 
-}
 //-----------------------------------------------------------------------------
 GroupReply::GroupReply (const std::string& _dev_name,
                         const std::string& _obj_name,

--- a/cppapi/client/group.h
+++ b/cppapi/client/group.h
@@ -141,8 +141,7 @@ public:
 ///@privatesection
   //- default ctor
   GroupReply ();
-  //- copy ctor
-  GroupReply (const GroupReply& src);
+
   //- ctor
   GroupReply (const std::string& dev_name,
               const std::string& obj_name,

--- a/cppapi/client/helpers/DeviceProxyHelper.h
+++ b/cppapi/client/helpers/DeviceProxyHelper.h
@@ -420,7 +420,7 @@ namespace Tango
 		//  Overloaded commands to  avoid usage of DevVarXX ARRAY for argout
 		//---------------------------------------------------------------------------
 		template <class _IN>
-			void internal_command_inout (const std::string& cmd_name, const _IN& argin, DevVarDoubleStringArray* argout,std::string file= __FILE__, int line= __LINE__)
+			void internal_command_inout (const std::string& TANGO_UNUSED(cmd_name), const _IN& TANGO_UNUSED(argin), DevVarDoubleStringArray* TANGO_UNUSED(argout), std::string file= __FILE__, int line= __LINE__)
 		{
 #if (defined(_MSC_VER) && _MSC_VER < 1300)
 #pragma message  (" TANGO WARNING ***** command_inout:Use only STL vector instead of DevVarDoubleStringArray *****")
@@ -437,7 +437,7 @@ namespace Tango
 		//  Overloaded commands to  avoid usage of DevVarXX ARRAY for argout
 		//---------------------------------------------------------------------------
 		template <class _IN>
-			void internal_command_inout (const std::string& cmd_name, const _IN& argin, DevVarLongStringArray* argout,std::string file= __FILE__, int line= __LINE__)
+			void internal_command_inout (const std::string& TANGO_UNUSED(cmd_name), const _IN& TANGO_UNUSED(argin), DevVarLongStringArray* TANGO_UNUSED(argout), std::string file= __FILE__, int line= __LINE__)
 		{
 #if (defined(_MSC_VER) && _MSC_VER < 1300)
 #pragma message  (" TANGO WARNING ***** command_inout:Use only STL vector instead of DevVarLongStringArray *****")
@@ -453,7 +453,7 @@ namespace Tango
 		//  Overloaded commands to  avoid usage of DevVarXX ARRAY for argout
 		//---------------------------------------------------------------------------
 		template <class _IN>
-			void internal_command_inout (const std::string& cmd_name, const _IN& argin, DevVarDoubleStringArray& argout,std::string file= __FILE__, int line= __LINE__)
+			void internal_command_inout (const std::string& TANGO_UNUSED(cmd_name), const _IN& TANGO_UNUSED(argin), DevVarDoubleStringArray& TANGO_UNUSED(argout), std::string file= __FILE__, int line= __LINE__)
 		{
 #if (defined(_MSC_VER) && _MSC_VER < 1300)
 #pragma message  (" TANGO WARNING ***** command_inout:Use only STL vector instead of DevVarDoubleStringArray *****")
@@ -470,7 +470,7 @@ namespace Tango
 		//  Overloaded commands to  avoid usage of DevVarXX ARRAY for argout
 		//---------------------------------------------------------------------------
 		template <class _IN>
-			void internal_command_inout (const std::string& cmd_name, const _IN& argin, DevVarLongStringArray& argout,std::string file= __FILE__, int line= __LINE__)
+			void internal_command_inout (const std::string& TANGO_UNUSED(cmd_name), const _IN& TANGO_UNUSED(argin), DevVarLongStringArray& TANGO_UNUSED(argout), std::string file= __FILE__, int line= __LINE__)
 		{
 #if (defined(_MSC_VER) && _MSC_VER < 1300)
 #pragma message  (" TANGO WARNING ***** command_inout:Use only STL vector instead of DevVarLongStringArray *****")
@@ -608,7 +608,7 @@ namespace Tango
 		//  Overloaded commands to  avoid usage of DevVarDoubleStringArray ARRAY
 		//---------------------------------------------------------------------------
 		template <class _OUT>
-			void internal_command_out(_OUT dummy, DevVarDoubleStringArray* argout,  std::string file= __FILE__, int line= __LINE__)
+			void internal_command_out(_OUT TANGO_UNUSED(dummy), DevVarDoubleStringArray* TANGO_UNUSED(argout),  std::string file= __FILE__, int line= __LINE__)
 		{
 #if (defined(_MSC_VER) && _MSC_VER < 1300)
 #pragma message  (" TANGO WARNING ***** command_out:Use only STL vector instead of DevVarDoubleStringArray *****")
@@ -626,7 +626,7 @@ namespace Tango
 		//  Overloaded commands to  avoid usage of DevVarLongStringArray ARRAY
 		//---------------------------------------------------------------------------
 		template <class _OUT>
-			void internal_command_out (_OUT dummy, DevVarLongStringArray* argout,  std::string file= __FILE__, int line= __LINE__)
+			void internal_command_out (_OUT TANGO_UNUSED(dummy), DevVarLongStringArray* TANGO_UNUSED(argout),  std::string file= __FILE__, int line= __LINE__)
 		{
 #if (defined(_MSC_VER) && _MSC_VER < 1300)
 #pragma message  (" TANGO WARNING ***** command_out:Use only STL vector instead of DevVarLongStringArray *****")
@@ -642,7 +642,7 @@ namespace Tango
 		//  Overloaded commands to  avoid usage of DevVarDoubleStringArray ARRAY
 		//---------------------------------------------------------------------------
 		template <class _OUT>
-			void internal_command_out(_OUT dummy, DevVarDoubleStringArray& argout,  std::string file= __FILE__, int line= __LINE__)
+			void internal_command_out(_OUT TANGO_UNUSED(dummy), DevVarDoubleStringArray& TANGO_UNUSED(argout),  std::string file= __FILE__, int line= __LINE__)
 		{
 #if (defined(_MSC_VER) && _MSC_VER < 1300)
 #pragma message  (" TANGO WARNING ***** command_out:Use only STL vector instead of DevVarDoubleStringArray *****")
@@ -658,7 +658,7 @@ namespace Tango
 		//  Overloaded commands to  avoid usage of DevVarLongStringArray ARRAY
 		//---------------------------------------------------------------------------
 		template <class _OUT>
-			void internal_command_out (_OUT dummy, DevVarLongStringArray& argout,  std::string file= __FILE__, int line= __LINE__)
+			void internal_command_out (_OUT TANGO_UNUSED(dummy), DevVarLongStringArray& TANGO_UNUSED(argout),  std::string file= __FILE__, int line= __LINE__)
 		{
 #if (defined(_MSC_VER) && _MSC_VER < 1300)
 #pragma message  (" TANGO WARNING ***** command_out:Use only STL vector instead of DevVarLongStringArray *****")

--- a/cppapi/server/dintrthread.cpp
+++ b/cppapi/server/dintrthread.cpp
@@ -178,7 +178,6 @@ DevIntrCmdType DevIntrThread::get_command(DevLong tout)
 
 void DevIntrThread::execute_cmd()
 {
-	std::vector<std::string>::iterator pos;
 	bool need_exit = false;
 
 	switch (local_cmd.cmd_code)
@@ -241,7 +240,7 @@ void DevIntrThread::push_event()
 	cout4 << "Device interface change event thread pushing event!" << std::endl;
 
 	AutoTangoMonitor sync(dev,true);
-	
+
 	if (shared_data.interface.has_changed(dev) == true)
 	{
 		cout4 << "Device interface has changed" << std::endl;

--- a/cppapi/server/jpeg/jpeg_bitstream.cpp
+++ b/cppapi/server/jpeg/jpeg_bitstream.cpp
@@ -373,6 +373,8 @@ void OutputBitStream::encode_block(short *block,HUFFMANTABLE *hDC,HUFFMANTABLE *
 //------------------------------------------------------------------------------
 // Sign extension
 
+#ifdef _WINDOWS
+
 static const int extend_test[16] =   /* entry n is 2**(n-1) */
   { 0, 0x0001, 0x0002, 0x0004, 0x0008, 0x0010, 0x0020, 0x0040, 0x0080,
     0x0100, 0x0200, 0x0400, 0x0800, 0x1000, 0x2000, 0x4000 };
@@ -384,8 +386,8 @@ static const int extend_offset[16] = /* entry n is (~0u << n) | 1 */
     (int)(((~0u)<<13) | 1), (int)(((~0u)<<14) | 1), (int)(((~0u)<<15) | 1) };
 
 // Tables are slightly faster with Visual C++
-#ifdef _WINDOWS
 #define HUFF_EXTEND(x,s) s = ((x) < extend_test[s] ? (x) + extend_offset[s] : (x))
+
 #else
 #define HUFF_EXTEND(x,s)  s = ((x) < (1<<((s)-1)) ? (x) + (int)(((~0u)<<(s)) | 1) : (x))
 #endif

--- a/cppapi/server/jpeg/jpeg_bitstream.h
+++ b/cppapi/server/jpeg/jpeg_bitstream.h
@@ -82,8 +82,9 @@ class OutputBitStream {
 #endif
    unsigned char *bufferPtr;
    unsigned char *numbits;
+#ifdef JPG_USE_ASM
    unsigned char  bScratch[4];
-
+#endif
 };
 
 // ------------------------------------------------------------

--- a/cppapi/server/multiattribute.cpp
+++ b/cppapi/server/multiattribute.cpp
@@ -1156,7 +1156,7 @@ Attribute &MultiAttribute::get_attr_by_name(const char *attr_name)
     {
         attr = ext->attr_map.at(st).att_ptr;
     }
-    catch(std::out_of_range e)
+    catch(std::out_of_range &e)
     {
         cout3 << "MultiAttribute::get_attr_by_name throwing exception" << std::endl;
         TangoSys_OMemStream o;
@@ -1211,7 +1211,7 @@ WAttribute &MultiAttribute::get_w_attr_by_name(const char *attr_name)
     {
         attr = ext->attr_map.at(st).att_ptr;
     }
-    catch(std::out_of_range e)
+    catch(std::out_of_range &e)
     {
         cout3 << "MultiAttribute::get_attr_by_name throwing exception" << std::endl;
         TangoSys_OMemStream o;
@@ -1279,7 +1279,7 @@ long MultiAttribute::get_attr_ind_by_name(const char *attr_name)
     {
         i = ext->attr_map.at(st).att_index_in_vector;
     }
-    catch(std::out_of_range e)
+    catch(std::out_of_range &e)
     {
         cout3 << "MultiAttribute::get_attr_ind_by_name throwing exception" << std::endl;
         TangoSys_OMemStream o;

--- a/cppapi/server/pollthread.cpp
+++ b/cppapi/server/pollthread.cpp
@@ -831,7 +831,6 @@ void PollThread::one_more_poll()
         }
 
         std::list<WorkItem>::iterator ite;
-        std::vector<WorkItem>::iterator et_ite;
 
         for (size_t loop = 0;loop < auto_upd.size();loop++)
         {

--- a/cppapi/server/w_attribute.cpp
+++ b/cppapi/server/w_attribute.cpp
@@ -3064,7 +3064,7 @@ bool WAttribute::check_rds_alarm()
                     unsigned short delta =
                         (data_format == Tango::SCALAR) ? ushort_array_val[0] - tmp_ush[0] : ushort_array_val[i]
                             - (*value.ush_seq)[i];
-                    if (abs(delta) >= delta_val.ush)
+                    if (delta >= delta_val.ush)
                     {
                         quality = Tango::ATTR_ALARM;
                         alarm.set(rds);
@@ -3083,7 +3083,7 @@ bool WAttribute::check_rds_alarm()
                     unsigned char delta =
                         (data_format == Tango::SCALAR) ? uchar_array_val[0] - tmp_cha[0] : uchar_array_val[i]
                             - (*value.cha_seq)[i];
-                    if (abs(delta) >= delta_val.uch)
+                    if (delta >= delta_val.uch)
                     {
                         quality = Tango::ATTR_ALARM;
                         alarm.set(rds);
@@ -3165,7 +3165,7 @@ bool WAttribute::check_rds_alarm()
                 for (i = 0; i < nb_data; i++)
                 {
                     unsigned char delta = encoded_val.encoded_data[i] - (*value.enc_seq)[0].encoded_data[i];
-                    if (abs(delta) >= delta_val.uch)
+                    if (delta >= delta_val.uch)
                     {
                         quality = Tango::ATTR_ALARM;
                         alarm.set(rds);

--- a/cppapi/server/w_attrsetval.tpp
+++ b/cppapi/server/w_attrsetval.tpp
@@ -106,7 +106,7 @@ void WAttribute::get_write_value(const T *&ptr)
 //-----------------------------------------------------------------------------------------------------------------
 
 template <typename T>
-void WAttribute::check_type(T &dummy,const std::string &origin)
+void WAttribute::check_type(T &TANGO_UNUSED(dummy), const std::string &origin)
 {
 #ifdef HAS_UNDERLYING
 	bool short_enum = std::is_same<short,typename std::underlying_type<T>::type>::value;

--- a/log4tango/tests/clock.cpp
+++ b/log4tango/tests/clock.cpp
@@ -1,6 +1,4 @@
-static const char rcsid[] = "$Id$";
-
-// 
+//
 // Copyright (C) :  2004,2005,2006,2007,2008,2009,2010
 //					Synchrotron SOLEIL
 //                	L'Orme des Merisiers


### PR DESCRIPTION
I've compiled tango in debug mode with both gcc 9.1 and clang 8.0.
I then fixed the obvious and easy to fix warnings. My original motivation was to get into a state were we can use `-Werror` for a travis job to avoid introducing new warnings.

But that would require some more work, this PR is the first step in that direction though.

Logs with remaining warnings: 
- [output-clang-cppTango.txt](https://github.com/tango-controls/cppTango/files/3447107/output-clang-cppTango.txt)
- [output-gcc9-cppTango.txt](https://github.com/tango-controls/cppTango/files/3447109/output-gcc9-cppTango.txt)

