### PR TITLE
CMakeLists.txt: Fix compilation problems on debian buster

### DIFF
--- a/configure/CMakeLists.txt
+++ b/configure/CMakeLists.txt
@@ -176,23 +176,19 @@ endif(WIN32)
 
 if(NOT WIN32)
     include(CheckCXXCompilerFlag)
-    CHECK_CXX_COMPILER_FLAG("-std=c++20" COMPILER_SUPPORTS_CXX20)
-    CHECK_CXX_COMPILER_FLAG("-std=c++17" COMPILER_SUPPORTS_CXX17)
+    # C++17 and higher support is currently not possible as omniorb uses
+    # throw specifications and these are not supported anymore.
     CHECK_CXX_COMPILER_FLAG("-std=c++14" COMPILER_SUPPORTS_CXX14)
     CHECK_CXX_COMPILER_FLAG("-std=c++11" COMPILER_SUPPORTS_CXX11)
     CHECK_CXX_COMPILER_FLAG("-std=c++0x" COMPILER_SUPPORTS_CXX0X)
-    if(COMPILER_SUPPORTS_CXX20)
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++20")
-    elseif(COMPILER_SUPPORTS_CXX17)
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17")
-    elseif(COMPILER_SUPPORTS_CXX14)
+    if(COMPILER_SUPPORTS_CXX14)
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")
     elseif(COMPILER_SUPPORTS_CXX11)
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
     elseif(COMPILER_SUPPORTS_CXX0X)
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++0x")
     else()
-        message("The compiler ${CMAKE_CXX_COMPILER} has no C++11/14/17/20 support. You may not benefit from performance optimizations.")
+        message("The compiler ${CMAKE_CXX_COMPILER} has no C++11/14 support. You may not benefit from performance optimizations.")
     endif()
 
     #setup for GNU CXX compiler


### PR DESCRIPTION
Since 60fcadac (CMakeLists.txt: Check for more modern -std= flags as
well, 2019-07-25) we are using the most modern -std flags avaiable.

And since 4e259462 (.travis: Run tests on debian 10 as well, 2019-06-05)
we use debian buster for testing as well.

The combination of the two features broke compilation on debian buster
as it's gcc supports C++17 but we actually don't have valid C++17 code
as omniorb uses throw specifications, which are not valid anymore.

The error looks like

/usr/include/omniORB4/internal/orbOptions.h:95:57: error: ISO C++17 does not allow dynamic exception specifications
     virtual void visit(const char* value,Source source) throw (BadParam) = 0;

...

So let's not use C++17 and C++20 for now.