### PR TITLE
Bump release nb

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,7 @@ endif()
 
 #convenient versions
 set(LIBRARY_VERSION "${MAJOR_VERSION}.${MINOR_VERSION}.${PATCH_VERSION}")
-set(SO_VERSION "${MAJOR_VERSION}")
+set(SO_VERSION "${MAJOR_VERSION}${MINOR_VERSION}")
 
 set(TANGO_HOST $ENV{TANGO_HOST})
 include(configure/CMakeLists.txt)


### PR DESCRIPTION
We said the next cppTango release will not be binary compatible with the previous version.
Increase the release number to 10.0.0 in preparation of this new release.
Update CHANGELOG.md with latest commits since cppTango 9.3.3.

This is not the Tango 10 we talk about since a while, but it would be logical to call it like that since we break the binary compatibility.
We could also call it 9.4.0 and change the SONAME of the generated library...
But 10.0.0 is probably cleaner to follow the most used versioning conventions?
Comments are welcome.