### PR TITLE
Fix debian7 travis 9.3-backports

### DIFF
--- a/.travis/debian7/Dockerfile
+++ b/.travis/debian7/Dockerfile
@@ -1,14 +1,10 @@
-FROM debian:wheezy-backports
+FROM debian/eol:wheezy
 
 ARG APP_UID=2000
 
 ARG APP_GID=2000
 
 MAINTAINER TANGO Controls team <tango@esrf.fr>
-
-RUN echo "deb http://archive.debian.org/debian wheezy main contrib" > /etc/apt/sources.list
-
-RUN echo "deb http://security.debian.org/debian-security wheezy/updates main" > /etc/apt/sources.list.d/security.list
 
 RUN echo 'deb http://archive.debian.org/debian wheezy-backports main contrib' > /etc/apt/sources.list.d/backports.list
 


### PR DESCRIPTION
Debian wheezy image has been moved to debian/eol (https://hub.docker.com/r/debian/eol)
Update .travis/debian7/Dockerfile to use this image.