### PR TITLE
.travis: Fix installation of non-stock cppzmq

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ before_install:
   - docker pull tangocs/mysql:9.2.2
   - docker pull tangocs/tango-cs:latest
   - git clone https://github.com/JoakimSoderberg/coveralls-cmake.git
-  - git clone -b v4.2.2 https://${CI_USER_TOKEN}@github.com/zeromq/cppzmq.git cppzmq
+  - (test ${STOCK_CPPZMQ} = "OFF" && git clone -b v4.2.2 https://${CI_USER_TOKEN}@github.com/zeromq/cppzmq.git cppzmq) || mkdir cppzmq
   - git clone -b tango-9-lts https://${CI_USER_TOKEN}@github.com/tango-controls/tango-idl.git idl
   - wget https://sonarcloud.io/static/cpp/build-wrapper-linux-x86.zip && unzip build-wrapper-linux-x86.zip
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,12 @@ language: cpp
 
 env:
   matrix:
-    - OS_TYPE=gcc-latest CMAKE_BUILD_TYPE=Debug   SONAR_SCANNER=OFF COVERALLS=OFF RUN_TESTS=OFF WARNINGS_AS_ERRORS=ON NON_STOCK_CPPZMQ=ON TANGO_USE_USING_NAMESPACE=OFF USE_PCH=ON
-    - OS_TYPE=debian10 CMAKE_BUILD_TYPE=Debug   SONAR_SCANNER=OFF COVERALLS=OFF RUN_TESTS=ON NON_STOCK_CPPZMQ=ON TANGO_USE_USING_NAMESPACE=OFF USE_PCH=ON
-    - OS_TYPE=debian10 CMAKE_BUILD_TYPE=Release SONAR_SCANNER=OFF COVERALLS=OFF RUN_TESTS=ON NON_STOCK_CPPZMQ=ON
-    - OS_TYPE=debian9  CMAKE_BUILD_TYPE=Debug   SONAR_SCANNER=OFF COVERALLS=OFF RUN_TESTS=ON NON_STOCK_CPPZMQ=ON
-    - OS_TYPE=debian8  CMAKE_BUILD_TYPE=Debug   SONAR_SCANNER=ON  COVERALLS=ON  RUN_TESTS=ON NON_STOCK_CPPZMQ=OFF
-    - OS_TYPE=debian7  CMAKE_BUILD_TYPE=Debug   SONAR_SCANNER=OFF COVERALLS=OFF RUN_TESTS=ON NON_STOCK_CPPZMQ=ON
+    - OS_TYPE=gcc-latest CMAKE_BUILD_TYPE=Debug   SONAR_SCANNER=OFF COVERALLS=OFF RUN_TESTS=OFF WARNINGS_AS_ERRORS=ON STOCK_CPPZMQ=ON TANGO_USE_USING_NAMESPACE=OFF USE_PCH=ON
+    - OS_TYPE=debian10 CMAKE_BUILD_TYPE=Debug   SONAR_SCANNER=OFF COVERALLS=OFF RUN_TESTS=ON STOCK_CPPZMQ=ON TANGO_USE_USING_NAMESPACE=OFF USE_PCH=ON
+    - OS_TYPE=debian10 CMAKE_BUILD_TYPE=Release SONAR_SCANNER=OFF COVERALLS=OFF RUN_TESTS=ON STOCK_CPPZMQ=ON
+    - OS_TYPE=debian9  CMAKE_BUILD_TYPE=Debug   SONAR_SCANNER=OFF COVERALLS=OFF RUN_TESTS=ON STOCK_CPPZMQ=ON
+    - OS_TYPE=debian8  CMAKE_BUILD_TYPE=Debug   SONAR_SCANNER=ON  COVERALLS=ON  RUN_TESTS=ON STOCK_CPPZMQ=OFF
+    - OS_TYPE=debian7  CMAKE_BUILD_TYPE=Debug   SONAR_SCANNER=OFF COVERALLS=OFF RUN_TESTS=ON STOCK_CPPZMQ=ON
 
 notifications:
   email: false
@@ -45,7 +45,7 @@ before_script:
   - docker build --build-arg APP_UID=$(id -u) --build-arg APP_GID=$(id -g) -t cpp_tango .travis/${OS_TYPE}
   - docker run --name cpp_tango -e TANGO_HOST=${TANGO_HOST} -e BINTRAY_USER_NAME=tango-ci -e BINTRAY_API_KEY=${CI_BINTRAY_API_KEY} -e COVERALLS_REPO_TOKEN=${COVERALLS_REPO_TOKEN} --link tango_cs:tango_cs -v `pwd`:/home/tango/src -v `pwd`/idl:/home/tango/idl -v `pwd`/cppzmq:/home/tango/cppzmq -v `pwd`/coveralls-cmake:/home/tango/coveralls-cmake -v `pwd`/build-wrapper-linux-x86:/home/tango/build-wrapper-linux-x86 -dit cpp_tango
   - .travis/install_tango_idl.sh
-  - (test ${NON_STOCK_CPPZMQ} = "ON" && .travis/install_cppzmq.sh) || true
+  - (test ${STOCK_CPPZMQ} = "OFF" && .travis/install_cppzmq.sh) || true
 #work around gcov ignored by sonar
   - sudo mkdir /home/tango && sudo mkdir /home/tango/src && sudo mount --bind `pwd` /home/tango/src
 

--- a/configure/CMakeLists.txt
+++ b/configure/CMakeLists.txt
@@ -151,6 +151,18 @@ Please install cppzmq (https://github.com/zeromq/cppzmq) on your system and/or u
 <OMNI_BASE>/include and system include directories).")
 endif()
 
+if(NOT WIN32)
+  try_compile(TANGO_ZMQ_HAS_DISCONNECT ${CMAKE_BINARY_DIR}/test_cppzmq_disconnect
+              SOURCES ${CMAKE_SOURCE_DIR}/configure/test_cppzmq_disconnect.cpp
+              COMPILE_DEFINITIONS "-I ${CPPZMQ_BASE}/include -I ${ZMQ_BASE}/include"
+              LINK_LIBRARIES "${ZMQ_PKG_LIBRARIES}")
+
+  message(STATUS "Check if zmq::socket has a disconnect method: ${TANGO_ZMQ_HAS_DISCONNECT}")
+else()
+  set(TANGO_ZMQ_HAS_DISCONNECT TRUE)
+  message(STATUS "Check if zmq::socket has a disconnect method: ${TANGO_ZMQ_HAS_DISCONNECT} (hardcoded)")
+endif(NOT WIN32)
+
 message("Verifying ${OMNIIDL_PATH}omniidl")
 if(WIN32)
     execute_process(COMMAND ${OMNIIDL_PATH}omniidl.exe -V RESULT_VARIABLE FAILED)

--- a/configure/test_cppzmq_disconnect.cpp
+++ b/configure/test_cppzmq_disconnect.cpp
@@ -1,0 +1,8 @@
+#include <zmq.hpp>
+
+int main(int, char**)
+{
+  zmq::context_t c;
+  zmq::socket_t s(c, ZMQ_REQ);
+  s.disconnect("some endpoint");
+}

--- a/cppapi/client/eventconsumer.h
+++ b/cppapi/client/eventconsumer.h
@@ -44,13 +44,6 @@
 
 #include <zmq.hpp>
 
-#ifdef ZMQ_VERSION
-	#if ZMQ_VERSION > 30201
-		#define ZMQ_HAS_DISCONNECT
-	#endif
-#endif
-
-
 namespace Tango
 {
 

--- a/cppapi/client/eventkeepalive.cpp
+++ b/cppapi/client/eventkeepalive.cpp
@@ -187,7 +187,7 @@ bool EventConsumerKeepAliveThread::reconnect_to_zmq_channel(EvChanIte &ipos,Even
 
 					std::string adm_name = ipos->second.full_adm_name;
 
-#ifdef ZMQ_HAS_DISCONNECT
+#ifdef TANGO_ZMQ_HAS_DISCONNECT
 //
 // Forget exception which could happen during massive restart of device server process running on the same host
 //
@@ -405,7 +405,7 @@ void EventConsumerKeepAliveThread::re_subscribe_event(EvCbIte &epos,EvChanIte &i
 void EventConsumerKeepAliveThread::reconnect_to_zmq_event(EvChanIte &ipos,EventConsumer *event_consumer,DeviceData &dd)
 {
 	EvCbIte epos;
-#ifdef ZMQ_HAS_DISCONNECT
+#ifdef TANGO_ZMQ_HAS_DISCONNECT
 	bool disconnect_called = false;
 #endif
 
@@ -447,7 +447,7 @@ void EventConsumerKeepAliveThread::reconnect_to_zmq_event(EvChanIte &ipos,EventC
 						std::string prefix = fqen.substr(0,pos + 1);
 						d_name.insert(0,prefix);
 
-#ifdef ZMQ_HAS_DISCONNECT
+#ifdef TANGO_ZMQ_HAS_DISCONNECT
 						if (disconnect_called == false)
 						{
 							event_consumer->disconnect_event(epos->second.fully_qualified_event_name,epos->second.endpoint);

--- a/cppapi/client/zmqeventconsumer.cpp
+++ b/cppapi/client/zmqeventconsumer.cpp
@@ -799,7 +799,7 @@ bool ZmqEventConsumer::process_ctrl(zmq::message_t &received_ctrl,zmq::pollitem_
 //
 
             const char *event_name = &(tmp_ptr[1]);
-#ifdef ZMQ_HAS_DISCONNECT
+#ifdef TANGO_ZMQ_HAS_DISCONNECT
             const char *endpoint = &(tmp_ptr[1 + ::strlen(event_name) + 1]);
             const char *endpoint_event = &(tmp_ptr[1 + ::strlen(event_name) + ::strlen(endpoint) + 2]);
 #endif
@@ -821,7 +821,7 @@ bool ZmqEventConsumer::process_ctrl(zmq::message_t &received_ctrl,zmq::pollitem_
                 multi_tango_host(heartbeat_sub_sock,UNSUBSCRIBE,base_name);
             }
 
-#ifdef ZMQ_HAS_DISCONNECT
+#ifdef TANGO_ZMQ_HAS_DISCONNECT
 //
 // Remove the endpoint in the vector of already connected heartbeat and disconnect the socket to this endpoint
 //
@@ -1348,7 +1348,7 @@ void ZmqEventConsumer::connect_event_channel(std::string &channel_name,TANGO_UNU
         buffer[length] = ZMQ_CONNECT_HEARTBEAT;
         length++;
 
-#ifdef ZMQ_HAS_DISCONNECT
+#ifdef TANGO_ZMQ_HAS_DISCONNECT
 		buffer[length] = 0;
 #else
         if (reconnect == true)
@@ -1720,7 +1720,7 @@ void ZmqEventConsumer::connect_event_system(TANGO_UNUSED(std::string &device_nam
             buffer[length] = ZMQ_CONNECT_EVENT;
         length++;
 
-#ifdef ZMQ_HAS_DISCONNECT
+#ifdef TANGO_ZMQ_HAS_DISCONNECT
 		buffer[length] = 0;
 #else
         if (filters.size() == 1 && filters[0] == "reconnect")
@@ -3545,7 +3545,7 @@ ReceivedFromAdmin ZmqEventConsumer::initialize_received_from_admin(const Tango::
     return result;
 }
 
-#ifdef ZMQ_HAS_DISCONNECT
+#ifdef TANGO_ZMQ_HAS_DISCONNECT
 void ZmqEventConsumer::disconnect_socket(zmq::socket_t& socket, const char* endpoint)
 {
     try

--- a/cppapi/server/tango_const.h.in
+++ b/cppapi/server/tango_const.h.in
@@ -145,6 +145,8 @@ const int   PUB_HWM                        = 1000;
 const int   SUB_HWM                        = 1000;
 const int   SUB_SEND_HWM                   = 10000;
 
+#cmakedefine TANGO_ZMQ_HAS_DISCONNECT
+
 //
 // Event when using a file as database stuff
 //


### PR DESCRIPTION
    In 86174eea (Travis Tests: Avoid code duplication, 2019-06-05) we added
    support for using the environment variable NON_STOCK_CPPZMQ to say if we
    use the stock version or the non-stock version.

    That commit got the logic wrong. Flip the naming to have now one less
    negation.

    STOCK_CPPZMQ=ON means that the system cppzmq is used, =OFF that we use
    the latest cppzmq from the repo.

(Adapted from fedback in https://github.com/tango-controls/cppTango/pull/598#issuecomment-545004240)