### PR TITLE
.travis.yml: Fail travis tests fast

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,8 +49,10 @@ before_script:
   - sudo mkdir /home/tango && sudo mkdir /home/tango/src && sudo mount --bind `pwd` /home/tango/src
 
 script:
+  - set -e
   - .travis/run.sh
   - .travis/test.sh COVERALLS=${COVERALLS}
+  - set +e
 
 after_success:
   - test ${SONAR_SCANNER} = "ON" && .travis/sonar.sh


### PR DESCRIPTION
Currently we try executing the tests even if the build fails.

This is a waste of CI time and also makes browsing the logs too
difficult.

Using `set -e` was suggested at
https://github.com/travis-ci/travis-ci/issues/1066#issuecomment-479594195.