### PR TITLE
.travis.yml: Fix exit code ignoring for failed tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,7 +61,7 @@ before_script:
 script:
   - set -e
   - .travis/run.sh
-  - (test ${RUN_TESTS} = "ON" && .travis/test.sh COVERALLS=${COVERALLS}) || true
+  - .travis/test.sh
   - set +e
 
 after_success:

--- a/.travis/test.sh
+++ b/.travis/test.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+if [ $RUN_TESTS = "OFF" ]
+then
+  echo "Skipping tests as requested"
+  exit 0
+fi
+
 TEST_COMMAND="exec ctest --output-on-failure"
 if [ $COVERALLS = "ON" ]
 then


### PR DESCRIPTION
In 753c3f1a (.travis.yml: Fail travis tests fast, 2019-10-23) we added
support for failing the build immediately on error.

This worked as it should.

But in 75dc8a2e (.travis.yml: Add environment variable which allows to
skip running the tests, 2019-10-23) support for not executing the tests
was added. And that failed to return the exit code from the test, as it
returned on error true from the outer ||.

Let's rewrite it so that it fails early and allows to skip the tests.

Close #610.