### PR TITLE
CMakeLists.txt: Allow precompiled headers for clang as well

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ include(CTest)
 option(WARNINGS_AS_ERRORS "Treat compiler warnings as errors" OFF)
 
 option(USE_PCH "Use precompiled header for server/tango.h" OFF)
-if (USE_PCH AND NOT (CMAKE_CXX_COMPILER_ID MATCHES "GNU|MSVC"))
+if (USE_PCH AND NOT (CMAKE_CXX_COMPILER_ID MATCHES "GNU|MSVC|Clang"))
     message(WARNING "Precompiled headers are not supported for selected compiler.")
     set(USE_PCH OFF)
 endif()


### PR DESCRIPTION
According to [1] clang has the same interface for generating and using
precompiled headers as GCC.

So let's allow it.

[1]: https://clang.llvm.org/docs/UsersManual.html#generating-a-pch-file