### PR TITLE
configure/test_cppzmq_disconnect.cpp: Be compatible with older zmq.hp…

### DIFF
--- a/configure/test_cppzmq_disconnect.cpp
+++ b/configure/test_cppzmq_disconnect.cpp
@@ -2,7 +2,7 @@
 
 int main(int, char**)
 {
-  zmq::context_t c;
+  zmq::context_t c(1);
   zmq::socket_t s(c, ZMQ_REQ);
   s.disconnect("some endpoint");
 }


### PR DESCRIPTION
…p versions as well

We used to ship a version of zmg.hpp with cppTango, see 5144cb80 (Add
again zmq.hpp before tagging release 9.2.5 to be consistent with 9.2.5
version from SVN Sourceforge (#348), 2017-01-11).

And in that version there was no default constructor for zmq::context_t
available. The constructor taking an integer parameter is still
available in newer versions so we can just use that here.