### PR TITLE
appveyor.yml: Add inline deployment on tag push

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -195,3 +195,20 @@ artifacts:
   - path: ./*.exe
   - path: ./*.zip
   - path: ./*.msi
+
+deploy:
+- provider: GitHub
+  tag: $(APPVEYOR_REPO_TAG_NAME)
+  description: "Release $(APPVEYOR_REPO_TAG_NAME)"
+  auth_token:
+    # User: cppTango-bot
+    # Personal Access token with repo scope, encrypted via https://ci.appveyor.com/tools/encrypt
+    secure: KnvPAbdhmiTQxTLOGq7nyNs6d1JYbKVKspPgigzQ3fDrI+nkaxqWCw6UmRkS2Gqe
+  artifact: /.*/
+  repository: tango-controls/cppTango
+  draft: true
+  prerelease: true
+  force_update: true
+  # deploy on tag push only
+  on:
+    APPVEYOR_REPO_TAG: true


### PR DESCRIPTION
Automate the deployment from appveyor.

We want to publish all artifacts as a new draft prelease on tag push
only.

I've published 9.3.4-rc1 from an environment in appveyor. This is an alternative solution to the inline deployment method.

For playing around I've used an OAuth token from my user. But we can not merge it as it is as using a token from a human user account is unsafe. This OAuth token allows read/write access to all repositories.

I propose to create a machine user which has only access to the cppTango repo and generate an OAuth token for her and use that here. See https://developer.github.com/v3/guides/managing-deploy-keys/#machine-users and https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line?query=machine%20user.

Close #602.