### PR TITLE
Remove second database instance from tests (#630)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,17 +61,6 @@ before_script:
   - >
       docker run
       --rm
-      --name mysql_db2
-      -e MYSQL_ROOT_PASSWORD=root
-      -e MYSQL_INITDB_SKIP_TZINFO=1
-      -d
-      tangocs/mysql:9.2.2
-      --sql-mode=""
-      --innodb=OFF
-      --default-storage-engine=MyISAM
-  - >
-      docker run
-      --rm
       --name tango_cs
       -e TANGO_HOST=127.0.0.1:10000
       -e MYSQL_HOST=mysql_db:3306
@@ -81,20 +70,7 @@ before_script:
       --link mysql_db:mysq_db
       -d
       tangocs/tango-cs:latest
-  - >
-      docker run
-      --rm
-      --name tango_cs2
-      -e TANGO_HOST=127.0.0.1:10000
-      -e MYSQL_HOST=mysql_db2:3306
-      -e MYSQL_USER=tango
-      -e MYSQL_PASSWORD=tango
-      -e MYSQL_DATABASE=tango
-      --link mysql_db2:mysq_db2
-      -d
-      tangocs/tango-cs:latest
   - TANGO_HOST_IP=$(docker inspect -f '{{ .NetworkSettings.IPAddress }}' tango_cs)
-  - TANGO_HOST_IP2=$(docker inspect -f '{{ .NetworkSettings.IPAddress }}' tango_cs2)
   - TANGO_HOST=${TANGO_HOST_IP}:10000
   - docker build --build-arg APP_UID=$(id -u) --build-arg APP_GID=$(id -g) -t cpp_tango .travis/${OS_TYPE}
   - >
@@ -107,7 +83,6 @@ before_script:
       -e BINTRAY_API_KEY=${CI_BINTRAY_API_KEY}
       -e COVERALLS_REPO_TOKEN=${COVERALLS_REPO_TOKEN}
       --link tango_cs
-      --link tango_cs2
       -v `pwd`:/home/tango/src
       -v `pwd`/idl:/home/tango/idl
       -v `pwd`/cppzmq:/home/tango/cppzmq
@@ -138,5 +113,5 @@ deploy:
 
 after-script:
   - docker stop cpp_tango
-  - docker stop tango_cs tango_cs2
-  - docker stop mysql_db mysql_db2
+  - docker stop tango_cs
+  - docker stop mysql_db

--- a/cpp_test_suite/environment/setup.sh
+++ b/cpp_test_suite/environment/setup.sh
@@ -30,15 +30,11 @@ function run_tango_container {
 }
 
 run_mysql_container mysql_db
-run_mysql_container mysql_db2
 run_tango_container tango_cs mysql_db
-run_tango_container tango_cs2 mysql_db2
 
 IPADDR=$(docker inspect -f '{{ .NetworkSettings.IPAddress }}' tango_cs)
-IPADDR2=$(docker inspect -f '{{ .NetworkSettings.IPAddress }}' tango_cs2)
 
 export TANGO_HOST=$IPADDR:10000
-export TANGO_HOST2=$IPADDR2:10000
 
 echo "TANGO_HOST=$TANGO_HOST"
 
@@ -47,13 +43,11 @@ echo "Create tango_host file"
 cat << EOF > tango_host
 #!/bin/bash
 export TANGO_HOST=$TANGO_HOST
-export TANGO_HOST2=$TANGO_HOST2
 EOF
 
 echo "Wait till tango-cs is online"
 if hash tango_admin 2>/dev/null; then
     tango_admin --ping-database 30
-    TANGO_HOST=$TANGO_HOST2 tango_admin --ping-database 30
 else
     sleep 30
 fi

--- a/cpp_test_suite/environment/shutdown.sh
+++ b/cpp_test_suite/environment/shutdown.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 
 echo "Shutdown test environment"
-docker stop tango_cs tango_cs2
-docker stop mysql_db mysql_db2
+docker stop tango_cs
+docker stop mysql_db
 
 echo "Revert tango_host file"
 echo "TANGO_HOST=$TANGO_HOST"

--- a/cpp_test_suite/new_tests/cxx_group.cpp
+++ b/cpp_test_suite/new_tests/cxx_group.cpp
@@ -829,16 +829,15 @@ public:
 
 	/* Verifies that a group can contain devices from a remote TANGO_HOST
 	 * (a Tango instance different from client's default TANGO_HOST).
-	 * An issue was reported when resolving names containing wildcards. */
+	 * An issue was reported when resolving names containing wildcards.
+	 * Update: to simplify test setup, the scenario has been changed
+	 * to unset client's TANGO_HOST instead of providing different value. */
 
 	void test_use_devices_from_remote_tango_host()
 	{
 		const std::string original_tango_host = std::getenv("TANGO_HOST");
-		const std::string external_tango_host = std::getenv("TANGO_HOST2");
 
-		const bool force_update = true;
-
-		TS_ASSERT_EQUALS(0, setenv("TANGO_HOST", external_tango_host.c_str(), force_update));
+		TS_ASSERT_EQUALS(0, unsetenv("TANGO_HOST"));
 		ApiUtil::instance()->cleanup();
 
 		Group group("group");
@@ -856,6 +855,7 @@ public:
 		TS_ASSERT(command_result >> state);
 		TS_ASSERT_EQUALS(ON, state);
 
+		const bool force_update = true;
 		TS_ASSERT_EQUALS(0, setenv("TANGO_HOST", original_tango_host.c_str(), force_update));
 		ApiUtil::instance()->cleanup();
 	}


### PR DESCRIPTION
The PR removes second database instance as proposed in #630. It impacts #608 test scenario.

Without #608 fix, with second database the failure was:
```
Tango exception
Severity = ERROR 
Error reason = DB_DeviceNotDefined
Desc : device test/debian8/10 not defined in the database !
Origin : DataBase::ImportDevice()
```
Without second database, the failure is:
```
25: Tango exception
25: Severity = ERROR
25: Error reason = API_TangoHostNotSet
25: Desc : TANGO_HOST env. variable not set, set it and retry (e.g. TANGO_HOST=<host>:<port>)
25: Origin : Database::Database
```