### PR TITLE
Install tango_admin in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,7 @@ before_install:
   - git clone https://github.com/JoakimSoderberg/coveralls-cmake.git
   - (test ${STOCK_CPPZMQ} = "OFF" && git clone -b v4.2.2 https://${CI_USER_TOKEN}@github.com/zeromq/cppzmq.git cppzmq) || mkdir cppzmq
   - git clone -b tango-9-lts https://${CI_USER_TOKEN}@github.com/tango-controls/tango-idl.git idl
+  - git clone -b Release_1.14 https://github.com/tango-controls/tango_admin.git
   - wget https://sonarcloud.io/static/cpp/build-wrapper-linux-x86.zip && unzip build-wrapper-linux-x86.zip
 
 before_script:
@@ -111,6 +112,7 @@ before_script:
       -v `pwd`:/home/tango/src
       -v `pwd`/idl:/home/tango/idl
       -v `pwd`/cppzmq:/home/tango/cppzmq
+      -v `pwd`/tango_admin:/home/tango/tango_admin
       -v `pwd`/coveralls-cmake:/home/tango/coveralls-cmake
       -v `pwd`/build-wrapper-linux-x86:/home/tango/build-wrapper-linux-x86
       -dit
@@ -123,6 +125,8 @@ before_script:
 script:
   - set -e
   - .travis/run.sh
+  - .travis/install_tango.sh
+  - .travis/install_tango_admin.sh
   - .travis/test.sh
   - set +e
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ before_install:
   - git clone https://github.com/JoakimSoderberg/coveralls-cmake.git
   - (test ${STOCK_CPPZMQ} = "OFF" && git clone -b v4.2.2 https://${CI_USER_TOKEN}@github.com/zeromq/cppzmq.git cppzmq) || mkdir cppzmq
   - git clone -b tango-9-lts https://${CI_USER_TOKEN}@github.com/tango-controls/tango-idl.git idl
-  - git clone -b Release_1.14 https://github.com/tango-controls/tango_admin.git
+  - git clone -b Release_1.15 https://github.com/tango-controls/tango_admin.git
   - wget https://sonarcloud.io/static/cpp/build-wrapper-linux-x86.zip && unzip build-wrapper-linux-x86.zip
 
 before_script:

--- a/.travis/install_tango.sh
+++ b/.travis/install_tango.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -e
+
+echo "Install tango"
+docker exec --user root cpp_tango make -C /home/tango/src/build install

--- a/.travis/install_tango_admin.sh
+++ b/.travis/install_tango_admin.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -e
+
+admin_dir="/home/tango/tango_admin"
+
+echo "Build tango_admin"
+docker exec cpp_tango mkdir -p "${admin_dir}/build"
+docker exec cpp_tango cmake -H"${admin_dir}" -B"${admin_dir}/build"
+docker exec cpp_tango make -C "${admin_dir}/build"
+
+echo "Install tango_admin"
+docker exec --user root cpp_tango cp "${admin_dir}/build/tango_admin" /usr/local/bin

--- a/cpp_test_suite/cxxtest/bin/start_server.sh.cmake
+++ b/cpp_test_suite/cxxtest/bin/start_server.sh.cmake
@@ -5,7 +5,12 @@ start_server(){
     @PROJECT_BINARY_DIR@/cpp_test_ds/DevTest $1 -v5 1>@PROJECT_BINARY_DIR@/cpp_test_ds/DevTest_$1.out 2>&1 &
     echo $! > @PROJECT_BINARY_DIR@/cpp_test_ds/DevTest_$1.pid
 
-    sleep 7
+    if hash tango_admin 2>/dev/null; then
+        tango_admin --ping-device "dserver/devtest/$1" 7
+    else
+        sleep 7
+    fi
+
     echo "Done. PID="`cat @PROJECT_BINARY_DIR@/cpp_test_ds/DevTest_$1.pid`
 }
 

--- a/cpp_test_suite/environment/pre_test.sh.cmake
+++ b/cpp_test_suite/environment/pre_test.sh.cmake
@@ -13,7 +13,11 @@ echo "`ldd @PROJECT_BINARY_DIR@/cpp_test_ds/DevTest`"
 @PROJECT_BINARY_DIR@/cpp_test_ds/DevTest @INST_NAME@ -v5 1>@PROJECT_BINARY_DIR@/cpp_test_ds/DevTest_@INST_NAME@.out 2>&1 &
 echo $! > @PROJECT_BINARY_DIR@/cpp_test_ds/DevTest_@INST_NAME@.pid
 
-sleep 3
+if hash tango_admin 2>/dev/null; then
+    tango_admin --ping-device "dserver/devtest/@INST_NAME@" 3
+else
+    sleep 3
+fi
 
 echo "Start FwdTest"
 echo "FwdTest libraries:"
@@ -21,4 +25,8 @@ echo "`ldd @PROJECT_BINARY_DIR@/cpp_test_ds/fwd_ds/FwdTest`"
 @PROJECT_BINARY_DIR@/cpp_test_ds/fwd_ds/FwdTest @INST_NAME@ -v5 1>@PROJECT_BINARY_DIR@/cpp_test_ds/fwd_ds/FwdTest_@INST_NAME@.out 2>&1 &
 echo $! > @PROJECT_BINARY_DIR@/cpp_test_ds/fwd_ds/FwdTest_@INST_NAME@.pid
 
-sleep 3
+if hash tango_admin 2>/dev/null; then
+    tango_admin --ping-device "dserver/fwdtest/@INST_NAME@" 3
+else
+    sleep 3
+fi


### PR DESCRIPTION
Install tango_admin in CI so that we can easily determine when device servers are running and available.

This change is extracted from #568 as it can stand on its own and will simplify bringing #568 up to date.