### PR TITLE
Correct interdependent tests

### DIFF
--- a/cpp_test_suite/event/att_conf_event_buffer.cpp
+++ b/cpp_test_suite/event/att_conf_event_buffer.cpp
@@ -140,6 +140,16 @@ int main(int argc, char **argv)
 
 		eve_id = device->subscribe_event(att_name,Tango::ATTR_CONF_EVENT,1,filters);
 
+		{
+			Tango::DevVarDoubleArray dvda(2);
+			dvda.length(2);
+			dvda[0] = 0.0;
+			dvda[1] = 0.0;
+			DeviceData d_in;
+			d_in << dvda;
+			device->command_inout("IOSetWAttrLimit", d_in);
+		}
+
 //
 // Send 10 attribute configuration events
 //

--- a/cpp_test_suite/event/event_lock.cpp
+++ b/cpp_test_suite/event/event_lock.cpp
@@ -45,6 +45,30 @@ void EventCallback::push_event(Tango::EventData *ed)
     }
 }
 
+void set_abs_change(std::string device_name, std::string attribute_name)
+{
+    Tango::DbDatum attribute_datum(attribute_name);
+    attribute_datum << 1;
+
+    Tango::DbDatum change_datum("abs_change");
+    change_datum << 1;
+
+    Tango::DbData data;
+    data.push_back(attribute_datum);
+    data.push_back(change_datum);
+
+    Tango::DbAttribute attribute(attribute_name, device_name);
+    attribute.put_property(data);
+
+    Tango::DeviceProxy device(device_name);
+    Tango::DeviceProxy admin_device(device.adm_name().c_str());
+    Tango::DeviceData name_data;
+    name_data << device_name;
+    admin_device.command_inout("DevRestart", name_data);
+
+    Tango_sleep(1);
+}
+
 int main(int argc, char *argv[])
 {
     Tango::DeviceProxy *dev;
@@ -63,6 +87,8 @@ int main(int argc, char *argv[])
 
     try
     {
+        set_abs_change(devName, att_name);
+
         dev = new Tango::DeviceProxy(devName);
         dev->poll_attribute(att_name, 1000);
 
@@ -94,10 +120,12 @@ int main(int argc, char *argv[])
     catch (Tango::DevFailed &ex)
     {
         Tango::Except::print_exception(ex);
+        assert(false);
     }
     catch (...)
     {
         cout << "Unknown exception....." << std::endl;
+        assert(false);
     }
 
     delete dev;

--- a/cpp_test_suite/new_tests/cxx_mem_attr.cpp
+++ b/cpp_test_suite/new_tests/cxx_mem_attr.cpp
@@ -82,7 +82,8 @@ public:
 
 	void test_One_memorized_attribute_failing_during_init_cmd(void)
 	{
-
+		DeviceAttribute short_attr_w("Short_attr_w", static_cast<DevShort>(10));
+		TS_ASSERT_THROWS_NOTHING(device1->write_attribute(short_attr_w));
 //
 // Ask the attribute to throw exception during any write call
 //


### PR DESCRIPTION
Some tests depend on configuration inherited from previous tests (since running device server instances are re-used). This means we are not able to run such tests in different order or separately with a fresh device server.

This PR is just a cherry pick of first three commits from #568.

Please check each commit description to see what has been changed.