### PR TITLE
Prevent duplicating defines in case they are already set

### DIFF
--- a/cppapi/server/tango_config.h
+++ b/cppapi/server/tango_config.h
@@ -59,13 +59,21 @@
 //
 
 #ifdef _WIN32
-	#define		__WIN32__
-	#define		__x86__
-	#ifndef _WIN32_WINNT
-		#define		_WIN32_WINNT 0x0500
-	#endif
-	#define		__NT__
-	#define		__OSVERSION 4
+  #ifndef __WIN32__
+    #define __WIN32__
+  #endif
+  #ifndef __x86__
+    #define __x86__
+  #endif
+  #ifndef _WIN32_WINNT
+    #define _WIN32_WINNT 0x0500
+  #endif
+  #ifndef __NT__
+    #define __NT__
+  #endif
+  #ifndef __OSVERSION
+    #define __OSVERSION 4
+  #endif
 #endif
 
 //


### PR DESCRIPTION
e.g. by a dependency manager or your build-system. From what I understand, these are required by omniORB, and the latter "exports" its defines for me, leading to duplications and compiler warnings.