### PR TITLE
fix build on PPC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,9 +45,9 @@ include_directories(${CMAKE_CURRENT_BINARY_DIR}/log4tango/include)
 #source code
 add_subdirectory("log4tango")
 add_subdirectory("cppapi")
-if(NOT WIN32)
+if(NOT WIN32 AND NOT PPC)
     add_subdirectory("cpp_test_suite")
-endif(NOT WIN32)
+endif(NOT WIN32 AND NOT PPC)
 
 if(WIN32)
     include(configure/cmake_win.cmake)

--- a/configure/cmake_linux.cmake
+++ b/configure/cmake_linux.cmake
@@ -4,8 +4,10 @@ add_library(tango SHARED    $<TARGET_OBJECTS:log4tango_objects>
                             $<TARGET_OBJECTS:client_objects>
                             $<TARGET_OBJECTS:idl_objects>
                             $<TARGET_OBJECTS:jpeg_objects>
-                            $<TARGET_OBJECTS:jpeg_mmx_objects>
                             $<TARGET_OBJECTS:server_objects>)
+if (NOT PPC)
+    add_library(tango SHARED $<TARGET_OBJECTS:jpeg_mmx_objects>)
+endif (NOT PPC)
 target_link_libraries(tango PUBLIC ${ZMQ_PKG_LIBRARIES} ${OMNIORB_PKG_LIBRARIES} ${OMNICOS_PKG_LIBRARIES} ${OMNIDYN_PKG_LIBRARIES} ${CMAKE_DL_LIBS})
 target_compile_options(tango PRIVATE -fPIC)
 target_include_directories(tango PUBLIC ${ZMQ_PKG_INCLUDE_DIRS} ${OMNIORB_PKG_INCLUDE_DIRS} ${OMNIDYN_PKG_INCLUDE_DIRS})
@@ -21,8 +23,10 @@ add_library(tango-static STATIC $<TARGET_OBJECTS:log4tango_objects>
                                 $<TARGET_OBJECTS:client_objects>
                                 $<TARGET_OBJECTS:idl_objects>
                                 $<TARGET_OBJECTS:jpeg_objects>
-                                $<TARGET_OBJECTS:jpeg_mmx_objects>
                                 $<TARGET_OBJECTS:server_objects>)
+if (NOT PPC)
+    add_library(tango-static STATIC $<TARGET_OBJECTS:jpeg_mmx_objects>)
+endif (NOT PPC)
 target_link_libraries(tango-static PUBLIC ${ZMQ_PKG_LIBRARIES} ${OMNIORB_PKG_LIBRARIES} ${OMNICOS_PKG_LIBRARIES} ${OMNIDYN_PKG_LIBRARIES} ${CMAKE_DL_LIBS})
 target_include_directories(tango-static PUBLIC ${ZMQ_PKG_INCLUDE_DIRS} ${OMNIORB_PKG_INCLUDE_DIRS} ${OMNIDYN_PKG_INCLUDE_DIRS})
 target_compile_options(tango-static PUBLIC ${ZMQ_PKG_CFLAGS_OTHER} ${OMNIORB_PKG_CFLAGS_OTHER} ${OMNICOS_PKG_CFLAGS_OTHER} ${OMNIDYN_PKG_CFLAGS_OTHER})

--- a/cppapi/server/CMakeLists.txt
+++ b/cppapi/server/CMakeLists.txt
@@ -132,7 +132,9 @@ set(HEADERS attrdesc.h
 
 add_subdirectory(idl)
 add_subdirectory(jpeg)
-add_subdirectory(jpeg_mmx)
+if (NOT PPC)
+  add_subdirectory(jpeg_mmx)
+endif (NOT PPC)
 
 if(WIN32)
     set(SOURCES_WIN


### PR DESCRIPTION
Add support for cmake option -DPPC=true to disable mmx optimization and cpp_test_suite. Required for 9.3-backports.