### PR TITLE
[Backport] log4tango: Fix snprintf test

### DIFF
--- a/log4tango/m4/AC_FUNC_SNPRINTF.m4
+++ b/log4tango/m4/AC_FUNC_SNPRINTF.m4
@@ -13,6 +13,7 @@ dnl
 AC_DEFUN([AC_FUNC_SNPRINTF],
 [AC_CACHE_CHECK(for working snprintf, ac_cv_func_snprintf,
 [AC_TRY_RUN([#include <stdio.h>
+#include <stdlib.h> // exit
 int main () { int l = snprintf(NULL,0,"%d",100); exit (!((3 <= l) || (-1 == l))); }
 ], ac_cv_func_snprintf=yes, ac_cv_func_snprintf=no,
 ac_cv_func_snprintf=no)])


### PR DESCRIPTION
The snprintf test was missing the declaration of the exit function.
This never found a working system snprintf implementation.

The fallout from this bug is that the LOG_* macros are not working as
e.g. TangoTest returns

1453759720 [140389277255488] INFO tangotest/tt/1 TangoTest::init_device::init device

Ready to accept request
1453759720 [140389141108480] INFO tangotest/tt/1 TangoTest::always_executed_hook()  TangoTest/tt/1
1453759720 [140389141108480] INFO tangotest/tt/1 TangoTest::always_executed_hook()  TangoTest/tt/1
1453759720 [140389141108480] INFO tangotest/tt/1 TangoTest::always_executed_hook()  TangoTest/tt/1
1453759720 [140389141108480] INFO tangotest/tt/1 TangoTest::always_executed_hook()  TangoTest/tt/1

instead of

1453842671 [139686148966208] INFO tangotest/tt/1 TangoTest::init_device::init device TangoTest/tt/1
1453842671 [139686148966208] DEBUG tangotest/tt/1 sleep_period=2000
1453842671 [139686148966208] DEBUG tangotest/tt/1 mthreaded_impl=0
1453842671 [139686148966208] DEBUG tangotest/tt/1 uShort_image_ro_size=251
Ready to accept request
1453842671 [139685942777600] INFO tangotest/tt/1 TangoTest::always_executed_hook()  TangoTest/tt/1

from the lines

TangoTest.cpp:  LOG_INFO(("TangoTest::init_device::init device %s", device_name.c_str()));
TangoTest.cpp:  LOG_DEBUG(("In read_attr_hardware for %d attributes",attr_list.size()));

Original report from the author of this commit at [1].

[1]: https://www.tango-controls.org/community/forum/c/development/c/log_-macros-not-working/