### PR TITLE
[Backport] Avoid undefined interface warning msvc

### DIFF
--- a/cppapi/server/dintrthread.h
+++ b/cppapi/server/dintrthread.h
@@ -59,7 +59,7 @@ struct _ShDevIntrTh
 	bool			cmd_pending;	// The new command flag
 	DevIntrCmdCode	cmd_code;		// The command code
 	bool			th_running;		// Thread running flag
-	#if _MSC_VER > 1900
+	#if _MSC_VER >= 1900
 	#ifdef interface
 	#undef interface
 	#endif


### PR DESCRIPTION
Undefine interface for Microsoft Visual Studio version 14.0.25431.01 Update 3
comming with _MSC_VER = 1900 to fix compilation error:
 "error C2236: unexpected token 'struct'. Did you forget a ';'?