### PR TITLE
appveyor.yml: Fail jobs faster

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -189,7 +189,7 @@ on_finish:
 
 on_failure:
   #RDP for failure
-  - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
+  # - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
 
 artifacts:
   - path: ./*.exe


### PR DESCRIPTION
The common case is that we are not debugging MSVC failures, therefore we
don't need to wait until the timeout hits if an error occurred.

This can be easily changed back for debugging.