### PR TITLE
travis.yml: remove deprecated skip_cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,6 @@ after_success:
 deploy:
   - provider: script
     script: bash .travis/deploy.sh
-    skip_cleanup: true
     on:
       tags: true
 


### PR DESCRIPTION
skip_cleanup is now deprecated, and cleanup is false by default.
Please refer to https://blog.travis-ci.com/2019-08-27-deployment-tooling-dpl-v2-preview-release for more details