### PR TITLE
Backport: appveyor.yml: Add inline deployment on tag push

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -328,3 +328,20 @@ artifacts:
   - path: ./*.exe
   - path: ./*.zip
   - path: ./*.msi
+
+deploy:
+- provider: GitHub
+  tag: $(APPVEYOR_REPO_TAG_NAME)
+  description: "Release $(APPVEYOR_REPO_TAG_NAME)"
+  auth_token:
+    # User: cppTango-bot
+    # Personal Access token with repo scope, encrypted via https://ci.appveyor.com/tools/encrypt
+    secure: KnvPAbdhmiTQxTLOGq7nyNs6d1JYbKVKspPgigzQ3fDrI+nkaxqWCw6UmRkS2Gqe
+  artifact: /.*/
+  repository: tango-controls/cppTango
+  draft: true
+  prerelease: true
+  force_update: true
+  # deploy on tag push only
+  on:
+    APPVEYOR_REPO_TAG: true


### PR DESCRIPTION
Automate the deployment from appveyor.

We want to publish all artifacts as a new draft prelease on tag push
only.

For reference see https://www.appveyor.com/docs/deployment/github/ and
https://www.appveyor.com/docs/appveyor-yml/.

I have created a new github machine user named cppTango-bot for that.
And also a personal access token which was encrypted on the appveyor
site.