### PR TITLE
Always allow to change attribute alarm thresholds

### DIFF
--- a/cpp_test_suite/new_tests/cxx_attr_misc.cpp
+++ b/cpp_test_suite/new_tests/cxx_attr_misc.cpp
@@ -1078,6 +1078,30 @@ cout << "status = " << status << endl;
 #undef QUOTE
 #undef __QUOTE
 
+/*
+ * Test for changing alarm treshold to value lower than currently read from
+ * hardware. Attribute should have alarm quality after property change.
+ */
+
+    void test_change_max_alarm_threshold_below_current_value()
+    {
+        const char* attr_name = "Short_attr_rw";
+        const DevShort attr_value = 20;
+
+        DeviceAttribute value(attr_name, attr_value);
+        TS_ASSERT_THROWS_NOTHING(device1->write_attribute(value));
+
+        TS_ASSERT_EQUALS(Tango::ON, device1->state());
+        TS_ASSERT_EQUALS(Tango::ATTR_VALID, device1->read_attribute(attr_name).get_quality());
+
+        auto config = device1->get_attribute_config(attr_name);
+        config.alarms.max_alarm = std::to_string(attr_value - 1);
+        AttributeInfoListEx config_in = { config };
+        TS_ASSERT_THROWS_NOTHING(device1->set_attribute_config(config_in));
+
+        TS_ASSERT_EQUALS(Tango::ALARM, device1->state());
+        TS_ASSERT_EQUALS(Tango::ATTR_ALARM, device1->read_attribute(attr_name).get_quality());
+    }
 };
 #undef cout
 #endif // AttrMiscTestSuite_h

--- a/cpp_test_suite/new_tests/cxx_mem_attr.cpp
+++ b/cpp_test_suite/new_tests/cxx_mem_attr.cpp
@@ -166,6 +166,54 @@ public:
 		TS_ASSERT(s_val_2 == 10);
 	}
 
+/*
+ * Test for changing min and max alarm threshold of a  memorized attribute
+ * with neither min_ nor max_value specified. Such scenario used to fail
+ * (#401), with misleading error message claiming that memorized value
+ * is above new limit.
+ */
+
+    void test_change_max_alarm_threshold_of_memorized_attribute()
+    {
+        const char* attr_name = "Short_attr_w";
+        const DevShort attr_value = 20;
+
+        unset_attribute_min_max_value(attr_name);
+
+        DeviceAttribute value(attr_name, attr_value);
+        TS_ASSERT_THROWS_NOTHING(device1->write_attribute(value));
+
+        auto config = device1->get_attribute_config(attr_name);
+        config.alarms.max_alarm = std::to_string(attr_value + 1);
+        AttributeInfoListEx config_in = { config };
+        TS_ASSERT_THROWS_NOTHING(device1->set_attribute_config(config_in));
+    }
+
+    void test_change_min_alarm_threshold_of_memorized_attribute()
+    {
+        const char* attr_name = "Short_attr_w";
+        const DevShort attr_value = -20;
+
+        unset_attribute_min_max_value(attr_name);
+
+        DeviceAttribute value(attr_name, attr_value);
+        TS_ASSERT_THROWS_NOTHING(device1->write_attribute(value));
+
+        auto config = device1->get_attribute_config(attr_name);
+        config.alarms.min_alarm = std::to_string(attr_value - 1);
+        AttributeInfoListEx config_in = { config };
+        TS_ASSERT_THROWS_NOTHING(device1->set_attribute_config(config_in));
+    }
+
+    void unset_attribute_min_max_value(const char* attr_name)
+    {
+        auto config = device1->get_attribute_config(attr_name);
+        config.min_value = AlrmValueNotSpec;
+        config.max_value = AlrmValueNotSpec;
+        AttributeInfoListEx config_in = { config };
+        TS_ASSERT_THROWS_NOTHING(device1->set_attribute_config(config_in));
+    }
 };
+
 #undef cout
 #endif // MemAttrTestSuite_h

--- a/cppapi/server/attrgetsetprop.cpp
+++ b/cppapi/server/attrgetsetprop.cpp
@@ -1320,12 +1320,12 @@ void Attribute::set_one_alarm_prop(const char *prop_name,const CORBA::String_mem
 		{
 			WAttribute *w_att = static_cast<WAttribute *>(this);
 			std::string mem_value;
-			if (strcmp(prop_name,"min_value") == 0 || strcmp(prop_name,"min_alarm") == 0)
+			if (strcmp(prop_name,"min_value") == 0)
 			{
 				if ((w_att->is_memorized() == true) && (w_att->mem_value_below_above(MIN,mem_value) == true))
 					throw_min_max_value(d_name,mem_value,MIN);
 			}
-			else if (strcmp(prop_name,"max_value") == 0 || strcmp(prop_name,"max_alarm") == 0)
+			else if (strcmp(prop_name,"max_value") == 0)
 			{
 				if ((w_att->is_memorized() == true) && (w_att->mem_value_below_above(MAX,mem_value) == true))
 					throw_min_max_value(d_name,mem_value,MAX);


### PR DESCRIPTION
Fixes #401

I couldn't find one so I also added a test that checks if one can set alarm threshold below current attribute value (the attribute goes immediately into alarm state).
