### PR TITLE
Safe interworking between read_attribute() and push_event()

### DIFF
--- a/cpp_test_suite/cpp_test_ds/DevTest.cpp
+++ b/cpp_test_suite/cpp_test_ds/DevTest.cpp
@@ -2659,3 +2659,12 @@ void DevTest::read_ReadWithPushAttr2(Tango::Attribute& att)
     attr_with_push_2 = 17;
     att.set_value(&attr_with_push_2);
 }
+
+void DevTest::read_PushItselfAfterSetAttr(Tango::Attribute& att)
+{
+    cout << "[DevTest::read_attr] attribute name PushItselfAfterSetAttr" << std::endl;
+
+    Tango::DevShort value = 15;
+    att.set_value(&value);
+    push_change_event(att.get_name(), &value);
+}

--- a/cpp_test_suite/cpp_test_ds/DevTest.cpp
+++ b/cpp_test_suite/cpp_test_ds/DevTest.cpp
@@ -2664,7 +2664,8 @@ void DevTest::read_PushItselfAfterSetAttr(Tango::Attribute& att)
 {
     cout << "[DevTest::read_attr] attribute name PushItselfAfterSetAttr" << std::endl;
 
-    Tango::DevShort value = 15;
-    att.set_value(&value);
-    push_change_event(att.get_name(), &value);
+    attr_push_itself_after_set = 15;
+    att.set_value(&attr_push_itself_after_set);
+
+    push_change_event(att.get_name(), &attr_push_itself_after_set);
 }

--- a/cpp_test_suite/cpp_test_ds/DevTest.cpp
+++ b/cpp_test_suite/cpp_test_ds/DevTest.cpp
@@ -2642,3 +2642,20 @@ void DevTest::cmd_push_state_status_event()
 	set_change_event("Status",false,false);
 }
 
+void DevTest::read_ReadWithPushAttr1(Tango::Attribute& att)
+{
+    cout << "[DevTest::read_attr] attribute name ReadWithPushAttr1" << std::endl;
+    attr_with_push_1 = 13;
+    att.set_value(&attr_with_push_1);
+}
+
+void DevTest::read_ReadWithPushAttr2(Tango::Attribute& att)
+{
+    cout << "[DevTest::read_attr] attribute name ReadWithPushAttr2" << std::endl;
+
+    Tango::DevShort new_value = 15;
+    push_change_event("ReadWithPushAttr1", &new_value, 1);
+
+    attr_with_push_2 = 17;
+    att.set_value(&attr_with_push_2);
+}

--- a/cpp_test_suite/cpp_test_ds/DevTest.h
+++ b/cpp_test_suite/cpp_test_ds/DevTest.h
@@ -157,6 +157,8 @@ public :
 	void read_DynEnum_attr(Tango::Attribute &att);
 	void read_ReynaldPoll_attr(Tango::Attribute &att);
 	void read_attr_asyn_write(Tango::Attribute &att);
+	void read_ReadWithPushAttr1(Tango::Attribute&);
+	void read_ReadWithPushAttr2(Tango::Attribute&);
 
 	void write_Short_attr_rw(Tango::WAttribute &att);
 	void write_Long64_attr_rw(Tango::WAttribute &att);
@@ -365,6 +367,8 @@ protected :
     double                                  Reynald_val;
 
     Tango::DevLong                          attr_asyn_write_val;
+    Tango::DevShort attr_with_push_1;
+    Tango::DevShort attr_with_push_2;
 };
 
 #endif

--- a/cpp_test_suite/cpp_test_ds/DevTest.h
+++ b/cpp_test_suite/cpp_test_ds/DevTest.h
@@ -159,6 +159,7 @@ public :
 	void read_attr_asyn_write(Tango::Attribute &att);
 	void read_ReadWithPushAttr1(Tango::Attribute&);
 	void read_ReadWithPushAttr2(Tango::Attribute&);
+	void read_PushItselfAfterSetAttr(Tango::Attribute&);
 
 	void write_Short_attr_rw(Tango::WAttribute &att);
 	void write_Long64_attr_rw(Tango::WAttribute &att);
@@ -369,6 +370,7 @@ protected :
     Tango::DevLong                          attr_asyn_write_val;
     Tango::DevShort attr_with_push_1;
     Tango::DevShort attr_with_push_2;
+    Tango::DevShort attr_push_itself_after_set;
 };
 
 #endif

--- a/cpp_test_suite/cpp_test_ds/DevTestClass.cpp
+++ b/cpp_test_suite/cpp_test_ds/DevTestClass.cpp
@@ -900,6 +900,8 @@ void DevTestClass::attribute_factory(std::vector<Tango::Attr *> &att_list)
   att_list.push_back(new ReadWithPushAttr1());
   att_list.back()->set_change_event(true, false);
   att_list.push_back(new ReadWithPushAttr2());
+  att_list.push_back(new PushItselfAfterSetAttr());
+  att_list.back()->set_change_event(true, false);
 }
 
 void DevTestClass::pipe_factory()

--- a/cpp_test_suite/cpp_test_ds/DevTestClass.cpp
+++ b/cpp_test_suite/cpp_test_ds/DevTestClass.cpp
@@ -896,6 +896,10 @@ void DevTestClass::attribute_factory(std::vector<Tango::Attr *> &att_list)
 
   att_list.push_back(new DynEnumAttr());
   att_list.push_back(new ReynaldPollAttr());
+
+  att_list.push_back(new ReadWithPushAttr1());
+  att_list.back()->set_change_event(true, false);
+  att_list.push_back(new ReadWithPushAttr2());
 }
 
 void DevTestClass::pipe_factory()

--- a/cpp_test_suite/cpp_test_ds/DevTestClass.h
+++ b/cpp_test_suite/cpp_test_ds/DevTestClass.h
@@ -1210,6 +1210,16 @@ public:
     {(static_cast<DevTest *>(dev))->read_ReadWithPushAttr2(att);}
 };
 
+class PushItselfAfterSetAttr : public Tango::Attr
+{
+public:
+    PushItselfAfterSetAttr() : Attr("PushItselfAfterSetAttr", Tango::DEV_SHORT, Tango::READ) {};
+    ~PushItselfAfterSetAttr() {};
+
+    virtual void read(Tango::DeviceImpl *dev,Tango::Attribute &att)
+    {(static_cast<DevTest *>(dev))->read_PushItselfAfterSetAttr(att);}
+};
+
 // ----------------------------------------------------------------------------
 
 

--- a/cpp_test_suite/cpp_test_ds/DevTestClass.h
+++ b/cpp_test_suite/cpp_test_ds/DevTestClass.h
@@ -1190,6 +1190,26 @@ public:
 		{(static_cast<DevTest *>(dev))->read_RPipeDE(*this);}
 };
 
+class ReadWithPushAttr1 : public Tango::Attr
+{
+public:
+    ReadWithPushAttr1() : Attr("ReadWithPushAttr1", Tango::DEV_SHORT, Tango::READ) {};
+    ~ReadWithPushAttr1() {};
+
+    virtual void read(Tango::DeviceImpl *dev,Tango::Attribute &att)
+    {(static_cast<DevTest *>(dev))->read_ReadWithPushAttr1(att);}
+};
+
+class ReadWithPushAttr2 : public Tango::Attr
+{
+public:
+    ReadWithPushAttr2() : Attr("ReadWithPushAttr2", Tango::DEV_SHORT, Tango::READ) {};
+    ~ReadWithPushAttr2() {};
+
+    virtual void read(Tango::DeviceImpl *dev,Tango::Attribute &att)
+    {(static_cast<DevTest *>(dev))->read_ReadWithPushAttr2(att);}
+};
+
 // ----------------------------------------------------------------------------
 
 

--- a/cpp_test_suite/new_tests/cxx_attr_misc.cpp
+++ b/cpp_test_suite/new_tests/cxx_attr_misc.cpp
@@ -1114,6 +1114,9 @@ cout << "status = " << status << endl;
         std::vector<std::string> attributes = {"ReadWithPushAttr2", "ReadWithPushAttr1"};
         std::vector<DeviceAttribute>* result = nullptr;
         TS_ASSERT_THROWS_NOTHING(result = device1->read_attributes(attributes));
+        Tango::DevShort out;
+        TS_ASSERT_THROWS_NOTHING((*result)[0] >> out);
+        TS_ASSERT_THROWS_NOTHING((*result)[1] >> out);
         delete result;
     }
 
@@ -1122,8 +1125,30 @@ cout << "status = " << status << endl;
         std::vector<std::string> attributes = {"ReadWithPushAttr1", "ReadWithPushAttr2"};
         std::vector<DeviceAttribute>* result = nullptr;
         TS_ASSERT_THROWS_NOTHING(result = device1->read_attributes(attributes));
+        Tango::DevShort out;
+        TS_ASSERT_THROWS_NOTHING((*result)[0] >> out);
+        TS_ASSERT_THROWS_NOTHING((*result)[1] >> out);
         delete result;
     }
+
+/*
+ * Test that if attribute pushes an event for itself from its read callback
+ * and push_event is called after set_value, an exception is raised. Such
+ * scenario was reported to cause a crash (#443).
+ */
+
+    void test_read_attribute_that_pushes_event_for_itself_after_calling_set_value()
+    {
+        DeviceAttribute result;
+        TS_ASSERT_THROWS_NOTHING(result = device1->read_attribute("PushItselfAfterSetAttr"));
+
+        Tango::DevShort out;
+        TS_ASSERT_THROWS_ASSERT(
+            result >> out,
+            Tango::DevFailed& e,
+            TS_ASSERT(string(e.errors[0].reason.in()) == "API_AttrValueNotSet"));
+    }
+
 };
 #undef cout
 #endif // AttrMiscTestSuite_h

--- a/cpp_test_suite/new_tests/cxx_attr_misc.cpp
+++ b/cpp_test_suite/new_tests/cxx_attr_misc.cpp
@@ -1109,6 +1109,9 @@ cout << "status = " << status << endl;
  * used to fail with API_AttrValueNotSet as reported in #201.
  */
 
+    static constexpr Tango::DevShort READ_WITH_PUSH_ATTR_1_VALUE = 13;
+    static constexpr Tango::DevShort READ_WITH_PUSH_ATTR_2_VALUE = 17;
+
     void test_read_two_attributes_one_pushes_event_for_another_1st_pushes()
     {
         std::vector<std::string> attributes = {"ReadWithPushAttr2", "ReadWithPushAttr1"};
@@ -1116,7 +1119,9 @@ cout << "status = " << status << endl;
         TS_ASSERT_THROWS_NOTHING(result = device1->read_attributes(attributes));
         Tango::DevShort out;
         TS_ASSERT_THROWS_NOTHING((*result)[0] >> out);
+        TS_ASSERT_EQUALS(out, READ_WITH_PUSH_ATTR_2_VALUE);
         TS_ASSERT_THROWS_NOTHING((*result)[1] >> out);
+        TS_ASSERT_EQUALS(out, READ_WITH_PUSH_ATTR_1_VALUE);
         delete result;
     }
 
@@ -1127,7 +1132,9 @@ cout << "status = " << status << endl;
         TS_ASSERT_THROWS_NOTHING(result = device1->read_attributes(attributes));
         Tango::DevShort out;
         TS_ASSERT_THROWS_NOTHING((*result)[0] >> out);
+        TS_ASSERT_EQUALS(out, READ_WITH_PUSH_ATTR_1_VALUE);
         TS_ASSERT_THROWS_NOTHING((*result)[1] >> out);
+        TS_ASSERT_EQUALS(out, READ_WITH_PUSH_ATTR_2_VALUE);
         delete result;
     }
 

--- a/cpp_test_suite/new_tests/cxx_attr_misc.cpp
+++ b/cpp_test_suite/new_tests/cxx_attr_misc.cpp
@@ -1102,6 +1102,28 @@ cout << "status = " << status << endl;
         TS_ASSERT_EQUALS(Tango::ALARM, device1->state());
         TS_ASSERT_EQUALS(Tango::ATTR_ALARM, device1->read_attribute(attr_name).get_quality());
     }
+
+/*
+ * Tests that it is possible to read two attributes in a single network call
+ * if one of the attributes pushes an event for the other one. Such scenario
+ * used to fail with API_AttrValueNotSet as reported in #201.
+ */
+
+    void test_read_two_attributes_one_pushes_event_for_another_1st_pushes()
+    {
+        std::vector<std::string> attributes = {"ReadWithPushAttr2", "ReadWithPushAttr1"};
+        std::vector<DeviceAttribute>* result = nullptr;
+        TS_ASSERT_THROWS_NOTHING(result = device1->read_attributes(attributes));
+        delete result;
+    }
+
+    void test_read_two_attributes_one_pushes_event_for_another_2nd_pushes()
+    {
+        std::vector<std::string> attributes = {"ReadWithPushAttr1", "ReadWithPushAttr2"};
+        std::vector<DeviceAttribute>* result = nullptr;
+        TS_ASSERT_THROWS_NOTHING(result = device1->read_attributes(attributes));
+        delete result;
+    }
 };
 #undef cout
 #endif // AttrMiscTestSuite_h

--- a/cppapi/server/attribute.cpp
+++ b/cppapi/server/attribute.cpp
@@ -5956,6 +5956,21 @@ void Attribute::remove_client_lib(int _l,const std::string &ev_name)
 		client_lib[i].erase(pos);
 }
 
+bool Attribute::is_readable() const
+{
+    // If the attribute is a forwarded one, force reading it from
+    // the root device. Another client could have written its value
+    return get_writable() != Tango::WRITE || is_fwd_att();
+}
+
+bool Attribute::is_writable() const
+{
+    const auto access_mode = get_writable();
+    return access_mode == Tango::READ_WRITE
+        || access_mode == Tango::READ_WITH_WRITE
+        || (access_mode == Tango::WRITE && ! is_fwd_att());
+}
+
 //-------------------------------------------------------------------------------------------------------------------
 //
 // operator overloading : 	<<

--- a/cppapi/server/attribute.cpp
+++ b/cppapi/server/attribute.cpp
@@ -3906,7 +3906,7 @@ void Attribute::fire_change_event(DevFailed *except)
 					{
 						if (quality != Tango::ATTR_INVALID)
 							delete_seq();
-//						set_value_flag (false);
+						set_value_flag (false);
 					}
 				}
 			}
@@ -3932,7 +3932,7 @@ void Attribute::fire_change_event(DevFailed *except)
 					{
 						if (quality != Tango::ATTR_INVALID)
 							delete_seq();
-//						set_value_flag (false);
+						set_value_flag (false);
 					}
 				}
 			}
@@ -4166,7 +4166,7 @@ void Attribute::fire_change_event(DevFailed *except)
 			{
 				if (quality != Tango::ATTR_INVALID)
 					delete_seq();
-//				set_value_flag (false);
+				set_value_flag (false);
 			}
 		}
 	}
@@ -4189,7 +4189,7 @@ void Attribute::fire_change_event(DevFailed *except)
 			{
 				if (quality != Tango::ATTR_INVALID)
 					delete_seq();
-//				set_value_flag (false);
+				set_value_flag (false);
 			}
 		}
 
@@ -4321,7 +4321,7 @@ void Attribute::fire_archive_event(DevFailed *except)
 					{
 						if (quality != Tango::ATTR_INVALID)
 							delete_seq();
-//						set_value_flag (false);
+						set_value_flag (false);
 					}
                 }
             }
@@ -4355,7 +4355,7 @@ void Attribute::fire_archive_event(DevFailed *except)
 					{
 						if (quality != Tango::ATTR_INVALID)
 							delete_seq();
-//						set_value_flag (false);
+						set_value_flag (false);
 					}
                 }
             }
@@ -4592,7 +4592,7 @@ void Attribute::fire_archive_event(DevFailed *except)
 			{
 				if (quality != Tango::ATTR_INVALID)
 					delete_seq();
-//				set_value_flag (false);
+				set_value_flag (false);
 			}
 		}
 	}
@@ -4616,7 +4616,7 @@ void Attribute::fire_archive_event(DevFailed *except)
 			{
 				if (quality != Tango::ATTR_INVALID)
 					delete_seq();
-//				set_value_flag (false);
+				set_value_flag (false);
 			}
 		}
 
@@ -4754,7 +4754,7 @@ void Attribute::fire_event(std::vector<std::string> &filt_names,std::vector<doub
 					{
 						if (quality != Tango::ATTR_INVALID)
 							delete_seq();
-//						set_value_flag (false);
+						set_value_flag (false);
 					}
 				}
 			}
@@ -4881,7 +4881,7 @@ void Attribute::fire_event(std::vector<std::string> &filt_names,std::vector<doub
 			{
 				if (quality != Tango::ATTR_INVALID)
 					delete_seq();
-//				set_value_flag (false);
+				set_value_flag (false);
 			}
 		}
 	}
@@ -4905,7 +4905,7 @@ void Attribute::fire_event(std::vector<std::string> &filt_names,std::vector<doub
 			{
 				if (quality != Tango::ATTR_INVALID)
 					delete_seq();
-//				set_value_flag (false);
+				set_value_flag (false);
 			}
 		}
 

--- a/cppapi/server/attribute.h
+++ b/cppapi/server/attribute.h
@@ -304,7 +304,7 @@ public:
  *
  * @return The attribute write type.
  */
-	Tango::AttrWriteType get_writable() {return writable;}
+	Tango::AttrWriteType get_writable() const {return writable;}
 /**
  * Get attribute name
  *
@@ -2306,7 +2306,7 @@ public:
 	void throw_startup_exception(const char*);
 
 	bool is_mem_exception() {return att_mem_exception;}
-	virtual bool is_fwd_att() {return false;}
+	virtual bool is_fwd_att() const {return false;}
 
 	void set_client_lib(int, EventType);
 	std::vector<int> &get_client_lib(EventType _et) {return client_lib[_et];}
@@ -2316,6 +2316,9 @@ public:
 	void add_startup_exception(std::string,const DevFailed &);
 
 	void fire_error_periodic_event(DevFailed *);
+
+	bool is_readable() const;
+	bool is_writable() const;
 
 #ifndef TANGO_HAS_LOG4TANGO
 	friend std::ostream &operator<<(std::ostream &,Attribute &);

--- a/cppapi/server/device_3.cpp
+++ b/cppapi/server/device_3.cpp
@@ -579,17 +579,8 @@ void Device_3Impl::update_readable_attribute_value(
     Tango::AttributeIdlData& aid,
     bool second_try,
     std::vector<long>& idx,
-	AttIdx& wanted_attr)
+    AttIdx& wanted_attr)
 {
-//
-// Set attr value (for readable attribute) but not for state/status
-//
-
-    if (wanted_attr.idx_in_multi_attr == -1)
-    {
-        return;
-    }
-
     Attribute &att = dev_attr->get_attr_by_ind(wanted_attr.idx_in_multi_attr);
     bool is_allowed_failed = false;
 

--- a/cppapi/server/device_3.cpp
+++ b/cppapi/server/device_3.cpp
@@ -402,9 +402,6 @@ void Device_3Impl::handle_read_attributes(
     const bool state_wanted = state_idx != STATE_STATUS_NOT_FOUND;
     const bool status_wanted = status_idx != STATE_STATUS_NOT_FOUND;
 
-    std::vector<AttIdx> wanted_attr;
-    std::vector<AttIdx> wanted_w_attr;
-
     auto readable_attributes = get_readable_attributes(attributes);
 
     always_executed_hook();
@@ -419,10 +416,11 @@ void Device_3Impl::handle_read_attributes(
 
         if (writable == Tango::READ_WRITE || writable == Tango::READ_WITH_WRITE)
         {
-            wanted_w_attr.push_back(entry);
-            wanted_attr.push_back(entry);
             att.get_when().tv_sec = 0;
             att.save_alarm_quality();
+
+            update_readable_attribute_value(names, aid, second_try, idx, entry);
+            update_writable_attribute_value(names, aid, second_try, idx, entry);
         }
         else if (writable == Tango::WRITE)
         {
@@ -430,48 +428,26 @@ void Device_3Impl::handle_read_attributes(
             {
                 // If the attribute is a forwarded one, force reading it from
                 // the root device. Another client could have written its value
-                wanted_attr.push_back(entry);
                 att.get_when().tv_sec = 0;
                 att.save_alarm_quality();
+
+                update_readable_attribute_value(names, aid, second_try, idx, entry);
             }
             else
             {
-                wanted_w_attr.push_back(entry);
+                update_writable_attribute_value(names, aid, second_try, idx, entry);
             }
         }
         else
         {
-            wanted_attr.push_back(entry);
             att.get_when().tv_sec = 0;
             att.save_alarm_quality();
-        }
-    }
 
-    const long num_of_names = names.length();
-    for (long i = 0; i < num_of_names; i++)
-    {
-        if (i == state_idx || i == status_idx)
-        {
-            // will be handled separately
-            continue;
+            update_readable_attribute_value(names, aid, second_try, idx, entry);
         }
 
-        const auto is_wanted = [i](const AttIdx& x){ return x.idx_in_names == i; };
-
-        auto wanted = std::find_if(wanted_attr.begin(), wanted_attr.end(), is_wanted);
-        if (wanted != wanted_attr.end())
-        {
-            update_readable_attribute_value(names, aid, second_try, idx, *wanted);
-        }
-
-        auto wanted_w = std::find_if(wanted_w_attr.begin(), wanted_w_attr.end(), is_wanted);
-        if (wanted_w != wanted_w_attr.end())
-        {
-            update_writable_attribute_value(names, aid, second_try, idx, *wanted_w);
-        }
-
-        const long index = second_try ? idx[i] : i;
-        store_attribute_for_network_transfer(names[i], aid, index);
+        const long index = second_try ? idx[entry.idx_in_names] : entry.idx_in_names;
+        store_attribute_for_network_transfer(names[entry.idx_in_names], aid, index);
     }
 
     if (state_wanted)
@@ -591,7 +567,7 @@ void Device_3Impl::update_readable_attribute_value(
     Tango::AttributeIdlData& aid,
     bool second_try,
     std::vector<long>& idx,
-    AttIdx& wanted_attr)
+    const AttIdx& wanted_attr)
 {
     Attribute &att = dev_attr->get_attr_by_ind(wanted_attr.idx_in_multi_attr);
     bool is_allowed_failed = false;
@@ -728,7 +704,7 @@ void Device_3Impl::update_writable_attribute_value(
     Tango::AttributeIdlData& aid,
     bool second_try,
     std::vector<long>& idx,
-    AttIdx& wanted_w_attr)
+    const AttIdx& wanted_w_attr)
 {
 //
 // Set attr value for writable attribute

--- a/cppapi/server/device_3.cpp
+++ b/cppapi/server/device_3.cpp
@@ -351,45 +351,8 @@ void Device_3Impl::read_attributes_no_except(
     AttributeIdlData& data,
     const AttributeIndicesInData& name_to_data_mapping)
 {
-//
-//  Write the device name into the per thread data for sub device diagnostics.
-//  Keep the old name, to put it back at the end!
-//  During device access inside the same server, the thread stays the same!
-//
+    SubDevDiag::ContextManager sub_dev_diag_context{get_name()};
 
-    SubDevDiag &sub = (Tango::Util::instance())->get_sub_dev_diag();
-    std::string last_associated_device = sub.get_associated_device();
-    sub.set_associated_device(get_name());
-
-    try
-    {
-        handle_read_attributes(names, data, name_to_data_mapping);
-    }
-    catch (...)
-    {
-        sub.set_associated_device(last_associated_device);
-        throw;
-    }
-
-    sub.set_associated_device(last_associated_device);
-
-    cout4 << "Leaving Device_3Impl::read_attributes_no_except" << std::endl;
-}
-
-void Device_3Impl::read_attributes_no_except(
-    const AttributeNames& names,
-    AttributeIdlData& data)
-{
-    AttributeIndicesInData indices(names.length());
-    std::iota(indices.begin(), indices.end(), 0);
-    read_attributes_no_except(names, data, indices);
-}
-
-void Device_3Impl::handle_read_attributes(
-    const AttributeNames& names,
-    AttributeIdlData& data,
-    const AttributeIndicesInData& name_to_data_mapping)
-{
     constexpr long STATE_STATUS_NOT_FOUND = -1;
 
     long state_idx = STATE_STATUS_NOT_FOUND;
@@ -452,6 +415,15 @@ void Device_3Impl::handle_read_attributes(
     {
         read_and_store_status_for_network_transfer(data, status_idx);
     }
+}
+
+void Device_3Impl::read_attributes_no_except(
+    const AttributeNames& names,
+    AttributeIdlData& data)
+{
+    AttributeIndicesInData indices(names.length());
+    std::iota(indices.begin(), indices.end(), 0);
+    read_attributes_no_except(names, data, indices);
 }
 
 AttributeAndIndexInDataPairs Device_3Impl::collect_attributes_to_read(

--- a/cppapi/server/device_3.cpp
+++ b/cppapi/server/device_3.cpp
@@ -340,7 +340,7 @@ Tango::AttributeValueList_3* Device_3Impl::read_attributes_3(const Tango::DevVar
 // arguments:
 //		in :
 //			- names: The names of the attribute to read
-//			- data : Structure with pointers for data to be returned to caller (several pointers acoording to
+//			- data : Structure with pointers for data to be returned to caller (several pointers according to
 //					caller IDL level)
 //			- name_to_data_mapping : Vector with index in data array for which we have to read data
 //

--- a/cppapi/server/device_3.cpp
+++ b/cppapi/server/device_3.cpp
@@ -386,7 +386,6 @@ void Device_3Impl::handle_read_attributes(
         if (att_name == "state")
         {
             x.idx_in_multi_attr = -1;
-            x.failed = false;
             wanted_attr.push_back(x);
             state_wanted = true;
             state_idx = i;
@@ -394,7 +393,6 @@ void Device_3Impl::handle_read_attributes(
         else if (att_name == "status")
         {
             x.idx_in_multi_attr = -1;
-            x.failed = false;
             wanted_attr.push_back(x);
             status_wanted = true;
             status_idx = i;
@@ -410,7 +408,6 @@ void Device_3Impl::handle_read_attributes(
                     (dev_attr->get_attr_by_ind(j).get_writable() == Tango::READ_WITH_WRITE))
                 {
                     x.idx_in_multi_attr = j;
-                    x.failed = false;
                     Attribute &att = dev_attr->get_attr_by_ind(x.idx_in_multi_attr);
                     if(att.is_startup_exception())
                         att.throw_startup_exception("Device_3Impl::read_attributes_no_except()");
@@ -432,7 +429,6 @@ void Device_3Impl::handle_read_attributes(
                         if (dev_attr->get_attr_by_ind(j).is_fwd_att() == true)
                         {
                             x.idx_in_multi_attr = j;
-                            x.failed = false;
                             Attribute &att = dev_attr->get_attr_by_ind(x.idx_in_multi_attr);
                             if(att.is_startup_exception())
                                 att.throw_startup_exception("Device_3Impl::read_attributes_no_except()");
@@ -443,7 +439,6 @@ void Device_3Impl::handle_read_attributes(
                         else
                         {
                             x.idx_in_multi_attr = j	;
-                            x.failed = false;
                             Attribute &att = dev_attr->get_attr_by_ind(x.idx_in_multi_attr);
                             if(att.is_startup_exception())
                                 att.throw_startup_exception("Device_3Impl::read_attributes_no_except()");
@@ -453,7 +448,6 @@ void Device_3Impl::handle_read_attributes(
                     else
                     {
                         x.idx_in_multi_attr = j;
-                        x.failed = false;
                         Attribute &att = dev_attr->get_attr_by_ind(x.idx_in_multi_attr);
                         if(att.is_startup_exception())
                             att.throw_startup_exception("Device_3Impl::read_attributes_no_except()");
@@ -647,8 +641,6 @@ void Device_3Impl::update_readable_attribute_value(
         else
             index = idx[wanted_attr.idx_in_names];
 
-        wanted_attr.failed = true;
-
         if (aid.data_5 != nullptr)
         {
             if ((att.get_attr_serial_model() == ATTR_BY_KERNEL) && (is_allowed_failed == false))
@@ -680,7 +672,6 @@ void Device_3Impl::update_readable_attribute_value(
         else
             index = idx[wanted_attr.idx_in_names];
 
-        wanted_attr.failed = true;
         Tango::DevErrorList del;
         del.length(1);
 
@@ -754,7 +745,6 @@ void Device_3Impl::update_writable_attribute_value(
         else
             index = idx[wanted_w_attr.idx_in_names];
 
-        wanted_w_attr.failed = true;
         AttrSerialModel atsm = att.get_attr_serial_model();
 
         if (aid.data_5 != nullptr)
@@ -796,39 +786,25 @@ void Device_3Impl::read_and_store_state_for_network_transfer(
 
     Tango::DevState d_state = Tango::UNKNOWN;
 
-//            long id = reading_state_necessary(wanted_attr);
-    long id = -1;
-    if (id == -1)
+    try
     {
-        try
-        {
-            alarmed_not_read(wanted_attr);
-            state_from_read = true;
-            if (is_alarm_state_forced() == true)
-                d_state = DeviceImpl::dev_state();
-            else
-                d_state = dev_state();
-            state_from_read = false;
-        }
-        catch (Tango::DevFailed &e)
-        {
-            state_from_read = false;
-            if (aid.data_5 != nullptr)
-                error_from_devfailed((*aid.data_5)[state_idx], e, name);
-            else if (aid.data_4 != nullptr)
-                error_from_devfailed((*aid.data_4)[state_idx], e, name);
-            else
-                error_from_devfailed((*aid.data_3)[state_idx], e, name);
-        }
-    }
-    else
-    {
-        if (aid.data_5 != nullptr)
-            error_from_errorlist((*aid.data_5)[state_idx], (*aid.data_5)[wanted_attr[id].idx_in_names].err_list, name);
-        else if (aid.data_4 != nullptr)
-            error_from_errorlist((*aid.data_4)[state_idx], (*aid.data_4)[wanted_attr[id].idx_in_names].err_list, name);
+        alarmed_not_read(wanted_attr);
+        state_from_read = true;
+        if (is_alarm_state_forced() == true)
+            d_state = DeviceImpl::dev_state();
         else
-            error_from_errorlist((*aid.data_3)[state_idx], (*aid.data_3)[wanted_attr[id].idx_in_names].err_list, name);
+            d_state = dev_state();
+        state_from_read = false;
+    }
+    catch (Tango::DevFailed &e)
+    {
+        state_from_read = false;
+        if (aid.data_5 != nullptr)
+            error_from_devfailed((*aid.data_5)[state_idx], e, name);
+        else if (aid.data_4 != nullptr)
+            error_from_devfailed((*aid.data_4)[state_idx], e, name);
+        else
+            error_from_devfailed((*aid.data_3)[state_idx], e, name);
     }
 
     if (is_error_stored(aid, state_idx))
@@ -2618,54 +2594,6 @@ void Device_3Impl::add_alarmed(std::vector<long> &att_list)
 			}
 		}
 	}
-}
-
-
-//+--------------------------------------------------------------------------------------------------------------------
-//
-// method :
-//		Device_3Impl::reading_state_necessary
-//
-// description :
-//		Method to check if it is necessary to read state. If the device has some alarmed attribute and one of these
-//		attributes has already been read and failed, it is not necessary to read state. It will also fail.
-//
-// argument:
-//		in :
-//			- wanted_attr : The list of attribute to be read by this call
-//
-// return:
-// 		This  method returns -1 if reading state is possible. Otherwise, it returns the index in the wanted_attr list
-// 		of the alarmed attribute which failed
-//
-//--------------------------------------------------------------------------------------------------------------------
-
-long Device_3Impl::reading_state_necessary(std::vector<AttIdx> &wanted_attr)
-{
-	std::vector<long> &alarmed_list = dev_attr->get_alarm_list();
-	long nb_alarmed_attr = alarmed_list.size();
-	long ret = -1;
-
-	if (nb_alarmed_attr == 0)
-		ret = -1;
-
-	else
-	{
-		long nb_attr = wanted_attr.size();
-		for (int j = 0;j < nb_alarmed_attr;j++)
-		{
-			for (int i = 0;i < nb_attr;i++)
-			{
-				if (alarmed_list[j] == wanted_attr[i].idx_in_multi_attr)
-				{
-					if (wanted_attr[i].failed == true)
-						return i;
-				}
-			}
-		}
-	}
-
-	return ret;
 }
 
 //+-------------------------------------------------------------------------------------------------------------------

--- a/cppapi/server/device_3.h
+++ b/cppapi/server/device_3.h
@@ -334,6 +334,45 @@ private:
 
     void real_ctor();
 
+    void call_read_attr_hardware_if_needed(
+        const std::vector<AttIdx>&,
+        bool state_wanted);
+    void update_readable_attribute_value(
+        const Tango::DevVarStringArray&,
+        Tango::AttributeIdlData&,
+        bool second_try,
+        std::vector<long>& idx,
+        AttIdx&);
+    void update_writable_attribute_value(
+        const Tango::DevVarStringArray&,
+        Tango::AttributeIdlData&,
+        bool second_try,
+        std::vector<long>& idx,
+        AttIdx&);
+    void read_state_and_status(
+        const Tango::DevVarStringArray&,
+        Tango::AttributeIdlData&,
+        std::vector<AttIdx>&,
+        bool state_wanted,
+        bool status_wanted,
+        int state_idx,
+        int status_idx,
+        Tango::DevState&,
+        Tango::ConstDevString&);
+    void store_attribute_for_network_transfer(
+        const Tango::DevVarStringArray&,
+        Tango::AttributeIdlData&,
+        bool second_try,
+        std::vector<long>& idx,
+        bool state_wanted,
+        bool status_wanted,
+        int state_idx,
+        int status_idx,
+        int attribute_index,
+        Tango::DevState&,
+        Tango::ConstDevString&);
+
+
     std::unique_ptr<Device_3ImplExt>     ext_3;           // Class extension
 };
 

--- a/cppapi/server/device_3.h
+++ b/cppapi/server/device_3.h
@@ -306,9 +306,6 @@ protected:
 	template <typename T,typename V>
 	void set_attribute_config_3_local(const T &,const V &,bool,int);
 
-	template <typename T> void error_from_devfailed(T &,DevFailed &,const char *);
-	template <typename T> void error_from_errorlist(T &,DevErrorList &,const char *);
-
 	template <typename T> void one_error(T &,const char *,const char *,std::string &,Attribute &);
 	template <typename T> void one_error(T &,const char *,const char *,std::string &,const char *);
 

--- a/cppapi/server/device_3.h
+++ b/cppapi/server/device_3.h
@@ -354,28 +354,19 @@ private:
         bool second_try,
         std::vector<long>& idx,
         AttIdx&);
-    void read_state_and_status(
-        const Tango::DevVarStringArray&,
+    void read_and_store_state_for_network_transfer(
+        const char* name,
         Tango::AttributeIdlData&,
-        std::vector<AttIdx>&,
-        bool state_wanted,
-        bool status_wanted,
         int state_idx,
-        int status_idx,
-        Tango::DevState&,
-        Tango::ConstDevString&);
+        std::vector<AttIdx>&);
+    void read_and_store_status_for_network_transfer(
+        const char* name,
+        Tango::AttributeIdlData&,
+        int status_idx);
     void store_attribute_for_network_transfer(
-        const Tango::DevVarStringArray&,
+        const char* name,
         Tango::AttributeIdlData&,
-        bool second_try,
-        std::vector<long>& idx,
-        bool state_wanted,
-        bool status_wanted,
-        int state_idx,
-        int status_idx,
-        int attribute_index,
-        Tango::DevState&,
-        Tango::ConstDevString&);
+        int index);
 
 
     std::unique_ptr<Device_3ImplExt>     ext_3;           // Class extension

--- a/cppapi/server/device_3.h
+++ b/cppapi/server/device_3.h
@@ -65,6 +65,8 @@ struct AttIdx
 	long	idx_in_multi_attr;
 };
 
+using AttributeAndIndexInDataPairs = std::vector<std::pair<Attribute*, long>>;
+
 /**
  * Base class for all TANGO device since version 3.
  *
@@ -333,26 +335,21 @@ private:
         const Tango::DevVarStringArray&,
         Tango::AttributeIdlData&,
         bool second_try,
-        std::vector<long> &idx);
-    std::vector<AttIdx> collect_attributes_to_read(
+        std::vector<long>& names_to_data_idx_mapping);
+    AttributeAndIndexInDataPairs collect_attributes_to_read(
         const Tango::DevVarStringArray&,
         Tango::AttributeIdlData&,
         bool second_try,
-        const std::vector<long>& idx,
-        long& state_index,
-        long& status_index);
-    AttributeIndices get_readable_attributes(const std::vector<AttIdx>& attributes);
+        std::vector<long>& names_to_data_idx_mapping,
+        long& state_index_in_data,
+        long& status_index_in_data);
+    AttributeIndices get_readable_attributes(const AttributeAndIndexInDataPairs&);
     void call_read_attr_hardware_if_needed(const AttributeIndices&, bool state_wanted);
     void update_readable_attribute_value(Attribute&, AttributeIdlData&, long index_in_data);
     void update_writable_attribute_value(Attribute&, AttributeIdlData&, long index_in_data);
     void store_attribute_for_network_transfer(Attribute&, AttributeIdlData&, long index_in_data);
-    void read_and_store_state_for_network_transfer(
-        Tango::AttributeIdlData&,
-        int state_idx,
-        const AttributeIndices&);
-    void read_and_store_status_for_network_transfer(
-        Tango::AttributeIdlData&,
-        int status_idx);
+    void read_and_store_state_for_network_transfer(AttributeIdlData&, long index_in_data, const AttributeIndices&);
+    void read_and_store_status_for_network_transfer(AttributeIdlData&, long index_in_data);
 
 
     std::unique_ptr<Device_3ImplExt>     ext_3;           // Class extension

--- a/cppapi/server/device_3.h
+++ b/cppapi/server/device_3.h
@@ -334,6 +334,11 @@ private:
 
     void real_ctor();
 
+    void handle_read_attributes(
+        const Tango::DevVarStringArray&,
+        Tango::AttributeIdlData&,
+        bool second_try,
+        std::vector<long> &idx);
     void call_read_attr_hardware_if_needed(
         const std::vector<AttIdx>&,
         bool state_wanted);

--- a/cppapi/server/device_3.h
+++ b/cppapi/server/device_3.h
@@ -348,13 +348,13 @@ private:
         Tango::AttributeIdlData&,
         bool second_try,
         std::vector<long>& idx,
-        AttIdx&);
+        const AttIdx&);
     void update_writable_attribute_value(
         const Tango::DevVarStringArray&,
         Tango::AttributeIdlData&,
         bool second_try,
         std::vector<long>& idx,
-        AttIdx&);
+        const AttIdx&);
     void read_and_store_state_for_network_transfer(
         const char* name,
         Tango::AttributeIdlData&,

--- a/cppapi/server/device_3.h
+++ b/cppapi/server/device_3.h
@@ -343,31 +343,16 @@ private:
         long& status_index);
     AttributeIndices get_readable_attributes(const std::vector<AttIdx>& attributes);
     void call_read_attr_hardware_if_needed(const AttributeIndices&, bool state_wanted);
-    void update_readable_attribute_value(
-        const Tango::DevVarStringArray&,
-        Tango::AttributeIdlData&,
-        bool second_try,
-        std::vector<long>& idx,
-        const AttIdx&);
-    void update_writable_attribute_value(
-        const Tango::DevVarStringArray&,
-        Tango::AttributeIdlData&,
-        bool second_try,
-        std::vector<long>& idx,
-        const AttIdx&);
+    void update_readable_attribute_value(Attribute&, AttributeIdlData&, long index_in_data);
+    void update_writable_attribute_value(Attribute&, AttributeIdlData&, long index_in_data);
+    void store_attribute_for_network_transfer(Attribute&, AttributeIdlData&, long index_in_data);
     void read_and_store_state_for_network_transfer(
-        const char* name,
         Tango::AttributeIdlData&,
         int state_idx,
         const AttributeIndices&);
     void read_and_store_status_for_network_transfer(
-        const char* name,
         Tango::AttributeIdlData&,
         int status_idx);
-    void store_attribute_for_network_transfer(
-        const char* name,
-        Tango::AttributeIdlData&,
-        int index);
 
 
     std::unique_ptr<Device_3ImplExt>     ext_3;           // Class extension

--- a/cppapi/server/device_3.h
+++ b/cppapi/server/device_3.h
@@ -334,7 +334,6 @@ private:
 
     void real_ctor();
 
-    void handle_read_attributes(const AttributeNames&, AttributeIdlData&, const AttributeIndicesInData&);
     AttributeAndIndexInDataPairs collect_attributes_to_read(
         const AttributeNames&,
         AttributeIdlData&,

--- a/cppapi/server/device_3.h
+++ b/cppapi/server/device_3.h
@@ -334,6 +334,13 @@ private:
         Tango::AttributeIdlData&,
         bool second_try,
         std::vector<long> &idx);
+    std::vector<AttIdx> collect_attributes_to_read(
+        const Tango::DevVarStringArray&,
+        Tango::AttributeIdlData&,
+        bool second_try,
+        const std::vector<long>& idx,
+        long& state_index,
+        long& status_index);
     void call_read_attr_hardware_if_needed(
         const std::vector<AttIdx>&,
         bool state_wanted);

--- a/cppapi/server/device_3.h
+++ b/cppapi/server/device_3.h
@@ -63,7 +63,6 @@ struct AttIdx
 {
 	long	idx_in_names;
 	long	idx_in_multi_attr;
-	bool	failed;
 };
 
 /**
@@ -294,7 +293,6 @@ protected:
 	void read_attributes_no_except(const Tango::DevVarStringArray&,Tango::AttributeIdlData &,bool,std::vector<long> &);
 	void write_attributes_in_db(std::vector<long> &,std::vector<AttIdx> &);
 	void add_alarmed(std::vector<long> &);
-	long reading_state_necessary(std::vector<AttIdx> &);
 	void state2attr(Tango::DevState,Tango::AttributeValue_3 &);
 	void state2attr(Tango::DevState,Tango::AttributeValue_4 &);
 	void state2attr(Tango::DevState,Tango::AttributeValue_5 &);

--- a/cppapi/server/device_3.h
+++ b/cppapi/server/device_3.h
@@ -292,14 +292,14 @@ protected:
 /// @privatesection
 	void read_attributes_no_except(const Tango::DevVarStringArray&,Tango::AttributeIdlData &,bool,std::vector<long> &);
 	void write_attributes_in_db(std::vector<long> &,std::vector<AttIdx> &);
-	void add_alarmed(std::vector<long> &);
+	void add_alarmed(AttributeIndices&);
 	void state2attr(Tango::DevState,Tango::AttributeValue_3 &);
 	void state2attr(Tango::DevState,Tango::AttributeValue_4 &);
 	void state2attr(Tango::DevState,Tango::AttributeValue_5 &);
 	void status2attr(Tango::ConstDevString,Tango::AttributeValue_3 &);
 	void status2attr(Tango::ConstDevString,Tango::AttributeValue_4 &);
 	void status2attr(Tango::ConstDevString,Tango::AttributeValue_5 &);
-	void alarmed_not_read(std::vector<AttIdx> &);
+	void alarmed_not_read(const AttributeIndices&);
 
 	void write_attributes_34(const Tango::AttributeValueList *,const Tango::AttributeValueList_4 *);
 
@@ -341,9 +341,8 @@ private:
         const std::vector<long>& idx,
         long& state_index,
         long& status_index);
-    void call_read_attr_hardware_if_needed(
-        const std::vector<AttIdx>&,
-        bool state_wanted);
+    AttributeIndices get_readable_attributes(const std::vector<AttIdx>& attributes);
+    void call_read_attr_hardware_if_needed(const AttributeIndices&, bool state_wanted);
     void update_readable_attribute_value(
         const Tango::DevVarStringArray&,
         Tango::AttributeIdlData&,
@@ -360,7 +359,7 @@ private:
         const char* name,
         Tango::AttributeIdlData&,
         int state_idx,
-        std::vector<AttIdx>&);
+        const AttributeIndices&);
     void read_and_store_status_for_network_transfer(
         const char* name,
         Tango::AttributeIdlData&,

--- a/cppapi/server/device_3.h
+++ b/cppapi/server/device_3.h
@@ -65,7 +65,9 @@ struct AttIdx
 	long	idx_in_multi_attr;
 };
 
+using AttributeNames = DevVarStringArray;
 using AttributeAndIndexInDataPairs = std::vector<std::pair<Attribute*, long>>;
+using AttributeIndicesInData = std::vector<long>;
 
 /**
  * Base class for all TANGO device since version 3.
@@ -292,7 +294,8 @@ public:
 
 protected:
 /// @privatesection
-	void read_attributes_no_except(const Tango::DevVarStringArray&,Tango::AttributeIdlData &,bool,std::vector<long> &);
+	void read_attributes_no_except(const Tango::DevVarStringArray&, Tango::AttributeIdlData&);
+	void read_attributes_no_except(const Tango::DevVarStringArray&, Tango::AttributeIdlData&, const AttributeIndicesInData&);
 	void write_attributes_in_db(std::vector<long> &,std::vector<AttIdx> &);
 	void add_alarmed(AttributeIndices&);
 	void state2attr(Tango::DevState,Tango::AttributeValue_3 &);
@@ -331,16 +334,11 @@ private:
 
     void real_ctor();
 
-    void handle_read_attributes(
-        const Tango::DevVarStringArray&,
-        Tango::AttributeIdlData&,
-        bool second_try,
-        std::vector<long>& names_to_data_idx_mapping);
+    void handle_read_attributes(const AttributeNames&, AttributeIdlData&, const AttributeIndicesInData&);
     AttributeAndIndexInDataPairs collect_attributes_to_read(
-        const Tango::DevVarStringArray&,
-        Tango::AttributeIdlData&,
-        bool second_try,
-        std::vector<long>& names_to_data_idx_mapping,
+        const AttributeNames&,
+        AttributeIdlData&,
+        const AttributeIndicesInData&,
         long& state_index_in_data,
         long& status_index_in_data);
     AttributeIndices get_readable_attributes(const AttributeAndIndexInDataPairs&);

--- a/cppapi/server/device_3.tpp
+++ b/cppapi/server/device_3.tpp
@@ -297,24 +297,6 @@ void Device_3Impl::set_attribute_config_3_local(const T &new_conf,TANGO_UNUSED(c
 }
 
 template <typename T>
-inline void Device_3Impl::error_from_devfailed(T &back,DevFailed &e,const char *na)
-{
-	back.err_list = e.errors;
-	back.quality = ATTR_INVALID;
-	back.name = Tango::string_dup(na);
-	clear_att_dim(back);
-}
-
-template <typename T>
-inline void Device_3Impl::error_from_errorlist(T &back,DevErrorList &e,const char *na)
-{
-	back.err_list = e;
-	back.quality = ATTR_INVALID;
-	back.name = Tango::string_dup(na);
-	clear_att_dim(back);
-}
-
-template <typename T>
 inline void Device_3Impl::one_error(T &back,const char *reas,const char *ori,std::string &mess,Attribute &att)
 {
 	back.err_list.length(1);

--- a/cppapi/server/device_4.cpp
+++ b/cppapi/server/device_4.cpp
@@ -589,7 +589,7 @@ Tango::AttributeValueList_4* Device_4Impl::read_attributes_4(const Tango::DevVar
 		try
 		{
 			AutoTangoMonitor sync(this);
-			read_attributes_no_except(real_names,aid,false,idx_in_back);
+			read_attributes_no_except(real_names, aid);
 		}
 		catch (...)
 		{
@@ -672,7 +672,7 @@ Tango::AttributeValueList_4* Device_4Impl::read_attributes_4(const Tango::DevVar
 
 				{
 					AutoTangoMonitor sync(this);
-					read_attributes_no_except(fwd_names,aid,true,idx_in_back);
+					read_attributes_no_except(fwd_names, aid, idx_in_back);
 					idx_in_back.clear();
 				}
 			}
@@ -742,7 +742,7 @@ Tango::AttributeValueList_4* Device_4Impl::read_attributes_4(const Tango::DevVar
 			try
 			{
 				AutoTangoMonitor sync(this);
-				read_attributes_no_except(names_from_device,aid,true,idx_in_back);
+				read_attributes_no_except(names_from_device, aid, idx_in_back);
 			}
 			catch (...)
 			{

--- a/cppapi/server/device_5.cpp
+++ b/cppapi/server/device_5.cpp
@@ -203,7 +203,7 @@ Tango::AttributeValueList_5* Device_5Impl::read_attributes_5(const Tango::DevVar
 		try
 		{
 			AutoTangoMonitor sync(this);
-			read_attributes_no_except(real_names,aid,false,idx_in_back);
+			read_attributes_no_except(real_names, aid);
 		}
 		catch (...)
 		{
@@ -286,7 +286,7 @@ Tango::AttributeValueList_5* Device_5Impl::read_attributes_5(const Tango::DevVar
 
 				{
 					AutoTangoMonitor sync(this);
-					read_attributes_no_except(fwd_names,aid,true,idx_in_back);
+					read_attributes_no_except(fwd_names, aid, idx_in_back);
 					idx_in_back.clear();
 				}
 			}
@@ -356,7 +356,7 @@ Tango::AttributeValueList_5* Device_5Impl::read_attributes_5(const Tango::DevVar
 			try
 			{
 				AutoTangoMonitor sync(this);
-				read_attributes_no_except(names_from_device,aid,true,idx_in_back);
+				read_attributes_no_except(names_from_device, aid, idx_in_back);
 			}
 			catch (...)
 			{

--- a/cppapi/server/fwdattribute.h
+++ b/cppapi/server/fwdattribute.h
@@ -48,7 +48,7 @@ public:
 	FwdAttribute(std::vector<AttrProperty> &,Attr &,std::string &,long);
 	~FwdAttribute();
 
-	virtual bool is_fwd_att() {return true;}
+	virtual bool is_fwd_att() const {return true;}
 	std::string &get_fwd_dev_name() {return fwd_dev_name;}
 	std::string &get_fwd_att_name() {return fwd_att_name;}
 

--- a/cppapi/server/multiattribute.h
+++ b/cppapi/server/multiattribute.h
@@ -43,6 +43,9 @@
 namespace Tango
 {
 
+using AttributeIndex = long;
+using AttributeIndices = std::vector<AttributeIndex>;
+
 class AttrProperty;
 class DeviceClass;
 

--- a/cppapi/server/subdev_diag.cpp
+++ b/cppapi/server/subdev_diag.cpp
@@ -486,4 +486,16 @@ void SubDevDiag::get_sub_devices_from_cache()
 		std::cerr << "No database cache found to initialise sub device map!" << std::endl;
 }
 
+SubDevDiag::ContextManager::ContextManager(std::string device_name)
+    : diag(Tango::Util::instance()->get_sub_dev_diag())
+    , previous_device_name(diag.get_associated_device())
+{
+    diag.set_associated_device(std::move(device_name));
+}
+
+SubDevDiag::ContextManager::~ContextManager()
+{
+    diag.set_associated_device(std::move(previous_device_name));
+}
+
 } // End of Tango namespace

--- a/cppapi/server/subdev_diag.h
+++ b/cppapi/server/subdev_diag.h
@@ -42,6 +42,17 @@ namespace Tango
 
 class SubDevDiag
 {
+public:
+    class ContextManager
+    {
+    public:
+        ContextManager(std::string device_name);
+        ~ContextManager();
+    private:
+        SubDevDiag& diag;
+        std::string previous_device_name;
+    };
+
 private:
 	// Type definition and map to keep the
 	// list of accessed sub devices in a device server.


### PR DESCRIPTION
This PR fixes two crashes reported in #443:
1. When Attr1 and Attr2 are read in single read_attributes({Attr1, Attr2}) and Attr2 pushes change event for Attr1 (order of attribute names passed to read_attributes is important here)
2. When attribute pushes a change event for itself from read callback after calling set_value.

In the first case, when Attr2 read callback pushes an event for Attr1, it overwrites and then releases CORBA sequence associated with Attr1. This is because sequence obtained from Attr1 read callback is not yet copied for network transfer when Attr2 read callback is called, i.e. it worked like this pseudocode:
```cpp
for(Attribute& a : attributes) { invoke_read_callback(a); }
for(Attribute& a : attributes) { store_sequence(a); }
```
This PR changes the behavior to be like:
```cpp
for(Attribute& a : attributes) { invoke_read_callback(a); store_sequence(a); }
```
This resolved the issue and allowed to revert correction for #241 which attempted to fix the same problem by keeping value flag set to true after deleting the sequence. Correction for #241 (330a68c) worked only for scenarios where attribute that pushed event was read first and resulted in a crash when attribute reading order was inverted.

In the second case, when push_event is called after set_value, we now get API_AttrValueNotSet exception instead of a crash. This is just result of reverting previous #241 correction. We cannot really 'fix' this scenario and make it work as one would expect because push_event and set_value are operating on the same buffer and push_event automatically releases that buffer when it is done with pushing the event. See also https://github.com/tango-controls/cppTango/issues/443#issuecomment-569268014.

I also took the opportunity to refactor whole Device_3Impl::read_attributes_no_except and split it into more manageable chunks.

Fixes #443, #241.