### PR TITLE
Enforce non-interactive package installation in CI

### DIFF
--- a/.travis/debian10/Dockerfile
+++ b/.travis/debian10/Dockerfile
@@ -6,6 +6,8 @@ ARG APP_GID=2000
 
 MAINTAINER TANGO Controls team <tango@esrf.fr>
 
+ENV DEBIAN_FRONTEND=noninteractive
+
 RUN apt-get update && apt-get install -y \
   apt-utils                              \
   build-essential                        \

--- a/.travis/debian8/Dockerfile
+++ b/.travis/debian8/Dockerfile
@@ -6,6 +6,8 @@ ARG APP_GID=2000
 
 MAINTAINER TANGO Controls team <tango@esrf.fr>
 
+ENV DEBIAN_FRONTEND=noninteractive
+
 RUN sed -i '/jessie-updates/d' /etc/apt/sources.list  # Now archived
 
 RUN apt-get update && apt-get install -y \

--- a/.travis/debian9/Dockerfile
+++ b/.travis/debian9/Dockerfile
@@ -6,6 +6,8 @@ ARG APP_GID=2000
 
 MAINTAINER TANGO Controls team <tango@esrf.fr>
 
+ENV DEBIAN_FRONTEND=noninteractive
+
 RUN apt-get update && apt-get install -y \
   apt-utils                              \
   build-essential                        \

--- a/.travis/gcc-latest/Dockerfile
+++ b/.travis/gcc-latest/Dockerfile
@@ -6,6 +6,8 @@ ARG APP_GID=2000
 
 MAINTAINER TANGO Controls team <tango@esrf.fr>
 
+ENV DEBIAN_FRONTEND=noninteractive
+
 RUN apt-get update && apt-get install -y \
   apt-utils                              \
   build-essential                        \

--- a/.travis/llvm-latest/Dockerfile
+++ b/.travis/llvm-latest/Dockerfile
@@ -8,6 +8,8 @@ ARG APP_GID=2000
 
 MAINTAINER TANGO Controls team <tango@esrf.fr>
 
+ENV DEBIAN_FRONTEND=noninteractive
+
 RUN apt-get update && apt-get install -y \
   apt-utils                              \
   build-essential                        \

--- a/.travis/ubuntu-20.04/Dockerfile
+++ b/.travis/ubuntu-20.04/Dockerfile
@@ -6,6 +6,8 @@ ARG APP_GID=2000
 
 MAINTAINER TANGO Controls team <tango@esrf.fr>
 
+ENV DEBIAN_FRONTEND=noninteractive
+
 RUN apt-get update && apt-get install -y \
   apt-utils                              \
   build-essential                        \


### PR DESCRIPTION
Fixes issue with failing ubuntu:focal jobs due to tzdata package asking
user to provide information about location and timezone.