### PR TITLE
Backport fix for #496 and #361 - event clients lost after dev restart

### DIFF
--- a/cpp_test_suite/new_tests/cxx_dserver_misc.cpp
+++ b/cpp_test_suite/new_tests/cxx_dserver_misc.cpp
@@ -14,6 +14,26 @@ using namespace std;
 #undef SUITE_NAME
 #define SUITE_NAME DServerMiscTestSuite
 
+struct EventCallback : public Tango::CallBack
+{
+    EventCallback()
+        : num_of_all_events(0)
+        , num_of_error_events(0)
+    {}
+
+    void push_event(Tango::EventData* event)
+    {
+        num_of_all_events++;
+        if (event->err)
+        {
+            num_of_error_events++;
+        }
+    }
+
+    int num_of_all_events;
+    int num_of_error_events;
+};
+
 class DServerMiscTestSuite: public CxxTest::TestSuite
 {
 protected:
@@ -211,6 +231,38 @@ cout << "str = " << str << endl;
 		TS_ASSERT(dserver->info().server_id == full_ds_name);
 		TS_ASSERT(dserver->info().server_version == server_version);
 	}
+
+    /* Tests that subscriber can receive events immediately after
+     * a device restart without a need to wait for re-subscription.
+     */
+    void test_event_subscription_recovery_after_device_restart()
+    {
+        EventCallback callback{};
+
+        std::string attribute_name = "event_change_tst";
+
+        TS_ASSERT_THROWS_NOTHING(device1->subscribe_event(
+            attribute_name,
+            Tango::USER_EVENT,
+            &callback));
+
+        TS_ASSERT_THROWS_NOTHING(device1->command_inout("IOPushEvent"));
+        Tango_sleep(2);
+        TS_ASSERT_EQUALS(2, callback.num_of_all_events);
+        TS_ASSERT_EQUALS(0, callback.num_of_error_events);
+
+        {
+            Tango::DeviceData input{};
+            input << device1_name;
+            TS_ASSERT_THROWS_NOTHING(dserver->command_inout("DevRestart", input));
+        }
+
+        TS_ASSERT_THROWS_NOTHING(device1->command_inout("IOPushEvent"));
+        Tango_sleep(2);
+        TS_ASSERT_EQUALS(3, callback.num_of_all_events);
+        TS_ASSERT_EQUALS(0, callback.num_of_error_events);
+    }
+
 };
 #undef cout
 #endif // DServerMiscTestSuite_h

--- a/cppapi/server/device.cpp
+++ b/cppapi/server/device.cpp
@@ -6148,6 +6148,25 @@ void DeviceImpl::get_event_param(vector<EventPar> &eve)
     }
 }
 
+void DeviceImpl::get_event_param(vector<EventSubscriptionState> &eve)
+{
+    ZmqEventSupplier *event_supplier_zmq = Util::instance()->get_zmq_event_supplier();
+
+    if (event_supplier_zmq->any_dev_intr_client(this) == true)
+    {
+        EventSubscriptionState ep;
+
+        ep.notifd = false;
+        ep.zmq = true;
+        ep.attribute_name = "";
+        ep.quality = false;
+        ep.data_ready = false;
+        ep.dev_intr_change = true;
+
+        eve.push_back(ep);
+    }
+}
+
 //+-----------------------------------------------------------------------------------------------------------------
 //
 // method :
@@ -6167,6 +6186,21 @@ void DeviceImpl::set_event_param(vector<EventPar> &eve)
     for (size_t loop = 0; loop < eve.size(); loop++)
     {
         if (eve[loop].attr_id == -1)
+        {
+            if (eve[loop].dev_intr_change == true)
+            {
+                set_event_intr_change_subscription(time(NULL));
+            }
+            break;
+        }
+    }
+}
+
+void DeviceImpl::set_event_param(vector<EventSubscriptionState> &eve)
+{
+    for (size_t loop = 0; loop < eve.size(); loop++)
+    {
+        if (eve[loop].attribute_name.empty())
         {
             if (eve[loop].dev_intr_change == true)
             {

--- a/cppapi/server/device.h
+++ b/cppapi/server/device.h
@@ -3414,8 +3414,10 @@ public:
 	void disable_intr_change_ev() {intr_change_ev = false;}
 	bool is_intr_change_ev_enable() {return intr_change_ev;}
 
-	void get_event_param(vector<EventPar> &);
-	void set_event_param(vector<EventPar> &);
+	void get_event_param(vector<EventPar> &); // Deprecated, use EventSubscriptionState overload
+	void set_event_param(vector<EventPar> &); // Deprecated, use EventSubscriptionState overload
+	void get_event_param(vector<EventSubscriptionState>&);
+	void set_event_param(vector<EventSubscriptionState>&);
 
 	void set_client_lib(int _l) {if (count(client_lib.begin(),client_lib.end(),_l)==0)client_lib.push_back(_l);}
 

--- a/cppapi/server/dserver.cpp
+++ b/cppapi/server/dserver.cpp
@@ -1102,9 +1102,11 @@ void DServer::restart(string &d_name)
 // Attribute properties may have changed after the restart.
 // Push an attribute configuration event to all registered subscribers.
 
-	for (Attribute* attr : new_dev->get_device_attr()->get_attribute_list())
+	vector<Tango::Attribute*>& dev_att_list = new_dev->get_device_attr()->get_attribute_list();
+	vector<Tango::Attribute*>::iterator ite_att;
+	for (ite_att = dev_att_list.begin(); ite_att != dev_att_list.end() ; ++ite_att)
 	{
-		new_dev->push_att_conf_event(attr);
+		new_dev->push_att_conf_event(*ite_att);
 	}
 }
 

--- a/cppapi/server/dserver.cpp
+++ b/cppapi/server/dserver.cpp
@@ -1098,6 +1098,14 @@ void DServer::restart(string &d_name)
 			event_supplier_zmq->push_dev_intr_change_event(new_dev,false,cmds_list,atts_list);
 		}
 	}
+
+// Attribute properties may have changed after the restart.
+// Push an attribute configuration event to all registered subscribers.
+
+	for (Attribute* attr : new_dev->get_device_attr()->get_attribute_list())
+	{
+		new_dev->push_att_conf_event(attr);
+	}
 }
 
 //+-----------------------------------------------------------------------------------------------------------------

--- a/cppapi/server/dserver.cpp
+++ b/cppapi/server/dserver.cpp
@@ -861,7 +861,7 @@ void DServer::restart(string &d_name)
 
 	vector<PollObj *> &p_obj = dev_to_del->get_poll_obj_list();
 	vector<Pol> dev_pol;
-	vector<EventPar> eve;
+	vector<EventSubscriptionState> eve;
 
 	for (i = 0;i < p_obj.size();i++)
 	{
@@ -1172,7 +1172,7 @@ void ServRestartThread::run(void *ptr)
 // Memorize event parameters and devices interface
 //
 
-	map<string,vector<EventPar> > map_events;
+	map<string,vector<EventSubscriptionState> > map_events;
 	map<string,DevIntr> map_dev_inter;
 
 	dev->mem_event_par(map_events);
@@ -1204,22 +1204,22 @@ void ServRestartThread::run(void *ptr)
 	dev->set_poll_th_pool_size(DEFAULT_POLLING_THREADS_POOL_SIZE);
 
     tg->set_svr_starting(true);
-	
+
 	vector<DeviceClass *> empty_class;
 	tg->set_class_list(&empty_class);
-	
+
 	{
 		AutoPyLock PyLo;
 		dev->init_device();
 	}
-	
+
 //
 // Set the class list pointer in the Util class and add the DServer object class
 //
 
 	tg->set_class_list(&(dev->get_class_list()));
 	tg->add_class_to_list(dev->get_device_class());
-	
+
 	tg->set_svr_starting(false);
 
 //
@@ -1975,6 +1975,25 @@ void DServer::mem_event_par(map<string,vector<EventPar> > &_map)
 	}
 }
 
+void DServer::mem_event_par(map<string,vector<EventSubscriptionState> > &_map)
+{
+	for (size_t i = 0;i < class_list.size();i++)
+	{
+		vector<DeviceImpl *> &dev_list = class_list[i]->get_device_list();
+		for (size_t j = 0;j < dev_list.size();j++)
+		{
+			vector<EventSubscriptionState> eve;
+			dev_list[j]->get_device_attr()->get_event_param(eve);
+			dev_list[j]->get_event_param(eve);
+
+			if (eve.size() != 0)
+			{
+				_map.insert(make_pair(dev_list[j]->get_name(),eve));
+			}
+		}
+	}
+}
+
 //+-----------------------------------------------------------------------------------------------------------------
 //
 // method :
@@ -1998,6 +2017,26 @@ void DServer::apply_event_par(map<string,vector<EventPar> > &_map)
 		{
 			string &dev_name = dev_list[j]->get_name();
 			map<string,vector<EventPar> >::iterator ite;
+			ite = _map.find(dev_name);
+
+			if (ite != _map.end())
+			{
+				dev_list[j]->get_device_attr()->set_event_param(ite->second);
+				dev_list[j]->set_event_param(ite->second);
+			}
+		}
+	}
+}
+
+void DServer::apply_event_par(map<string,vector<EventSubscriptionState> > &_map)
+{
+	for (size_t i = 0;i < class_list.size();i++)
+	{
+		vector<DeviceImpl *> &dev_list = class_list[i]->get_device_list();
+		for (size_t j = 0;j < dev_list.size();j++)
+		{
+			string &dev_name = dev_list[j]->get_name();
+			map<string,vector<EventSubscriptionState> >::iterator ite;
 			ite = _map.find(dev_name);
 
 			if (ite != _map.end())

--- a/cppapi/server/dserver.h
+++ b/cppapi/server/dserver.h
@@ -127,8 +127,10 @@ public :
 	void _create_cpp_class(const char *c1,const char *c2) {this->create_cpp_class(c1,c2);}
 
 	void mcast_event_for_att(string &,string &,vector<string> &);
-	void mem_event_par(map<string, vector<EventPar> > &);
-	void apply_event_par(map<string,vector<EventPar> > &);
+	void mem_event_par(map<string, vector<EventPar> > &); // Deprecated, use EventSubscriptionState overload
+	void apply_event_par(map<string,vector<EventPar> > &); // Deprecated, use EventSubscriptionState overload
+	void mem_event_par(map<string, vector<EventSubscriptionState> >&);
+	void apply_event_par(map<string,vector<EventSubscriptionState> >&);
 
 	void mem_devices_interface(map<string,DevIntr> &);
 	void changed_devices_interface(map<string,DevIntr> &);
@@ -158,6 +160,7 @@ protected :
 	static ClassFactoryFuncPtr 		class_factory_func_ptr;
 
 private:
+
 #if ((defined _TG_WINDOWS_) && (defined TANGO_HAS_DLL) && !(defined _TANGO_LIB))
 	__declspec(dllexport) void class_factory();
 #else

--- a/cppapi/server/multiattribute.cpp
+++ b/cppapi/server/multiattribute.cpp
@@ -1614,32 +1614,52 @@ void MultiAttribute::set_event_param(vector<EventPar> &eve)
 
 				if (eve[i].change.empty() == false)
 				{
+					std::string event_name = EventName[CHANGE_EVENT];
 					for (ite = eve[i].change.begin();ite != eve[i].change.end();++ite)
+					{
 						att.set_change_event_sub(*ite);
+						att.set_client_lib(*ite, event_name);
+					}
 				}
 
 				if (eve[i].periodic.empty() == false)
 				{
+					std::string event_name = EventName[PERIODIC_EVENT];
 					for (ite = eve[i].periodic.begin();ite != eve[i].periodic.end();++ite)
+					{
 						att.set_periodic_event_sub(*ite);
+						att.set_client_lib(*ite, event_name);
+					}
 				}
 
 				if (eve[i].archive.empty() == false)
 				{
+					std::string event_name = EventName[ARCHIVE_EVENT];
 					for (ite = eve[i].archive.begin();ite != eve[i].archive.end();++ite)
+					{
 						att.set_archive_event_sub(*ite);
+						att.set_client_lib(*ite, event_name);
+					}
 				}
 
 				if (eve[i].att_conf.empty() == false)
 				{
+					std::string event_name = EventName[ATTR_CONF_EVENT];
 					for (ite = eve[i].att_conf.begin();ite != eve[i].att_conf.end();++ite)
+					{
 						att.set_att_conf_event_sub(*ite);
+						att.set_client_lib(*ite, event_name);
+					}
 				}
 
 				if (eve[i].user.empty() == false)
 				{
+					std::string event_name = EventName[USER_EVENT];
 					for (ite = eve[i].user.begin();ite != eve[i].user.end();++ite)
+					{
 						att.set_user_event_sub(*ite);
+						att.set_client_lib(*ite, event_name);
+					}
 				}
 
 				if (eve[i].quality == true)

--- a/cppapi/server/multiattribute.h
+++ b/cppapi/server/multiattribute.h
@@ -61,6 +61,13 @@ struct EventPar
 	bool        	zmq;
 };
 
+// This structure is intended to be used in place of EventPar. Field attribute_name
+// replaces attr_id. EventPar is left untouched for backward compatibility with 9.3.
+struct EventSubscriptionState : public EventPar
+{
+    std::string attribute_name;
+};
+
 //=============================================================================
 //
 //			The MultiAttribute class
@@ -283,8 +290,10 @@ public:
 	void remove_attribute(string &,bool);
 	vector<long> &get_w_attr_list() {return writable_attr_list;}
 	bool is_att_quality_alarmed();
-	void get_event_param(vector<EventPar> &);
-	void set_event_param(vector<EventPar> &);
+	void get_event_param(vector<EventPar> &); // Deprecated, use EventSubscriptionState overload
+	void set_event_param(vector<EventPar> &); // Deprecated, use EventSubscriptionState overload
+	void get_event_param(vector<EventSubscriptionState> &);
+	void set_event_param(vector<EventSubscriptionState> &);
 	void add_alarmed_quality_factor(string &);
 	void add_default(vector<AttrProperty> &,string &,string &,long);
 	void add_attr(Attribute *att);


### PR DESCRIPTION
Summary of changes comparing to original commits:
* Correction for #496 (backport of #573):
  * 6c22521 - test only
  * 8712a7a - Event names are passed instead of event type enums
    to avoid changing `set_client_lib` signature
  * 7115111 - I needed to provide a new struct next to EventPar
    and implement a set of overloads that use the new struct
	and attribute_name field instead of attr_id
* Correction for #361 (dependent on previous one, backport of #694):
  * 3950063 - test only
  * b306962 - no changes