### PR TITLE
Use std::chrono in polling calculations

### DIFF
--- a/cpp_test_suite/cpp_test_ds/DevTest.cpp
+++ b/cpp_test_suite/cpp_test_ds/DevTest.cpp
@@ -1,5 +1,6 @@
 #include <tango.h>
 #include <DevTest.h>
+#include <tango_clock.h>
 
 #ifdef WIN32
 #include <sys/timeb.h>
@@ -1848,30 +1849,13 @@ void DevTest::read_slow_actuator(Tango::Attribute &att)
 	slow_actua++;
 	att.set_value(&slow_actua);
 
-	struct timeval now;
-#ifdef WIN32
-	struct _timeb before_win;
-	_ftime(&before_win);
-	now.tv_sec = (unsigned long)before_win.time;
-	now.tv_usec = (long)before_win.millitm * 1000;
-#else
-	gettimeofday(&now,NULL);
-#endif
-	long delta;
 	if (slow_actua_write.tv_sec != 0)
 	{
+		auto now = std::chrono::system_clock::now();
+		auto delta = now - Tango::make_system_time(slow_actua_write);
 
-#define COMPUTE_TIME_DIFF(RESULT,BEFORE,AFTER) \
-long bef = ((BEFORE.tv_sec - 1095000000) * 1000) + (BEFORE.tv_usec / 1000); \
-long after = ((AFTER.tv_sec - 1095000000) * 1000) + (AFTER.tv_usec / 1000); \
-RESULT = after - bef;
-
-		COMPUTE_TIME_DIFF(delta,slow_actua_write,now);
-
-#undef COMPUTE_TIME_DIFF
-
-		cout << "Delta time = " << delta << std::endl;
-		if (delta > 3000)
+		cout << "Delta time = " << Tango::duration_ms(delta) << std::endl;
+		if (delta > std::chrono::milliseconds(3000))
 		{
 			att.set_quality(Tango::ATTR_VALID);
 			slow_actua_write.tv_sec = 0;

--- a/cpp_test_suite/cpp_test_ds/DevTest.cpp
+++ b/cpp_test_suite/cpp_test_ds/DevTest.cpp
@@ -1860,7 +1860,16 @@ void DevTest::read_slow_actuator(Tango::Attribute &att)
 	long delta;
 	if (slow_actua_write.tv_sec != 0)
 	{
+
+#define COMPUTE_TIME_DIFF(RESULT,BEFORE,AFTER) \
+long bef = ((BEFORE.tv_sec - 1095000000) * 1000) + (BEFORE.tv_usec / 1000); \
+long after = ((AFTER.tv_sec - 1095000000) * 1000) + (AFTER.tv_usec / 1000); \
+RESULT = after - bef;
+
 		COMPUTE_TIME_DIFF(delta,slow_actua_write,now);
+
+#undef COMPUTE_TIME_DIFF
+
 		cout << "Delta time = " << delta << std::endl;
 		if (delta > 3000)
 		{

--- a/cpp_test_suite/old_tests/size.cpp
+++ b/cpp_test_suite/old_tests/size.cpp
@@ -1,4 +1,4 @@
-/* 
+/*
  * Check size of user classes/structure (For compatibility prurpose)
  *
  * This test suite has to be run on a redhate4 host
@@ -31,17 +31,17 @@ int main(int argc, char **argv)
 	check_size("Attr",sizeof(Attr),128, &isOK);  // Was 52 in V4
 	check_size("SpectrumAttr",sizeof(SpectrumAttr),144, &isOK);	// Was 60 in V4
 	check_size("ImageAttr",sizeof(ImageAttr),160, &isOK);	// Was 68 in V4
-		
+
 	check_size("DeviceImpl",sizeof(DeviceImpl),1760, &isOK);
 	check_size("Device_2Impl",sizeof(Device_2Impl),1776, &isOK);
-	
+
 	check_size("DeviceClass",sizeof(DeviceClass),416, &isOK);  	// Was 48 in V4
-	check_size("Util",sizeof(Util),1616, &isOK);	// Was 68 in V4
+	check_size("Util",sizeof(Util),1624, &isOK);	// Was 68 in V4
 
 	check_size("Attribute",sizeof(Attribute),2536, &isOK);		// Was 208 in V4
 	check_size("WAttribute",sizeof(WAttribute),3200, &isOK);	// Was 252 in V4
 	check_size("MultiAttribute",sizeof(MultiAttribute),80, &isOK);
-	
+
 	check_size("Command",sizeof(Command),72, &isOK);
 	check_size("TemplCommand",sizeof(TemplCommand),112, &isOK);
 	check_size("TemplCommandIn",sizeof(TemplCommandIn<int>),136, &isOK);
@@ -61,7 +61,7 @@ int main(int argc, char **argv)
 	check_size("DbServer",sizeof(DbServer),32, &isOK);
 	check_size("DbDatum",sizeof(DbDatum),56, &isOK);
 	check_size("DbData",sizeof(DbData),24, &isOK);
-	
+
 	check_size("CmdDoneEvent",sizeof(CmdDoneEvent),48, &isOK);
 	check_size("AttrReadEvent",sizeof(AttrReadEvent),48, &isOK);
 	check_size("AttrWrittenEvent",sizeof(AttrWrittenEvent),40, &isOK);

--- a/cppapi/client/Connection.h
+++ b/cppapi/client/Connection.h
@@ -30,7 +30,9 @@
 #ifndef _CONNECTION_H
 #define _CONNECTION_H
 
+#include <tango_optional.h>
 
+#include <chrono>
 
 /****************************************************************************************
  * 																						*
@@ -122,8 +124,7 @@ protected :
     bool				tr_reco;
     Tango::Device_3_var device_3;
 
-    bool			  	prev_failed;
-    double		  		prev_failed_t0;
+    tango_optional<std::chrono::steady_clock::time_point> prev_failed_t0;
 
     Tango::Device_4_var	device_4;
     omni_mutex			adm_dev_mutex;

--- a/cppapi/client/DeviceProxy.h
+++ b/cppapi/client/DeviceProxy.h
@@ -27,6 +27,7 @@
 #ifndef _DEVICEPROXY_H
 #define _DEVICEPROXY_H
 
+#include <chrono>
 
 /****************************************************************************************
  * 																						*
@@ -75,7 +76,7 @@ private :
 	void redo_synch_write_call(TgRequest &);
 	void write_attribute(const AttributeValueList &);
 	void write_attribute(const AttributeValueList_4 &);
-	void create_locking_thread(ApiUtil *,DevLong);
+	void create_locking_thread(ApiUtil *, std::chrono::seconds);
 	void local_import(std::string &);
 	void unsubscribe_all_events();
 

--- a/cppapi/client/attr_proxy.cpp
+++ b/cppapi/client/attr_proxy.cpp
@@ -34,12 +34,6 @@
 #include <tango.h>
 #include <eventconsumer.h>
 
-#ifdef _TG_WINDOWS_
-#include <sys/timeb.h>
-#else
-#include <sys/time.h>
-#endif /* _TG_WINDOWS_ */
-
 #include <time.h>
 #include <signal.h>
 

--- a/cppapi/client/devapi_base.cpp
+++ b/cppapi/client/devapi_base.cpp
@@ -8814,7 +8814,7 @@ void DeviceProxy::lock(int lock_validity)
         std::map<std::string, LockingThread>::iterator pos = au->lock_threads.find(adm_dev_name);
         if (pos == au->lock_threads.end())
         {
-            create_locking_thread(au, lock_validity);
+            create_locking_thread(au, std::chrono::seconds(lock_validity));
         }
         else
         {
@@ -8830,7 +8830,7 @@ void DeviceProxy::lock(int lock_validity)
                 delete pos->second.mon;
                 au->lock_threads.erase(pos);
 
-                create_locking_thread(au, lock_validity);
+                create_locking_thread(au, std::chrono::seconds(lock_validity));
             }
             else
             {
@@ -8854,7 +8854,7 @@ void DeviceProxy::lock(int lock_validity)
                 pos->second.shared->dev_name = device_name;
                 {
                     omni_mutex_lock guard(lock_mutex);
-                    pos->second.shared->lock_validity = lock_valid;
+                    pos->second.shared->lock_validity = std::chrono::seconds(lock_valid);
                 }
 
                 pos->second.mon->signal();
@@ -9030,7 +9030,7 @@ void DeviceProxy::unlock(bool force)
 //
 //-----------------------------------------------------------------------------
 
-void DeviceProxy::create_locking_thread(ApiUtil *au, DevLong dl)
+void DeviceProxy::create_locking_thread(ApiUtil *au, std::chrono::seconds dl)
 {
 
     LockingThread lt;

--- a/cppapi/client/devapi_base.cpp
+++ b/cppapi/client/devapi_base.cpp
@@ -51,6 +51,8 @@
 #include <signal.h>
 #include <algorithm>
 
+#include <chrono>
+
 using namespace CORBA;
 
 namespace Tango
@@ -2642,17 +2644,7 @@ void DeviceProxy::unsubscribe_all_events()
 
 int DeviceProxy::ping()
 {
-    int elapsed;
-
-#ifndef _TG_WINDOWS_
-    struct timeval before, after;
-
-    gettimeofday(&before, NULL);
-#else
-    struct _timeb before, after;
-
-    _ftime(&before);
-#endif /* _TG_WINDOWS_ */
+    auto before = std::chrono::steady_clock::now();
 
     int ctr = 0;
 
@@ -2716,17 +2708,9 @@ int DeviceProxy::ping()
                                               (const char *) "DeviceProxy::ping()");
         }
     }
-#ifndef _TG_WINDOWS_
-    gettimeofday(&after, NULL);
-    elapsed = (after.tv_sec - before.tv_sec) * 1000000;
-    elapsed = (after.tv_usec - before.tv_usec) + elapsed;
-#else
-    _ftime(&after);
-    elapsed = (after.time - before.time) * 1000000;
-    elapsed = (after.millitm - before.millitm) * 1000 + elapsed;
-#endif /* _TG_WINDOWS_ */
 
-    return (elapsed);
+    auto after = std::chrono::steady_clock::now();
+    return std::chrono::duration_cast<std::chrono::microseconds>(after - before).count();
 }
 
 //-----------------------------------------------------------------------------

--- a/cppapi/client/devapi_base.cpp
+++ b/cppapi/client/devapi_base.cpp
@@ -35,11 +35,9 @@
 #include <devapi_utils.tpp>
 
 #ifdef _TG_WINDOWS_
-#include <sys/timeb.h>
 #include <process.h>
 #include <ws2tcpip.h>
 #else
-#include <sys/time.h>
 #include <netdb.h>
 #include <sys/socket.h>
 #include <netinet/in.h>

--- a/cppapi/client/event.cpp
+++ b/cppapi/client/event.cpp
@@ -38,11 +38,9 @@
 #include <stdio.h>
 
 #ifdef _TG_WINDOWS_
-#include <sys/timeb.h>
 #include <process.h>
 #else
 #include <unistd.h>
-#include <sys/time.h>
 #endif
 
 using namespace CORBA;

--- a/cppapi/client/event.cpp
+++ b/cppapi/client/event.cpp
@@ -33,6 +33,7 @@
 #include <tango.h>
 #include <eventconsumer.h>
 #include <event.tpp>
+#include <tango_clock.h>
 
 #include <stdio.h>
 
@@ -3574,22 +3575,7 @@ EventData::~EventData()
 
 void EventData::set_time()
 {
-#ifdef _TG_WINDOWS_
-		struct _timeb t;
-		_ftime(&t);
-
-		reception_date.tv_sec  = (CORBA::Long)t.time;
-		reception_date.tv_usec = (CORBA::Long)(t.millitm * 1000);
-		reception_date.tv_nsec = 0;
-#else
-		struct timezone tz;
-		struct timeval tv;
-		gettimeofday(&tv,&tz);
-
-		reception_date.tv_sec  = (CORBA::Long)tv.tv_sec;
-		reception_date.tv_usec = (CORBA::Long)tv.tv_usec;
-		reception_date.tv_nsec = 0;
-#endif
+	reception_date = make_TimeVal(std::chrono::system_clock::now());
 }
 
 FwdEventData::FwdEventData():EventData(),av_5(nullptr),event_data(nullptr)
@@ -3703,22 +3689,7 @@ AttrConfEventData::~AttrConfEventData()
 
 void AttrConfEventData::set_time()
 {
-#ifdef _TG_WINDOWS_
-		struct _timeb t;
-		_ftime(&t);
-
-		reception_date.tv_sec  = (CORBA::Long)t.time;
-		reception_date.tv_usec = (CORBA::Long)(t.millitm * 1000);
-		reception_date.tv_nsec = 0;
-#else
-		struct timezone tz;
-		struct timeval tv;
-		gettimeofday(&tv,&tz);
-
-		reception_date.tv_sec  = (CORBA::Long)tv.tv_sec;
-		reception_date.tv_usec = (CORBA::Long)tv.tv_usec;
-		reception_date.tv_nsec = 0;
-#endif
+	reception_date = make_TimeVal(std::chrono::system_clock::now());
 }
 
 FwdAttrConfEventData::FwdAttrConfEventData():AttrConfEventData(),fwd_attr_conf(nullptr)
@@ -3821,22 +3792,7 @@ DataReadyEventData & DataReadyEventData::operator=(const DataReadyEventData &ri)
 
 void DataReadyEventData::set_time()
 {
-#ifdef _TG_WINDOWS_
-		struct _timeb t;
-		_ftime(&t);
-
-		reception_date.tv_sec  = (CORBA::Long)t.time;
-		reception_date.tv_usec = (CORBA::Long)(t.millitm * 1000);
-		reception_date.tv_nsec = 0;
-#else
-		struct timezone tz;
-		struct timeval tv;
-		gettimeofday(&tv,&tz);
-
-		reception_date.tv_sec  = (CORBA::Long)tv.tv_sec;
-		reception_date.tv_usec = (CORBA::Long)tv.tv_usec;
-		reception_date.tv_nsec = 0;
-#endif
+	reception_date = make_TimeVal(std::chrono::system_clock::now());
 }
 
 /************************************************************************/
@@ -3990,22 +3946,7 @@ DevIntrChangeEventData & DevIntrChangeEventData::operator=(const DevIntrChangeEv
 
 void DevIntrChangeEventData::set_time()
 {
-#ifdef _TG_WINDOWS_
-		struct _timeb t;
-		_ftime(&t);
-
-		reception_date.tv_sec  = (CORBA::Long)t.time;
-		reception_date.tv_usec = (CORBA::Long)(t.millitm * 1000);
-		reception_date.tv_nsec = 0;
-#else
-		struct timezone tz;
-		struct timeval tv;
-		gettimeofday(&tv,&tz);
-
-		reception_date.tv_sec  = (CORBA::Long)tv.tv_sec;
-		reception_date.tv_usec = (CORBA::Long)tv.tv_usec;
-		reception_date.tv_nsec = 0;
-#endif
+	reception_date = make_TimeVal(std::chrono::system_clock::now());
 }
 
 /************************************************************************/
@@ -4100,22 +4041,7 @@ PipeEventData::~PipeEventData()
 
 void PipeEventData::set_time()
 {
-#ifdef _TG_WINDOWS_
-		struct _timeb t;
-		_ftime(&t);
-
-		reception_date.tv_sec  = (CORBA::Long)t.time;
-		reception_date.tv_usec = (CORBA::Long)(t.millitm * 1000);
-		reception_date.tv_nsec = 0;
-#else
-		struct timezone tz;
-		struct timeval tv;
-		gettimeofday(&tv,&tz);
-
-		reception_date.tv_sec  = (CORBA::Long)tv.tv_sec;
-		reception_date.tv_usec = (CORBA::Long)tv.tv_usec;
-		reception_date.tv_nsec = 0;
-#endif
+	reception_date = make_TimeVal(std::chrono::system_clock::now());
 }
 
 } /* End of Tango namespace */

--- a/cppapi/client/eventkeepalive.cpp
+++ b/cppapi/client/eventkeepalive.cpp
@@ -39,11 +39,9 @@
 #include <stdio.h>
 
 #ifdef _TG_WINDOWS_
-#include <sys/timeb.h>
 #include <process.h>
 #else
 #include <unistd.h>
-#include <sys/time.h>
 #endif
 
 using namespace CORBA;

--- a/cppapi/client/lockthread.cpp
+++ b/cppapi/client/lockthread.cpp
@@ -41,11 +41,8 @@
 #include <algorithm>
 #include <time.h>
 
-#ifndef _TG_WINDOWS_
-#include <sys/time.h>
-#else
+#ifdef _TG_WINDOWS_
 #include <sys/types.h>
-#include <sys/timeb.h>
 #endif
 
 namespace Tango

--- a/cppapi/client/notifdeventconsumer.cpp
+++ b/cppapi/client/notifdeventconsumer.cpp
@@ -39,11 +39,9 @@
 #include <stdio.h>
 
 #ifdef _TG_WINDOWS_
-#include <sys/timeb.h>
 #include <process.h>
 #else
 #include <unistd.h>
-#include <sys/time.h>
 #endif
 
 using namespace CORBA;

--- a/cppapi/client/proxy_asyn.cpp
+++ b/cppapi/client/proxy_asyn.cpp
@@ -36,15 +36,9 @@
 #include <ac_config.h>
 #endif
 
-
 #include <tango.h>
 
 #define _dyn_attr
-#ifdef _TG_WINDOWS_
-	#include <sys/timeb.h>
-#else
-	#include <sys/time.h>
-#endif
 
 namespace Tango
 {

--- a/cppapi/client/proxy_asyn_cb.cpp
+++ b/cppapi/client/proxy_asyn_cb.cpp
@@ -34,13 +34,6 @@
 
 #include <tango.h>
 
-
-#ifdef _TG_WINDOWS_
-	#include <sys/timeb.h>
-#else
-	#include <sys/time.h>
-#endif
-
 namespace Tango
 {
 

--- a/cppapi/client/zmqeventconsumer.cpp
+++ b/cppapi/client/zmqeventconsumer.cpp
@@ -41,7 +41,6 @@
 #ifdef _TG_WINDOWS_
 #include <winsock2.h>
 #include <ws2tcpip.h>
-#include <sys/timeb.h>
 #include <process.h>
 #else
 #include <unistd.h>

--- a/cppapi/server/CMakeLists.txt
+++ b/cppapi/server/CMakeLists.txt
@@ -129,7 +129,9 @@ set(HEADERS attrdesc.h
             subdev_diag.h
             encoded_attribute.h
             encoded_format.h
-            event_subscription_state.h)
+            event_subscription_state.h
+            tango_optional.h
+            )
 
 add_subdirectory(idl)
 add_subdirectory(jpeg)

--- a/cppapi/server/CMakeLists.txt
+++ b/cppapi/server/CMakeLists.txt
@@ -131,7 +131,7 @@ set(HEADERS attrdesc.h
             encoded_format.h
             event_subscription_state.h
             tango_optional.h
-            poll_clock.h
+            tango_clock.h
             )
 
 add_subdirectory(idl)

--- a/cppapi/server/CMakeLists.txt
+++ b/cppapi/server/CMakeLists.txt
@@ -131,6 +131,7 @@ set(HEADERS attrdesc.h
             encoded_format.h
             event_subscription_state.h
             tango_optional.h
+            poll_clock.h
             )
 
 add_subdirectory(idl)

--- a/cppapi/server/attrgetsetprop.cpp
+++ b/cppapi/server/attrgetsetprop.cpp
@@ -43,9 +43,6 @@
 
 #ifdef _TG_WINDOWS_
 #include <sys/types.h>
-#include <sys/timeb.h>
-#else
-#include <sys/time.h>
 #endif /* _TG_WINDOWS_ */
 
 namespace Tango

--- a/cppapi/server/attribute.cpp
+++ b/cppapi/server/attribute.cpp
@@ -46,9 +46,6 @@
 
 #ifdef _TG_WINDOWS_
 #include <sys/types.h>
-#include <sys/timeb.h>
-#else
-#include <sys/time.h>
 #endif /* _TG_WINDOWS_ */
 
 namespace Tango

--- a/cppapi/server/attribute.cpp
+++ b/cppapi/server/attribute.cpp
@@ -39,6 +39,7 @@
 #include <attribute.h>
 #include <classattribute.h>
 #include <eventsupplier.h>
+#include <tango_clock.h>
 
 #include <functional>
 #include <algorithm>
@@ -1681,22 +1682,7 @@ void Attribute::set_time()
 {
 	if (date == true)
 	{
-#ifdef _TG_WINDOWS_
-		struct _timeb t;
-		_ftime(&t);
-
-		when.tv_sec = (CORBA::Long)t.time;
-		when.tv_usec = (CORBA::Long)(t.millitm * 1000);
-		when.tv_nsec = 0;
-#else
-		struct timezone tz;
-		struct timeval tv;
-		gettimeofday(&tv,&tz);
-
-		when.tv_sec = (CORBA::Long)tv.tv_sec;
-		when.tv_usec = (CORBA::Long)tv.tv_usec;
-		when.tv_nsec = 0;
-#endif
+		when = make_TimeVal(std::chrono::system_clock::now());
 	}
 }
 
@@ -3247,21 +3233,7 @@ void Attribute::Attribute_2_AttributeValue(Tango::AttributeValue_3 *ptr,Tango::D
 			a <<= str_seq;
 		}
 
-#ifdef _TG_WINDOWS_
-		struct _timeb t;
-		_ftime(&t);
-
-		ptr->time.tv_sec = (long)t.time;
-		ptr->time.tv_usec = (long)(t.millitm * 1000);
-		ptr->time.tv_nsec = 0;
-#else
-		struct timeval after;
-
-		gettimeofday(&after,NULL);
-		ptr->time.tv_sec = after.tv_sec;
-		ptr->time.tv_usec = after.tv_usec;
-		ptr->time.tv_nsec = 0;
-#endif
+		ptr->time = make_TimeVal(std::chrono::system_clock::now());
 		ptr->r_dim.dim_x = 1;
 		ptr->r_dim.dim_y = 0;
 		ptr->w_dim.dim_x = 0;

--- a/cppapi/server/attribute.h
+++ b/cppapi/server/attribute.h
@@ -36,7 +36,7 @@
 #include <attrdesc.h>
 #include <fwdattrdesc.h>
 #include <encoded_attribute.h>
-#include <poll_clock.h>
+#include <tango_clock.h>
 
 #include <functional>
 #include <time.h>

--- a/cppapi/server/attribute.h
+++ b/cppapi/server/attribute.h
@@ -36,6 +36,7 @@
 #include <attrdesc.h>
 #include <fwdattrdesc.h>
 #include <encoded_attribute.h>
+#include <poll_clock.h>
 
 #include <functional>
 #include <time.h>
@@ -2469,13 +2470,15 @@ protected:
     double				archive_abs_change[2];			// Delta for absolute change events
     int					event_period;					// Delta for periodic events in ms
     int					archive_period;					// Delta for archive periodic events in ms
-    double				last_periodic;					// Last time a periodic event was detected
-    double				archive_last_periodic;			// Last time an archive periodic event was detected
     long				periodic_counter;				// Number of periodic events sent so far
     long				archive_periodic_counter;		// Number of periodic events sent so far
     LastAttrValue		prev_change_event;				// Last change attribute
     LastAttrValue		prev_quality_event;				// Last quality attribute
     LastAttrValue		prev_archive_event;				// Last archive attribute
+
+    PollClock::time_point last_periodic;            // Last time a periodic event was detected
+    PollClock::time_point archive_last_periodic;    // Last time an archive periodic event was detected
+    PollClock::time_point archive_last_event;       // Last time an archive event was detected (periodic or not)
 
     time_t				event_change3_subscription;		// Last time() a subscription was made
     time_t				event_change4_subscription;
@@ -2494,7 +2497,6 @@ protected:
     time_t				event_attr_conf5_subscription;	// Last time() a subscription was made
     time_t				event_data_ready_subscription;	// Last time() a subscription was made
 
-    double				archive_last_event;				// Last time an archive event was detected (periodic or not)
     long				idx_in_attr;					// Index in MultiClassAttribute vector
     std::string				d_name;							// The device name
     DeviceImpl 			*dev;							// The device object

--- a/cppapi/server/attribute.tpp
+++ b/cppapi/server/attribute.tpp
@@ -33,6 +33,7 @@
 #ifndef _ATTRIBUTE_TPP
 #define _ATTRIBUTE_TPP
 
+#include <tango_clock.h>
 
 namespace Tango
 {
@@ -1383,22 +1384,7 @@ void Attribute::Attribute_2_AttributeValue_base(T *ptr, Tango::DeviceImpl *d)
             ptr->value.string_att_value(str_seq);
         }
 
-#ifdef _TG_WINDOWS_
-        struct _timeb t;
-        _ftime(&t);
-
-        ptr->time.tv_sec = (long)t.time;
-        ptr->time.tv_usec = (long)(t.millitm * 1000);
-        ptr->time.tv_nsec = 0;
-#else
-        struct timeval after;
-
-        gettimeofday(&after, NULL);
-
-        ptr->time.tv_sec = after.tv_sec;
-        ptr->time.tv_usec = after.tv_usec;
-        ptr->time.tv_nsec = 0;
-#endif
+        ptr->time = make_TimeVal(std::chrono::system_clock::now());
         ptr->r_dim.dim_x = 1;
         ptr->r_dim.dim_y = 0;
         ptr->w_dim.dim_x = 0;

--- a/cppapi/server/attrsetval.tpp
+++ b/cppapi/server/attrsetval.tpp
@@ -36,6 +36,12 @@
 
 #include <type_traits>
 
+#ifdef _TG_WINDOWS_
+#include <sys/timeb.h>
+#else
+#include <sys/time.h>
+#endif /* _TG_WINDOWS_ */
+
 namespace Tango
 {
 

--- a/cppapi/server/blackbox.cpp
+++ b/cppapi/server/blackbox.cpp
@@ -38,6 +38,7 @@
 
 #include <tango.h>
 #include <blackbox.h>
+#include <tango_clock.h>
 
 #include <stdio.h>
 
@@ -95,7 +96,7 @@ BlackBoxElt::BlackBoxElt()
     req_type = Req_Unknown;
     attr_type = Attr_Unknown;
     op_type = Op_Unknown;
-    when.tv_sec = when.tv_usec = 0;
+    when = {};
     host_ip_str[0] = '\0';
     client_ident = false;
     attr_names.reserve(DEFAULT_ATTR_NB);
@@ -168,21 +169,7 @@ void BlackBox::insert_corba_attr(BlackBoxElt_AttrType attr)
     box[insert_elt].attr_type = attr;
     box[insert_elt].op_type = Op_Unknown;
     box[insert_elt].client_ident = false;
-
-#ifdef _TG_WINDOWS_
-    //
-    // Note that the exact conversion between milli-sec and u-sec will be done only when data is send back to user.
-    // This save some times in unnecessary computation
-    //
-        struct _timeb t;
-        _ftime(&t);
-
-        box[insert_elt].when.tv_usec = (long)t.millitm;
-        box[insert_elt].when.tv_sec = (unsigned long)t.time;
-#else
-    struct timezone tz;
-    gettimeofday(&box[insert_elt].when, &tz);
-#endif
+    box[insert_elt].when = std::chrono::system_clock::now();
 
 //
 // get client address
@@ -253,20 +240,7 @@ void BlackBox::insert_cmd_nl(const char *cmd, long vers, DevSource sour)
     box[insert_elt].cmd_name = cmd;
     box[insert_elt].source = sour;
     box[insert_elt].client_ident = false;
-#ifdef _TG_WINDOWS_
-    //
-    // Note that the exact conversion between milli-sec and u-sec will be done only when data is send back to user.
-    // This save some times in unnecessary computation
-    //
-        struct _timeb t;
-        _ftime(&t);
-
-        box[insert_elt].when.tv_usec = (long)t.millitm;
-        box[insert_elt].when.tv_sec = (unsigned long)t.time;
-#else
-    struct timezone tz;
-    gettimeofday(&box[insert_elt].when, &tz);
-#endif
+    box[insert_elt].when = std::chrono::system_clock::now();
 
 //
 // get client address
@@ -471,20 +445,7 @@ void BlackBox::insert_op_nl(BlackBoxElt_OpType op)
     box[insert_elt].attr_type = Attr_Unknown;
     box[insert_elt].op_type = op;
     box[insert_elt].client_ident = false;
-#ifdef _TG_WINDOWS_
-    //
-    // Note that the exact conversion between milli-sec and u-sec will be done only when data is send back to user.
-    // This save some times in unnecessary computation
-    //
-        struct _timeb t;
-        _ftime(&t);
-
-        box[insert_elt].when.tv_usec = (long)t.millitm;
-        box[insert_elt].when.tv_sec = (unsigned long)t.time;
-#else
-    struct timezone tz;
-    gettimeofday(&box[insert_elt].when, &tz);
-#endif
+    box[insert_elt].when = std::chrono::system_clock::now();
 
 //
 // get client address
@@ -561,20 +522,7 @@ void BlackBox::insert_attr(const Tango::DevVarStringArray &names, long vers, Dev
         box[insert_elt].attr_names.push_back(tmp_str);
     }
 
-#ifdef _TG_WINDOWS_
-    //
-    // Note that the exact conversion between milli-sec and u-sec will be done only when data is send back to user.
-    // This save some times in unnecessary computation
-    //
-        struct _timeb t;
-        _ftime(&t);
-
-        box[insert_elt].when.tv_usec = (long)t.millitm;
-        box[insert_elt].when.tv_sec = (unsigned long)t.time;
-#else
-    struct timezone tz;
-    gettimeofday(&box[insert_elt].when, &tz);
-#endif
+    box[insert_elt].when = std::chrono::system_clock::now();
 
 //
 // get client address
@@ -631,20 +579,7 @@ void BlackBox::insert_attr(const Tango::DevVarStringArray &names, const ClntIden
         box[insert_elt].attr_names.push_back(tmp_str);
     }
 
-#ifdef _TG_WINDOWS_
-    //
-    // Note that the exact conversion between milli-sec and u-sec will be done only when data is send back to user.
-    // This save some times in unnecessary computation
-    //
-        struct _timeb t;
-        _ftime(&t);
-
-        box[insert_elt].when.tv_usec = (long)t.millitm;
-        box[insert_elt].when.tv_sec = (unsigned long)t.time;
-#else
-    struct timezone tz;
-    gettimeofday(&box[insert_elt].when, &tz);
-#endif
+    box[insert_elt].when = std::chrono::system_clock::now();
 
 //
 // get client address
@@ -717,20 +652,7 @@ void BlackBox::insert_attr(const char *name, const ClntIdent &cl_id, TANGO_UNUSE
     std::string tmp_str(name);
     box[insert_elt].attr_names.push_back(tmp_str);
 
-#ifdef _TG_WINDOWS_
-    //
-    // Note that the exact conversion between milli-sec and u-sec will be done only when data is send back to user.
-    // This save some times in unnecessary computation
-    //
-        struct _timeb t;
-        _ftime(&t);
-
-        box[insert_elt].when.tv_usec = (long)t.millitm;
-        box[insert_elt].when.tv_sec = (unsigned long)t.time;
-#else
-    struct timezone tz;
-    gettimeofday(&box[insert_elt].when, &tz);
-#endif
+    box[insert_elt].when = std::chrono::system_clock::now();
 
 //
 // get client address
@@ -801,20 +723,7 @@ void BlackBox::insert_attr(const Tango::DevPipeData &pipe_val, const ClntIdent &
     std::string tmp_str(pipe_val.name);
     box[insert_elt].attr_names.push_back(tmp_str);
 
-#ifdef _TG_WINDOWS_
-    //
-    // Note that the exact conversion between milli-sec and u-sec will be done only when data is send back to user.
-    // This save some times in unnecessary computation
-    //
-        struct _timeb t;
-        _ftime(&t);
-
-        box[insert_elt].when.tv_usec = (long)t.millitm;
-        box[insert_elt].when.tv_sec = (unsigned long)t.time;
-#else
-    struct timezone tz;
-    gettimeofday(&box[insert_elt].when, &tz);
-#endif
+    box[insert_elt].when = std::chrono::system_clock::now();
 
 //
 // get client address
@@ -921,21 +830,7 @@ void BlackBox::insert_attr_nl(const Tango::AttributeValueList &att_list, long ve
         box[insert_elt].attr_names.push_back(tmp_str);
     }
     box[insert_elt].client_ident = false;
-
-#ifdef _TG_WINDOWS_
-    //
-    // Note that the exact conversion between milli-sec and u-sec will be done only when data is send back to user.
-    // This save some times in unnecessary computation
-    //
-        struct _timeb t;
-        _ftime(&t);
-
-        box[insert_elt].when.tv_usec = (long)t.millitm;
-        box[insert_elt].when.tv_sec = (unsigned long)t.time;
-#else
-    struct timezone tz;
-    gettimeofday(&box[insert_elt].when, &tz);
-#endif
+    box[insert_elt].when = std::chrono::system_clock::now();
 
 //
 // get client address
@@ -967,20 +862,7 @@ void BlackBox::insert_attr_nl_4(const Tango::AttributeValueList_4 &att_list)
         box[insert_elt].attr_names.push_back(tmp_str);
     }
 
-#ifdef _TG_WINDOWS_
-    //
-    // Note that the exact conversion between milli-sec and u-sec will be done only when data is send back to user.
-    // This save some times in unnecessary computation
-    //
-        struct _timeb t;
-        _ftime(&t);
-
-        box[insert_elt].when.tv_usec = (long)t.millitm;
-        box[insert_elt].when.tv_sec = (unsigned long)t.time;
-#else
-    struct timezone tz;
-    gettimeofday(&box[insert_elt].when, &tz);
-#endif
+    box[insert_elt].when = std::chrono::system_clock::now();
 
 //
 // get client address
@@ -1080,20 +962,7 @@ void BlackBox::insert_attr_wr_nl(const Tango::AttributeValueList_4 &att_list,
         box[insert_elt].attr_names.push_back(tmp_str);
     }
 
-#ifdef _TG_WINDOWS_
-    //
-    // Note that the exact conversion between milli-sec and u-sec will be done only when data is send back to user.
-    // This save some times in unnecessary computation
-    //
-        struct _timeb t;
-        _ftime(&t);
-
-        box[insert_elt].when.tv_usec = (long)t.millitm;
-        box[insert_elt].when.tv_sec = (unsigned long)t.time;
-#else
-    struct timezone tz;
-    gettimeofday(&box[insert_elt].when, &tz);
-#endif
+    box[insert_elt].when = std::chrono::system_clock::now();
 
 //
 // get client address
@@ -1224,7 +1093,8 @@ void BlackBox::build_info_as_str(long index)
 // Convert time to a string
 //
 
-    date_ux_to_str(box[index].when, date_str, sizeof(date_str));
+    auto when_timeval = make_timeval(box[index].when);
+    date_ux_to_str(when_timeval, date_str, sizeof(date_str));
     elt_str = date_str;
 
 //

--- a/cppapi/server/blackbox.cpp
+++ b/cppapi/server/blackbox.cpp
@@ -44,7 +44,6 @@
 
 #ifdef _TG_WINDOWS_
 #include <sys/types.h>
-#include <sys/timeb.h>
 #include <ws2tcpip.h>
 #else
 #include <sys/time.h>

--- a/cppapi/server/blackbox.h
+++ b/cppapi/server/blackbox.h
@@ -40,6 +40,7 @@
 #endif
 #include <time.h>
 #include <omniORB4/omniInterceptors.h>
+#include <chrono>
 
 namespace Tango
 {
@@ -155,7 +156,7 @@ public:
 	BlackBoxElt_OpType		op_type;
 	std::string					cmd_name;
 	std::vector<std::string>			attr_names;
-	struct timeval			when;
+	std::chrono::system_clock::time_point when;
 	char					host_ip_str[IP_ADDR_BUFFER_SIZE];
 	DevSource				source;
 

--- a/cppapi/server/device.cpp
+++ b/cppapi/server/device.cpp
@@ -43,7 +43,7 @@
 #include <classattribute.h>
 #include <eventsupplier.h>
 #include <apiexcept.h>
-#include <poll_clock.h>
+#include <tango_clock.h>
 
 #ifdef TANGO_HAS_LOG4TANGO
 #include <logging.h>

--- a/cppapi/server/device.cpp
+++ b/cppapi/server/device.cpp
@@ -43,6 +43,7 @@
 #include <classattribute.h>
 #include <eventsupplier.h>
 #include <apiexcept.h>
+#include <poll_clock.h>
 
 #ifdef TANGO_HAS_LOG4TANGO
 #include <logging.h>
@@ -2810,8 +2811,8 @@ Tango::AttributeValueList *DeviceImpl::read_attributes(const Tango::DevVarString
                         std::transform(att_name.begin(), att_name.end(), att_name.begin(), ::tolower);
 
                         std::vector<PollObj *>::iterator ite = get_polled_obj_by_type_name(Tango::POLL_ATTR, att_name);
-                        long upd = (*ite)->get_upd();
-                        if (upd == 0)
+                        auto upd = (*ite)->get_upd();
+                        if (upd == PollClock::duration::zero())
                         {
                             o << "Attribute ";
                             o << att.get_name();

--- a/cppapi/server/device.h
+++ b/cppapi/server/device.h
@@ -47,6 +47,12 @@
 #include <dintrthread.h>
 #include "event_subscription_state.h"
 
+#ifdef _TG_WINDOWS_
+#include <sys/timeb.h>
+#else
+#include <sys/time.h>
+#endif /* _TG_WINDOWS_ */
+
 namespace Tango
 {
 

--- a/cppapi/server/device_2.cpp
+++ b/cppapi/server/device_2.cpp
@@ -42,6 +42,7 @@
 
 #include <tango.h>
 #include <device_2.h>
+#include <poll_clock.h>
 #include <new>
 
 #ifdef _TG_WINDOWS_
@@ -332,22 +333,12 @@ CORBA::Any *Device_2Impl::command_inout_2(const char *in_cmd,
 // Skip this test for object with external polling triggering (upd = 0)
 //
 
-			long tmp_upd = polled_cmd->get_upd();
-			if (tmp_upd != 0)
+			auto tmp_upd = polled_cmd->get_upd();
+			if (tmp_upd != PollClock::duration::zero())
 			{
-				double last = polled_cmd->get_last_insert_date();
-				struct timeval now;
-#ifdef _TG_WINDOWS_
-				struct _timeb now_win;
-				_ftime(&now_win);
-				now.tv_sec = (unsigned long)now_win.time;
-				now.tv_usec = (long)now_win.millitm * 1000;
-#else
-				gettimeofday(&now,NULL);
-#endif
-				now.tv_sec = now.tv_sec - DELTA_T;
-				double now_d = (double)now.tv_sec + ((double)now.tv_usec / 1000000);
-				double diff_d = now_d - last;
+				auto last = polled_cmd->get_last_insert_date();
+				auto now = PollClock::now();
+				auto diff_d = now - last;
 				if (diff_d > polled_cmd->get_authorized_delta())
 				{
 					TangoSys_OMemStream o;
@@ -737,22 +728,12 @@ Tango::AttributeValueList* Device_2Impl::read_attributes_2(const Tango::DevVarSt
 // Skip this test for object with external polling triggering (upd = 0)
 //
 
-					long tmp_upd = polled_attr->get_upd();
-					if (tmp_upd != 0)
+					auto tmp_upd = polled_attr->get_upd();
+					if (tmp_upd != PollClock::duration::zero())
 					{
-						double last = polled_attr->get_last_insert_date();
-						struct timeval now;
-#ifdef _TG_WINDOWS_
-						struct _timeb now_win;
-						_ftime(&now_win);
-						now.tv_sec = (unsigned long)now_win.time;
-						now.tv_usec = (long)now_win.millitm;
-#else
-						gettimeofday(&now,NULL);
-#endif
-						now.tv_sec = now.tv_sec - DELTA_T;
-						double now_d = (double)now.tv_sec + ((double)now.tv_usec / 1000000);
-						double diff_d = now_d - last;
+						auto last = polled_attr->get_last_insert_date();
+						auto now = PollClock::now();
+						auto diff_d = now - last;
 						if (diff_d > polled_attr->get_authorized_delta())
 						{
 							delete back;

--- a/cppapi/server/device_2.cpp
+++ b/cppapi/server/device_2.cpp
@@ -42,7 +42,7 @@
 
 #include <tango.h>
 #include <device_2.h>
-#include <poll_clock.h>
+#include <tango_clock.h>
 #include <new>
 
 #ifdef _TG_WINDOWS_

--- a/cppapi/server/device_2.cpp
+++ b/cppapi/server/device_2.cpp
@@ -45,13 +45,6 @@
 #include <tango_clock.h>
 #include <new>
 
-#ifdef _TG_WINDOWS_
-#include <sys/timeb.h>
-#else
-#include <sys/time.h>
-#endif /* _TG_WINDOWS_ */
-
-
 namespace Tango
 {
 

--- a/cppapi/server/device_3.cpp
+++ b/cppapi/server/device_3.cpp
@@ -38,7 +38,7 @@
 #include <device_3.h>
 #include <eventsupplier.h>
 #include <device_3.tpp>
-#include <poll_clock.h>
+#include <tango_clock.h>
 #include <new>
 
 

--- a/cppapi/server/device_3.cpp
+++ b/cppapi/server/device_3.cpp
@@ -41,14 +41,6 @@
 #include <tango_clock.h>
 #include <new>
 
-
-#ifdef _TG_WINDOWS_
-#include <sys/timeb.h>
-#else
-#include <sys/time.h>
-#endif /* _TG_WINDOWS_ */
-
-
 namespace Tango
 {
 

--- a/cppapi/server/device_3.tpp
+++ b/cppapi/server/device_3.tpp
@@ -32,6 +32,8 @@
 #ifndef _DEVICE_3_TPP
 #define _DEVICE_3_TPP
 
+#include <tango_clock.h>
+
 namespace Tango
 {
 
@@ -403,22 +405,7 @@ inline void Device_3Impl::init_out_data_quality(T &back,Attribute &att,AttrQuali
 template <typename T>
 inline void Device_3Impl::base_state2attr(T &back)
 {
-
-#ifdef _TG_WINDOWS_
-	struct _timeb after_win;
-
-	_ftime(&after_win);
-	back.time.tv_sec = (long)after_win.time;
-	back.time.tv_usec = (long)after_win.millitm * 1000;
-	back.time.tv_nsec = 0;
-#else
-	struct timeval after;
-
-	gettimeofday(&after,NULL);
-	back.time.tv_sec = after.tv_sec;
-	back.time.tv_usec = after.tv_usec;
-	back.time.tv_nsec = 0;
-#endif
+	back.time = make_TimeVal(std::chrono::system_clock::now());
 	back.quality = Tango::ATTR_VALID;
 	back.name = Tango::string_dup("State");
 	back.r_dim.dim_x = 1;
@@ -430,22 +417,7 @@ inline void Device_3Impl::base_state2attr(T &back)
 template <typename T>
 inline void Device_3Impl::base_status2attr(T &back)
 {
-
-#ifdef _TG_WINDOWS_
-	struct _timeb after_win;
-
-	_ftime(&after_win);
-	back.time.tv_sec = (long)after_win.time;
-	back.time.tv_usec = (long)after_win.millitm * 1000;
-	back.time.tv_nsec = 0;
-#else
-	struct timeval after;
-
-	gettimeofday(&after,NULL);
-	back.time.tv_sec = after.tv_sec;
-	back.time.tv_usec = after.tv_usec;
-	back.time.tv_nsec = 0;
-#endif
+	back.time = make_TimeVal(std::chrono::system_clock::now());
 	back.quality = Tango::ATTR_VALID;
 	back.name = Tango::string_dup("Status");
 	back.r_dim.dim_x = 1;

--- a/cppapi/server/dserver.cpp
+++ b/cppapi/server/dserver.cpp
@@ -1014,7 +1014,7 @@ void DServer::restart(std::string &d_name)
 // Send command to the polling thread
 //
 
-		send->lvalue[0] = dev_pol[i].upd;
+		send->lvalue[0] = std::chrono::duration_cast<std::chrono::milliseconds>(dev_pol[i].upd).count();
 		send->svalue[0] = Tango::string_dup(name[0]);
 		if (dev_pol[i].type == Tango::POLL_CMD)
 			send->svalue[1] = Tango::string_dup("command");

--- a/cppapi/server/dserver.h
+++ b/cppapi/server/dserver.h
@@ -39,6 +39,7 @@
 
 #include <tango.h>
 #include "event_subscription_state.h"
+#include <poll_clock.h>
 
 namespace Tango
 {
@@ -203,9 +204,9 @@ public:
 
 struct Pol
 {
-	PollObjType 	type;
-	long			upd;
-	std::string 			name;
+	PollObjType type;
+	PollClock::duration upd;
+	std::string name;
 };
 
 

--- a/cppapi/server/dserver.h
+++ b/cppapi/server/dserver.h
@@ -39,7 +39,7 @@
 
 #include <tango.h>
 #include "event_subscription_state.h"
-#include <poll_clock.h>
+#include <tango_clock.h>
 
 namespace Tango
 {

--- a/cppapi/server/dserverpoll.cpp
+++ b/cppapi/server/dserverpoll.cpp
@@ -392,7 +392,7 @@ Tango::DevVarStringArray *DServer::dev_poll_status(std::string &dev_name)
                     }
 
 					s.setf(std::ios::fixed);
-					s << std::setprecision(3) << std::chrono::nanoseconds(tmp_db).count() / 1e6;
+					s << std::setprecision(3) << duration_ms(tmp_db);
 					returned_info = returned_info + s.str();
 
 					s.str("");
@@ -405,7 +405,7 @@ Tango::DevVarStringArray *DServer::dev_poll_status(std::string &dev_name)
 					auto since = poll_list[i]->get_last_insert_date_i();
 					auto now = PollClock::now();
 					auto diff = now - since;
-					double diff_t = std::chrono::nanoseconds(diff - tmp_db).count() / 1e9;
+					double diff_t = duration_s(diff - tmp_db);
 					if (diff_t < 1.0)
 					{
 						long nb_msec = (long)(diff_t * 1000);

--- a/cppapi/server/dserverpoll.cpp
+++ b/cppapi/server/dserverpoll.cpp
@@ -35,6 +35,7 @@
 #endif
 
 #include <tango.h>
+#include <poll_clock.h>
 
 #ifdef _TG_WINDOWS_
 	#include <sys/timeb.h>
@@ -198,7 +199,7 @@ Tango::DevVarStringArray *DServer::dev_poll_status(std::string &dev_name)
 // Create map of polled attributes read by the same call
 //
 
-    std::map<int,std::vector<std::string> > polled_together;
+    std::map<PollClock::duration, std::vector<std::string> > polled_together;
 
     bool poll_bef_9 = false;
     if (polling_bef_9_def == true)
@@ -214,8 +215,8 @@ Tango::DevVarStringArray *DServer::dev_poll_status(std::string &dev_name)
                 continue;
             else
             {
-                long po = poll_list[i]->get_upd();
-                std::map<int,std::vector<std::string> >::iterator ite = polled_together.find(po);
+                auto po = poll_list[i]->get_upd();
+                auto ite = polled_together.find(po);
 
                 Attribute &att = dev->get_device_attr()->get_attr_by_name(poll_list[i]->get_name().c_str());
 
@@ -223,7 +224,7 @@ Tango::DevVarStringArray *DServer::dev_poll_status(std::string &dev_name)
                 {
                     std::vector<std::string> tmp_name;
                     tmp_name.push_back(att.get_name());
-                    polled_together.insert(std::pair<int,std::vector<std::string> >(po,tmp_name));
+                    polled_together.emplace(po, tmp_name);
                 }
                 else
                     ite->second.push_back(att.get_name());
@@ -298,16 +299,16 @@ Tango::DevVarStringArray *DServer::dev_poll_status(std::string &dev_name)
 		std::string tmp_str;
 		std::string per;
 
-		long po = poll_list[i]->get_upd();
+		auto po = poll_list[i]->get_upd();
 
-		if (po == 0)
+		if (po == PollClock::duration::zero())
 		{
 			returned_info = returned_info + "\nPolling externally triggered";
 		}
 		else
 		{
 			returned_info = returned_info + "\nPolling period (mS) = ";
-			s << po;
+			s << std::chrono::duration_cast<std::chrono::milliseconds>(po).count();
 			s >> tmp_str;
 			returned_info = returned_info + tmp_str;
 			s.clear();	// clear the stream eof flag
@@ -355,21 +356,21 @@ Tango::DevVarStringArray *DServer::dev_poll_status(std::string &dev_name)
 // Add needed time to execute last command
 //
 
-			double tmp_db = poll_list[i]->get_needed_time_i();
-			if (tmp_db == 0.0)
+			auto tmp_db = poll_list[i]->get_needed_time_i();
+			if (tmp_db == PollClock::duration::zero())
 			{
 				returned_info = returned_info + "\nThe polling buffer is externally filled in";
 			}
 			else
 			{
-				if (po != 0)
+				if (po != PollClock::duration::zero())
 				{
 					returned_info = returned_info + "\nTime needed for the last ";
 					if (type == Tango::POLL_CMD)
 						returned_info = returned_info + "command execution (mS) = ";
 					else
                     {
-                        std::map<int,std::vector<std::string> >::iterator ite = polled_together.find(po);
+                        auto ite = polled_together.find(po);
                         if (ite != polled_together.end())
                         {
                             if (ite->second.size() == 1)
@@ -391,7 +392,7 @@ Tango::DevVarStringArray *DServer::dev_poll_status(std::string &dev_name)
                     }
 
 					s.setf(std::ios::fixed);
-					s << std::setprecision(3) << tmp_db;
+					s << std::setprecision(3) << std::chrono::nanoseconds(tmp_db).count() / 1e6;
 					returned_info = returned_info + s.str();
 
 					s.str("");
@@ -401,20 +402,10 @@ Tango::DevVarStringArray *DServer::dev_poll_status(std::string &dev_name)
 //
 
 					returned_info = returned_info + "\nData not updated since ";
-					double since = poll_list[i]->get_last_insert_date_i();
-					struct timeval now;
-#ifdef _TG_WINDOWS_
-					struct _timeb now_win;
-					_ftime(&now_win);
-					now.tv_sec = (unsigned long)now_win.time;
-					now.tv_usec = (long)now_win.millitm * 1000;
-#else
-					gettimeofday(&now,NULL);
-#endif
-					now.tv_sec = now.tv_sec - DELTA_T;
-					double now_d = (double)now.tv_sec + ((double)now.tv_usec / 1000000);
-					double diff_t = now_d - since;
-					diff_t = diff_t - (tmp_db / 1000);
+					auto since = poll_list[i]->get_last_insert_date_i();
+					auto now = PollClock::now();
+					auto diff = now - since;
+					double diff_t = std::chrono::nanoseconds(diff - tmp_db).count() / 1e9;
 					if (diff_t < 1.0)
 					{
 						long nb_msec = (long)(diff_t * 1000);
@@ -470,14 +461,12 @@ Tango::DevVarStringArray *DServer::dev_poll_status(std::string &dev_name)
 
 			try
 			{
-				std::vector<double> delta;
-				poll_list[i]->get_delta_t_i(delta,4);
+				auto delta = poll_list[i]->get_delta_t_i(4);
 
 				returned_info = returned_info + "\nDelta between last records (in mS) = ";
 				for (unsigned long j = 0;j < delta.size();j++)
 				{
-					long nb_msec = (long)(delta[j] * 1000);
-					s << nb_msec;
+					s << std::chrono::duration_cast<std::chrono::milliseconds>(delta[j]).count();
 					returned_info = returned_info + s.str();
 					s.str("");
 					if (j != (delta.size() - 1))
@@ -757,7 +746,7 @@ void DServer::add_obj_polling(const Tango::DevVarLongStringArray *argin,bool wit
 		depth = dev->get_attr_poll_ring_depth(obj_name);
 
 	dev->get_poll_monitor().get_monitor();
-	poll_list.push_back(new PollObj(dev,type,obj_name,upd,depth));
+	poll_list.push_back(new PollObj(dev,type,obj_name,std::chrono::milliseconds(upd),depth));
 	dev->get_poll_monitor().rel_monitor();
 
 	PollingThreadInfo *th_info;
@@ -806,7 +795,7 @@ void DServer::add_obj_polling(const Tango::DevVarLongStringArray *argin,bool wit
 		shared_cmd.cmd_code = POLL_ADD_OBJ;
 		shared_cmd.dev = dev;
 		shared_cmd.index = poll_list.size() - 1;
-		shared_cmd.new_upd = delta_ms;
+		shared_cmd.new_upd = std::chrono::milliseconds(delta_ms);
 
 		mon.signal();
 
@@ -853,7 +842,7 @@ void DServer::add_obj_polling(const Tango::DevVarLongStringArray *argin,bool wit
 		shared_cmd.cmd_code = POLL_ADD_OBJ;
 		shared_cmd.dev = dev;
 		shared_cmd.index = poll_list.size() - 1;
-		shared_cmd.new_upd = delta_ms;
+		shared_cmd.new_upd = std::chrono::milliseconds(delta_ms);
 
 		PollThread *poll_th = th_info->poll_th;
 		poll_th->set_local_cmd(shared_cmd);
@@ -1156,28 +1145,6 @@ void DServer::upd_obj_polling_period(const Tango::DevVarLongStringArray *argin,b
 	check_upd_authorized(dev,upd,type,obj_name);
 
 //
-// Check that it is not an externally triggered polling object. In this case, throw exception
-//
-
-/*	long tmp_upd = (*ite)->get_upd();
-	if (tmp_upd == 0)
-	{
-		TangoSys_OMemStream o;
-
-		o << "Polling for ";
-		if (type == Tango::POLL_CMD)
-			o << "command ";
-		else
-			o << "attribute ";
-		o << (argin->svalue)[2];
-		o << " (device " << (argin->svalue)[0] << ") ";
-		o << " is externally triggered. Remove and add object to change its polling period";
-		o << std::ends;
-		Except::throw_exception((const char *)API_NotSupported,o.str(),
-					(const char *)"DServer::upd_obj_polling_period");
-	}*/
-
-//
 // Check that the update period is not to small
 //
 
@@ -1208,7 +1175,7 @@ void DServer::upd_obj_polling_period(const Tango::DevVarLongStringArray *argin,b
 // Update polling period
 //
 
-	(*ite)->update_upd(upd);
+	(*ite)->update_upd(std::chrono::milliseconds(upd));
 
 //
 // Send command to the polling thread
@@ -1230,7 +1197,7 @@ void DServer::upd_obj_polling_period(const Tango::DevVarLongStringArray *argin,b
 		shared_cmd.dev = dev;
 		shared_cmd.name = obj_name;
 		shared_cmd.type = type;
-		shared_cmd.new_upd = (argin->lvalue)[0];
+		shared_cmd.new_upd = std::chrono::milliseconds((argin->lvalue)[0]);
 
 		shared_cmd.index = distance(dev->get_poll_obj_list().begin(),ite);
 
@@ -1243,7 +1210,7 @@ void DServer::upd_obj_polling_period(const Tango::DevVarLongStringArray *argin,b
 		shared_cmd.dev = dev;
 		shared_cmd.name = obj_name;
 		shared_cmd.type = type;
-		shared_cmd.new_upd = (argin->lvalue)[0];
+		shared_cmd.new_upd = std::chrono::milliseconds((argin->lvalue)[0]);
 
 		shared_cmd.index = distance(dev->get_poll_obj_list().begin(),ite);
 
@@ -1421,7 +1388,7 @@ void DServer::rem_obj_polling(const Tango::DevVarStringArray *argin,bool with_db
 	}
 
 	std::vector<PollObj *>::iterator ite = dev->get_polled_obj_by_type_name(type,obj_name);
-	long tmp_upd = (*ite)->get_upd();
+	auto tmp_upd = (*ite)->get_upd();
 
 	PollingThreadInfo *th_info = nullptr;
 	int poll_th_id = 0;
@@ -1467,7 +1434,7 @@ void DServer::rem_obj_polling(const Tango::DevVarStringArray *argin,bool with_db
 					mon.wait();
 				}
 				shared_cmd.cmd_pending = true;
-				if (tmp_upd == 0)
+				if (tmp_upd == PollClock::duration::zero())
 					shared_cmd.cmd_code = POLL_REM_EXT_TRIG_OBJ;
 				else
 					shared_cmd.cmd_code = POLL_REM_OBJ;
@@ -1505,7 +1472,7 @@ void DServer::rem_obj_polling(const Tango::DevVarStringArray *argin,bool with_db
 			else
 			{
 				shared_cmd.cmd_pending = true;
-				if (tmp_upd == 0)
+				if (tmp_upd == PollClock::duration::zero())
 					shared_cmd.cmd_code = POLL_REM_EXT_TRIG_OBJ;
 				else
 					shared_cmd.cmd_code = POLL_REM_OBJ;

--- a/cppapi/server/dserverpoll.cpp
+++ b/cppapi/server/dserverpoll.cpp
@@ -37,12 +37,6 @@
 #include <tango.h>
 #include <tango_clock.h>
 
-#ifdef _TG_WINDOWS_
-	#include <sys/timeb.h>
-#else
-	#include <sys/time.h>
-#endif
-
 #include <iomanip>
 
 namespace Tango

--- a/cppapi/server/dserverpoll.cpp
+++ b/cppapi/server/dserverpoll.cpp
@@ -35,7 +35,7 @@
 #endif
 
 #include <tango.h>
-#include <poll_clock.h>
+#include <tango_clock.h>
 
 #ifdef _TG_WINDOWS_
 	#include <sys/timeb.h>

--- a/cppapi/server/eventsupplier.cpp
+++ b/cppapi/server/eventsupplier.cpp
@@ -613,8 +613,8 @@ bool EventSupplier::detect_and_push_archive_event(DeviceImpl *device_impl,
         auto arch_period = get_minimal_event_reporting_period(std::chrono::milliseconds(arch_period_ms));
 
         cout3 << "EventSupplier::detect_and_push_archive_event():"
-              << " ms_since_last_periodic = " << std::fixed << std::chrono::nanoseconds(ms_since_last_periodic).count() / 1e6 << " ms"
-              << ", arch_period = " << std::fixed << std::chrono::nanoseconds(arch_period).count() / 1e6 << " ms"
+              << " ms_since_last_periodic = " << std::fixed << duration_ms(ms_since_last_periodic) << " ms"
+              << ", arch_period = " << std::fixed << duration_ms(arch_period) << " ms"
               << ", attr.prev_archive_event.inited = " << attr.prev_archive_event.inited
               << std::endl;
 
@@ -731,7 +731,7 @@ bool EventSupplier::detect_and_push_archive_event(DeviceImpl *device_impl,
         }
 
         auto time_delta = time_bef_attr - attr.archive_last_event;
-        auto time_delta_ms = std::chrono::nanoseconds(time_delta).count() / 1e6;
+        auto time_delta_ms = duration_ms(time_delta);
         filterable_names.push_back("delta_event");
         filterable_data.push_back(time_delta_ms);
         attr.archive_last_event = time_bef_attr;
@@ -875,8 +875,8 @@ bool EventSupplier::detect_and_push_periodic_event(DeviceImpl *device_impl,
     auto ms_since_last_periodic = time_bef_attr - attr.last_periodic;
 
     cout3 << "EventSupplier::detect_and_push_is_periodic_event():"
-          << " delta since last periodic " << std::fixed << std::chrono::nanoseconds(ms_since_last_periodic).count() / 1e6 << " ms"
-          << ", event_period " << std::fixed << std::chrono::nanoseconds(eve_period).count() / 1e6 << " ms"
+          << " delta since last periodic " << std::fixed << duration_ms(ms_since_last_periodic) << " ms"
+          << ", event_period " << std::fixed << duration_ms(eve_period) << " ms"
           << " for " << device_impl->get_name() + "/" + attr_name << std::endl;
 
     if (ms_since_last_periodic > eve_period)

--- a/cppapi/server/eventsupplier.h
+++ b/cppapi/server/eventsupplier.h
@@ -43,7 +43,7 @@
 #define _EVENT_SUPPLIER_API_H
 
 #include <except.h>
-#include <poll_clock.h>
+#include <tango_clock.h>
 
 #if defined (_TG_WINDOWS_) && defined (_USRDLL) && !defined(_TANGO_LIB)
 #define USE_stub_in_nt_dll

--- a/cppapi/server/eventsupplier.h
+++ b/cppapi/server/eventsupplier.h
@@ -66,6 +66,7 @@
 #include <sys/time.h>
 #endif
 
+#include <chrono>
 
 namespace Tango
 {
@@ -322,8 +323,8 @@ private :
 
     struct ConnectedClient
     {
-        client_addr             clnt;
-        time_t                  date;
+        client_addr clnt;
+        std::chrono::steady_clock::time_point date;
     };
 
 	zmq::context_t              zmq_context;            // ZMQ context

--- a/cppapi/server/eventsupplier.h
+++ b/cppapi/server/eventsupplier.h
@@ -43,6 +43,7 @@
 #define _EVENT_SUPPLIER_API_H
 
 #include <except.h>
+#include <poll_clock.h>
 
 #if defined (_TG_WINDOWS_) && defined (_USRDLL) && !defined(_TANGO_LIB)
 #define USE_stub_in_nt_dll
@@ -111,23 +112,55 @@ public :
         zmq::message_t	  		  *zmq_mess;
     };
 
-	SendEventType detect_and_push_events(DeviceImpl *,struct SuppliedEventData &,DevFailed *,std::string &,struct timeval *);
+	SendEventType detect_and_push_events(
+		DeviceImpl *,
+	    struct SuppliedEventData &,
+	    DevFailed *,
+	    std::string &,
+	    PollClock::time_point);
 
 //------------------ Change event ---------------------------
 
-	bool detect_change(Attribute &,struct SuppliedEventData &,bool,double &,double &,DevFailed *,bool &,DeviceImpl *);
+	bool detect_change(
+	    Attribute &,
+	    struct SuppliedEventData &,
+	    bool,
+	    double &,
+	    double &,
+	    DevFailed *,
+	    bool &,
+	    DeviceImpl *);
 
 //------------------ Detect, push change event --------------
 
-	bool detect_and_push_change_event(DeviceImpl *,struct SuppliedEventData &,Attribute &,std::string &,DevFailed *,bool user_push = false);
+	bool detect_and_push_change_event(
+	    DeviceImpl *,
+	    struct SuppliedEventData &,
+	    Attribute &,
+	    std::string &,
+	    DevFailed *,
+	    bool user_push = false);
 
 //------------------ Detect, push archive event --------------
 
-	bool detect_and_push_archive_event(DeviceImpl *,struct SuppliedEventData &,Attribute &,std::string &,DevFailed *,struct timeval *,bool user_push = false);
+	bool detect_and_push_archive_event(
+	    DeviceImpl *,
+	    struct SuppliedEventData &,
+	    Attribute &,
+	    std::string &,
+	    DevFailed *,
+	    PollClock::time_point,
+	    bool user_push = false);
 
 //------------------ Detect, push periodic event -------------
 
-	bool detect_and_push_periodic_event(DeviceImpl *,struct SuppliedEventData &,Attribute &,std::string &,DevFailed *,struct timeval *);
+	bool detect_and_push_periodic_event(
+	    DeviceImpl *,
+	    struct SuppliedEventData &,
+	    Attribute &,
+	    std::string &,
+	    DevFailed *,
+	    PollClock::time_point);
 
 //------------------ Push event -------------------------------
 
@@ -153,10 +186,6 @@ public :
 	void set_one_subscription_cmd(bool val) {one_subscription_cmd = val;}
 
 protected :
-	inline int timeval_diff(TimeVal before, TimeVal after)
-	{
-		return ((after.tv_sec-before.tv_sec)*1000000 + after.tv_usec - before.tv_usec);
-	}
 
 	static std::string 		    fqdn_prefix;
 

--- a/cppapi/server/fwdattribute.h
+++ b/cppapi/server/fwdattribute.h
@@ -37,6 +37,8 @@
 #ifdef _TG_WINDOWS_
 #include <sys/types.h>
 #include <sys/timeb.h>
+#else
+#include <sys/time.h>
 #endif
 
 namespace Tango

--- a/cppapi/server/notifdeventsupplier.cpp
+++ b/cppapi/server/notifdeventsupplier.cpp
@@ -45,11 +45,9 @@
 #include <stdio.h>
 
 #ifdef _TG_WINDOWS_
-#include <sys/timeb.h>
 #include <process.h>
 #else
 #include <unistd.h>
-#include <sys/time.h>
 #endif
 
 using namespace CORBA;

--- a/cppapi/server/pipe.cpp
+++ b/cppapi/server/pipe.cpp
@@ -635,22 +635,7 @@ void Pipe::set_one_str_prop(const char *prop_name,const CORBA::String_member &co
 
 void Pipe::set_time()
 {
-#ifdef _TG_WINDOWS_
-	struct _timeb t;
-	_ftime(&t);
-
-	when.tv_sec = (CORBA::Long)t.time;
-	when.tv_usec = (CORBA::Long)(t.millitm * 1000);
-	when.tv_nsec = 0;
-#else
-	struct timezone tz;
-	struct timeval tv;
-	gettimeofday(&tv,&tz);
-
-	when.tv_sec = (CORBA::Long)tv.tv_sec;
-	when.tv_usec = (CORBA::Long)tv.tv_usec;
-	when.tv_nsec = 0;
-#endif
+	when = make_TimeVal(std::chrono::system_clock::now());
 }
 
 //+-------------------------------------------------------------------------

--- a/cppapi/server/pipe.cpp
+++ b/cppapi/server/pipe.cpp
@@ -36,6 +36,7 @@
 
 #include <tango.h>
 #include <eventsupplier.h>
+#include <tango_clock.h>
 
 namespace Tango
 {
@@ -743,20 +744,11 @@ void Pipe::fire_event(DeviceImpl *dev,DevFailed *except)
 	event_supplier_zmq->push_event(dev, event_type, f_names, f_data, f_names_lg, f_data_lg, ad, name, except, true);
 }
 
-#ifdef _TG_WINDOWS_
 void Pipe::fire_event(DeviceImpl *_dev,DevicePipeBlob *_dat,bool reuse_it)
 {
-	struct _timeb now_win;
-	struct timeval now;
-
-	_ftime(&now_win);
-	now.tv_sec = (unsigned long)now_win.time;
-	now.tv_usec = (long)now_win.millitm * 1000;
-
-	fire_event(_dev,_dat,now,reuse_it);
+	auto now = make_timeval(std::chrono::system_clock::now());
+	fire_event(_dev, _dat, now, reuse_it);
 }
-#endif // _TG_WINDOWS_
-
 
 void Pipe::fire_event(DeviceImpl *dev,DevicePipeBlob *p_data,struct timeval &t,bool reuse_it)
 {
@@ -814,7 +806,6 @@ void Pipe::fire_event(DeviceImpl *dev,DevicePipeBlob *p_data,struct timeval &t,b
 	::memset(&(ad.pipe_val->time),0,sizeof(ad.pipe_val->time));
 	ad.pipe_val->time.tv_sec = t.tv_sec;
 	ad.pipe_val->time.tv_usec = t.tv_usec;
-
 
 	const std::string &bl_name = p_data->get_name();
 	if (bl_name.size() != 0)

--- a/cppapi/server/pipe.h
+++ b/cppapi/server/pipe.h
@@ -374,11 +374,7 @@ public:
 	omni_mutex *get_user_pipe_mutex() {return user_pipe_mutex;}
 
 	void fire_event(DeviceImpl *,DevFailed *);
-#ifdef _TG_WINDOWS_
 	void fire_event(DeviceImpl *,DevicePipeBlob *,bool);
-#else
-	void fire_event(DeviceImpl *_dev,DevicePipeBlob *_dat,bool bo) {struct timeval now;gettimeofday(&now,NULL);fire_event(_dev,_dat,now,bo);}
-#endif
 	void fire_event(DeviceImpl *,DevicePipeBlob *,struct timeval &,bool);
 
 	void set_event_subscription(time_t _t) {event_subscription = _t;}

--- a/cppapi/server/poll_clock.h
+++ b/cppapi/server/poll_clock.h
@@ -43,12 +43,15 @@ inline PollClock::time_point wall_time_to_poll_time(WallClock::time_point wall)
 
 inline TimeVal make_TimeVal(PollClock::time_point poll_tp)
 {
+    constexpr std::chrono::nanoseconds::rep NANOS_IN_SEC = 1000*1000*1000;
+    constexpr std::chrono::nanoseconds::rep NANOS_IN_USEC = 1000;
+
     auto wall_tp = __detail::poll_time_to_wall_time(poll_tp);
     auto time_ns = std::chrono::nanoseconds(wall_tp.time_since_epoch()).count();
     TimeVal tv{};
-    tv.tv_sec = time_ns / 1000000000;
-    tv.tv_usec = (time_ns % 1000000000) / 1000.0;
-    tv.tv_nsec = 0; // Intentionally set to 0
+    tv.tv_sec = time_ns / NANOS_IN_SEC;
+    tv.tv_usec = (time_ns % NANOS_IN_SEC) / NANOS_IN_USEC;
+    tv.tv_nsec = (time_ns % NANOS_IN_SEC) % NANOS_IN_USEC;
     return tv;
 }
 

--- a/cppapi/server/poll_clock.h
+++ b/cppapi/server/poll_clock.h
@@ -1,0 +1,76 @@
+#ifndef _POLL_CLOCK_H
+#define _POLL_CLOCK_H
+
+#include <chrono>
+#include <ratio>
+
+#include <idl/tango.h>
+
+namespace Tango
+{
+
+using PollClock = std::chrono::steady_clock;
+
+static_assert(
+    std::ratio_less_equal<PollClock::duration::period, std::micro>::value,
+    "Polling thread requires microsecond precision");
+
+namespace __detail
+{
+
+using WallClock = std::chrono::system_clock;
+
+// The conversion is based on the duration equality assumption:
+// (poll_ref - poll) == (wall_ref - wall)
+
+inline WallClock::time_point poll_time_to_wall_time(PollClock::time_point poll)
+{
+    auto poll_ref = PollClock::now();
+    auto wall_ref = WallClock::now();
+    auto wall = wall_ref - (poll_ref - poll);
+    // We must cast, on Windows system_clock has only 1ms precision.
+    return std::chrono::time_point_cast<WallClock::duration>(wall);
+}
+
+inline PollClock::time_point wall_time_to_poll_time(WallClock::time_point wall)
+{
+    auto poll_ref = PollClock::now();
+    auto wall_ref = WallClock::now();
+    return poll_ref - (wall_ref - wall);
+}
+
+} // namespace __detail
+
+inline TimeVal make_TimeVal(PollClock::time_point poll_tp)
+{
+    auto wall_tp = __detail::poll_time_to_wall_time(poll_tp);
+    auto time_ns = std::chrono::nanoseconds(wall_tp.time_since_epoch()).count();
+    TimeVal tv{};
+    tv.tv_sec = time_ns / 1000000000;
+    tv.tv_usec = (time_ns % 1000000000) / 1000.0;
+    tv.tv_nsec = 0; // Intentionally set to 0
+    return tv;
+}
+
+inline PollClock::time_point make_poll_time(::timeval tv)
+{
+    auto wall_time = __detail::WallClock::time_point{
+          std::chrono::seconds(tv.tv_sec)
+        + std::chrono::microseconds(tv.tv_usec)};
+    return __detail::wall_time_to_poll_time(wall_time);
+}
+
+inline PollClock::time_point make_poll_time(TimeVal tv)
+{
+    // We must cast, on Windows we do not have required ns precision.
+    auto wall_duration = std::chrono::duration_cast<__detail::WallClock::duration>(
+          std::chrono::seconds(tv.tv_sec)
+        + std::chrono::microseconds(tv.tv_usec)
+        + std::chrono::nanoseconds(tv.tv_nsec));
+    auto wall_time = __detail::WallClock::time_point{wall_duration};
+    return __detail::wall_time_to_poll_time(wall_time);
+}
+
+} // namespace Tango
+
+#endif

--- a/cppapi/server/pollext.h
+++ b/cppapi/server/pollext.h
@@ -39,6 +39,12 @@
 
 #include <tango.h>
 
+#ifdef _TG_WINDOWS_
+#include <sys/timeb.h>
+#else
+#include <sys/time.h>
+#endif /* _TG_WINDOWS_ */
+
 namespace Tango
 {
 

--- a/cppapi/server/pollext.tpp
+++ b/cppapi/server/pollext.tpp
@@ -35,6 +35,13 @@
 
 #include <tango.h>
 
+#ifdef _TG_WINDOWS_
+#include <sys/types.h>
+#include <sys/timeb.h>
+#else
+#include <sys/time.h>
+#endif /* _TG_WINDOWS_ */
+
 namespace Tango
 {
 

--- a/cppapi/server/pollobj.cpp
+++ b/cppapi/server/pollobj.cpp
@@ -39,12 +39,8 @@
 #include <pollring.h>
 #include <pollring.tpp>
 
-
 #ifdef _TG_WINDOWS_
 #include <sys/types.h>
-#include <sys/timeb.h>
-#else
-#include <sys/time.h>
 #endif /* _TG_WINDOWS_ */
 
 namespace Tango

--- a/cppapi/server/pollobj.h
+++ b/cppapi/server/pollobj.h
@@ -39,7 +39,7 @@
 
 #include <tango.h>
 #include <pollring.h>
-#include <poll_clock.h>
+#include <tango_clock.h>
 
 namespace Tango
 {

--- a/cppapi/server/pollring.cpp
+++ b/cppapi/server/pollring.cpp
@@ -66,7 +66,7 @@ namespace Tango
 
 RingElt::RingElt()
 {
-	when.tv_sec = when.tv_usec = 0;
+	when = {};
 	cmd_result = NULL;
 	attr_value = NULL;
 	attr_value_3 = NULL;
@@ -142,7 +142,7 @@ PollRing::~PollRing()
 //--------------------------------------------------------------------------
 
 
-void PollRing::insert_data(CORBA::Any *any_ptr,struct timeval &t)
+void PollRing::insert_data(CORBA::Any *any_ptr, PollClock::time_point t)
 {
 
 //
@@ -163,7 +163,7 @@ void PollRing::insert_data(CORBA::Any *any_ptr,struct timeval &t)
 	inc_indexes();
 }
 
-void PollRing::insert_data(Tango::AttributeValueList *attr_val,struct timeval &t)
+void PollRing::insert_data(Tango::AttributeValueList *attr_val, PollClock::time_point t)
 {
 
 //
@@ -184,7 +184,7 @@ void PollRing::insert_data(Tango::AttributeValueList *attr_val,struct timeval &t
 	inc_indexes();
 }
 
-void PollRing::insert_data(Tango::AttributeValueList_3 *attr_val,struct timeval &t)
+void PollRing::insert_data(Tango::AttributeValueList_3 *attr_val, PollClock::time_point t)
 {
 
 //
@@ -205,7 +205,7 @@ void PollRing::insert_data(Tango::AttributeValueList_3 *attr_val,struct timeval 
 	inc_indexes();
 }
 
-void PollRing::insert_data(Tango::AttributeValueList_4 *attr_val,struct timeval &t,bool unlock)
+void PollRing::insert_data(Tango::AttributeValueList_4 *attr_val, PollClock::time_point t, bool unlock)
 {
 
 //
@@ -241,7 +241,7 @@ void PollRing::insert_data(Tango::AttributeValueList_4 *attr_val,struct timeval 
 	inc_indexes();
 }
 
-void PollRing::insert_data(Tango::AttributeValueList_5 *attr_val,struct timeval &t,bool unlock)
+void PollRing::insert_data(Tango::AttributeValueList_5 *attr_val, PollClock::time_point t, bool unlock)
 {
 
 //
@@ -290,7 +290,7 @@ void PollRing::insert_data(Tango::AttributeValueList_5 *attr_val,struct timeval 
 //--------------------------------------------------------------------------
 
 
-void PollRing::insert_except(Tango::DevFailed *ex,struct timeval &t)
+void PollRing::insert_except(Tango::DevFailed *ex, PollClock::time_point t)
 {
 
 //
@@ -353,8 +353,9 @@ void PollRing::inc_indexes()
 //
 //--------------------------------------------------------------------------
 
-void PollRing::get_delta_t(std::vector<double> &res,long nb)
+std::vector<PollClock::duration> PollRing::get_delta_t(long nb)
 {
+    std::vector<PollClock::duration> res{};
 
 //
 // Throw exception if nothing in ring
@@ -387,12 +388,6 @@ void PollRing::get_delta_t(std::vector<double> &res,long nb)
 	}
 
 //
-// Clear the result vector
-//
-
-	res.clear();
-
-//
 // Compute how many delta can be computed
 //
 
@@ -406,8 +401,8 @@ void PollRing::get_delta_t(std::vector<double> &res,long nb)
 	long i;
 	for (i = 0;i < nb;i++)
 	{
-		double t_ref = (double)ring[read_index].when.tv_sec + ((double)ring[read_index].when.tv_usec / 1000000);
-		double t_prev = (double)ring[prev_read].when.tv_sec + ((double)ring[prev_read].when.tv_usec / 1000000);
+		auto t_ref = ring[read_index].when;
+		auto t_prev = ring[prev_read].when;
 
 		res.push_back(t_ref - t_prev);
 		prev_read--;
@@ -417,6 +412,8 @@ void PollRing::get_delta_t(std::vector<double> &res,long nb)
 		if (read_index < 0)
 			read_index = max_elt - 1;
 	}
+
+	return res;
 }
 
 //+-------------------------------------------------------------------------
@@ -428,7 +425,7 @@ void PollRing::get_delta_t(std::vector<double> &res,long nb)
 //
 //--------------------------------------------------------------------------
 
-struct timeval PollRing::get_last_insert_date()
+PollClock::time_point PollRing::get_last_insert_date()
 {
 	if (insert_elt == 0)
 		return ring[max_elt - 1].when;
@@ -768,9 +765,7 @@ void PollRing::get_cmd_history(long n,Tango::DevCmdHistoryList *ptr)
 
 	for (i = 0;i < n;i++)
 	{
-		(*ptr)[seq_index].time.tv_sec = ring[index].when.tv_sec + DELTA_T;
-		(*ptr)[seq_index].time.tv_usec = ring[index].when.tv_usec;
-		(*ptr)[seq_index].time.tv_nsec = 0;
+		(*ptr)[seq_index].time = make_TimeVal(ring[index].when);
 
 		if (ring[index].except == NULL)
 		{
@@ -1004,9 +999,7 @@ void PollRing::get_cmd_history(long n,Tango::DevCmdHistory_4 *ptr,Tango::CmdArgT
 // Copy dates
 //
 
-		ptr->dates[seq_index].tv_sec = ring[index].when.tv_sec + DELTA_T;
-		ptr->dates[seq_index].tv_usec = ring[index].when.tv_usec;
-		ptr->dates[seq_index].tv_nsec = 0;
+		ptr->dates[seq_index] = make_TimeVal(ring[index].when);
 
 //
 // Error treatement
@@ -1523,9 +1516,7 @@ void PollRing::get_attr_history(long n,Tango::DevAttrHistoryList *ptr,long type)
 
 	for (i = 0;i < n;i++)
 	{
-		(*ptr)[seq_index].value.time.tv_sec = ring[index].when.tv_sec + DELTA_T;
-		(*ptr)[seq_index].value.time.tv_usec = ring[index].when.tv_usec;
-		(*ptr)[seq_index].value.time.tv_nsec = 0;
+		(*ptr)[seq_index].value.time = make_TimeVal(ring[index].when);
 
 		if (ring[index].except == NULL)
 		{
@@ -1713,9 +1704,7 @@ void PollRing::get_attr_history(long n,Tango::DevAttrHistoryList_3 *ptr,long typ
 
 	for (i = 0;i < n;i++)
 	{
-		(*ptr)[seq_index].value.time.tv_sec = ring[index].when.tv_sec + DELTA_T;
-		(*ptr)[seq_index].value.time.tv_usec = ring[index].when.tv_usec;
-		(*ptr)[seq_index].value.time.tv_nsec = 0;
+		(*ptr)[seq_index].value.time = make_TimeVal(ring[index].when);
 
 		if (ring[index].except == NULL)
 		{
@@ -1919,9 +1908,7 @@ void PollRing::get_attr_history_43(long n,Tango::DevAttrHistoryList_3 *ptr,long 
 
 	for (i = 0;i < n;i++)
 	{
-		(*ptr)[seq_index].value.time.tv_sec = ring[index].when.tv_sec + DELTA_T;
-		(*ptr)[seq_index].value.time.tv_usec = ring[index].when.tv_usec;
-		(*ptr)[seq_index].value.time.tv_nsec = 0;
+		(*ptr)[seq_index].value.time = make_TimeVal(ring[index].when);
 
 		if (ring[index].except == NULL)
 		{

--- a/cppapi/server/pollring.cpp
+++ b/cppapi/server/pollring.cpp
@@ -46,9 +46,6 @@
 
 #ifdef _TG_WINDOWS_
 #include <sys/types.h>
-#include <sys/timeb.h>
-#else
-#include <sys/time.h>
 #endif /* _TG_WINDOWS_ */
 
 namespace Tango

--- a/cppapi/server/pollring.h
+++ b/cppapi/server/pollring.h
@@ -35,6 +35,7 @@
 #define _POLLRING_H
 
 #include <tango.h>
+#include <poll_clock.h>
 
 namespace Tango
 {
@@ -60,7 +61,7 @@ public:
 	Tango::AttributeValueList_4	*attr_value_4;
 	Tango::AttributeValueList_5	*attr_value_5;
 	Tango::DevFailed			*except;
-	struct timeval				when;
+	PollClock::time_point when;
 };
 
 inline bool operator<(const RingElt &,const RingElt &)
@@ -89,17 +90,17 @@ public:
 	PollRing(long);
 	~PollRing();
 
-	void insert_data(CORBA::Any *,struct timeval &);
-	void insert_data(Tango::AttributeValueList *,struct timeval &);
-	void insert_data(Tango::AttributeValueList_3 *,struct timeval &);
-	void insert_data(Tango::AttributeValueList_4 *,struct timeval &,bool);
-	void insert_data(Tango::AttributeValueList_5 *,struct timeval &,bool);
-	void insert_except(Tango::DevFailed *,struct timeval &);
+	void insert_data(CORBA::Any *, PollClock::time_point);
+	void insert_data(Tango::AttributeValueList *,   PollClock::time_point);
+	void insert_data(Tango::AttributeValueList_3 *, PollClock::time_point);
+	void insert_data(Tango::AttributeValueList_4 *, PollClock::time_point, bool);
+	void insert_data(Tango::AttributeValueList_5 *, PollClock::time_point, bool);
+	void insert_except(Tango::DevFailed *,          PollClock::time_point);
 
 	template <typename T> void force_copy_data(T *);
 
-	void get_delta_t(std::vector<double> &,long nb);
-	struct timeval get_last_insert_date();
+	std::vector<PollClock::duration> get_delta_t(long nb);
+	PollClock::time_point get_last_insert_date();
 	bool is_empty() {if (nb_elt == 0) return true;else return false;}
 
 	bool is_last_an_error();

--- a/cppapi/server/pollring.h
+++ b/cppapi/server/pollring.h
@@ -55,12 +55,12 @@ class RingElt
 public:
 	RingElt();
 
-	CORBA::Any					*cmd_result;
-	Tango::AttributeValueList	*attr_value;
-	Tango::AttributeValueList_3	*attr_value_3;
-	Tango::AttributeValueList_4	*attr_value_4;
-	Tango::AttributeValueList_5	*attr_value_5;
-	Tango::DevFailed			*except;
+	CORBA::Any* cmd_result;
+	Tango::AttributeValueList * attr_value;
+	Tango::AttributeValueList_3* attr_value_3;
+	Tango::AttributeValueList_4* attr_value_4;
+	Tango::AttributeValueList_5* attr_value_5;
+	Tango::DevFailed* except;
 	PollClock::time_point when;
 };
 

--- a/cppapi/server/pollring.h
+++ b/cppapi/server/pollring.h
@@ -35,7 +35,7 @@
 #define _POLLRING_H
 
 #include <tango.h>
-#include <poll_clock.h>
+#include <tango_clock.h>
 
 namespace Tango
 {

--- a/cppapi/server/pollring.tpp
+++ b/cppapi/server/pollring.tpp
@@ -353,8 +353,7 @@ void PollRing::get_attr_history(long n,T *ptr,long type)
         }
         else
         {
-            ptr->dates[seq_index].tv_sec = ring[index].when.tv_sec + DELTA_T;
-            ptr->dates[seq_index].tv_usec = ring[index].when.tv_usec;
+            ptr->dates[seq_index] = make_TimeVal(ring[index].when);
         }
         ptr->dates[seq_index].tv_nsec = 0;
 

--- a/cppapi/server/pollthread.cpp
+++ b/cppapi/server/pollthread.cpp
@@ -1310,13 +1310,13 @@ void PollThread::compute_sleep_time()
 
             if (next < after)
             {
-                if (after - next < DISCARD_THRESHOLD)
+                if ((after - next) < DISCARD_THRESHOLD)
                 {
                     sleep = tango_nullopt;
                 }
                 else
                 {
-                    while (after - next > DISCARD_THRESHOLD)
+                    while ((after - next) > DISCARD_THRESHOLD)
                     {
                         cout5 << "Discard one elt !!!!!!!!!!!!!" << std::endl;
                         WorkItem tmp = works.front();

--- a/cppapi/server/pollthread.cpp
+++ b/cppapi/server/pollthread.cpp
@@ -38,12 +38,6 @@
 #include <eventsupplier.h>
 #include <pollthread.tpp>
 
-#ifdef _TG_WINDOWS_
-	#include <sys/timeb.h>
-#else
-	#include <sys/time.h>
-#endif
-
 #include <iomanip>
 
 extern omni_thread::key_t key_py_data;

--- a/cppapi/server/pollthread.cpp
+++ b/cppapi/server/pollthread.cpp
@@ -1355,7 +1355,7 @@ void PollThread::compute_sleep_time()
         }
         else
         {
-            cout5 << "Sleep for : -1 (undefined)" << std::endl;
+            cout5 << "Sleep for : do not sleep" << std::endl;
         }
 	}
 }

--- a/cppapi/server/pollthread.cpp
+++ b/cppapi/server/pollthread.cpp
@@ -237,7 +237,7 @@ void *PollThread::run_undetached(TANGO_UNUSED(void *ptr))
 //		If the work list is empty, the thread waits for ever.
 //
 // returns :
-// 		The method returns true if the thread has been awaken due to a new command sent by the main thread
+// 		Enumeration indicating the type of detected event when waiting for next command.
 //
 //------------------------------------------------------------------------------------------------------------------
 

--- a/cppapi/server/pollthread.cpp
+++ b/cppapi/server/pollthread.cpp
@@ -352,7 +352,7 @@ void PollThread::execute_cmd()
                 if (local_cmd.new_upd != PollClock::duration::zero())
                 {
                     cout5 << "Received a delta from now of "
-                        << std::fixed << std::chrono::nanoseconds(local_cmd.new_upd).count() / 1e6 << " ms"
+                        << std::fixed << duration_ms(local_cmd.new_upd) << " ms"
                         << std::endl;
                     wo.wake_up_date += local_cmd.new_upd;
                 }
@@ -979,23 +979,23 @@ void PollThread::print_list()
 				}
 
 				cout5 << "Dev name = " << ite->dev->get_name() << ", obj name = " << obj_list << ", next wake_up at "
-					<< std::fixed << std::chrono::nanoseconds(ite->wake_up_date.time_since_epoch()).count() / 1e9 << " s "
-					<< std::fixed << "(in " << std::chrono::nanoseconds(ite->wake_up_date - PollClock::now()).count() / 1e6 << " ms)"
+					<< std::fixed << duration_s(ite->wake_up_date.time_since_epoch()) << " s "
+					<< std::fixed << "(in " << duration_ms(ite->wake_up_date - PollClock::now()) << " ms)"
 					<< std::endl;
 			}
 			else
 			{
 				cout5 << ite->name[0] << ", next wake_up at "
-					<< std::fixed << std::chrono::nanoseconds(ite->wake_up_date.time_since_epoch()).count() / 1e9 << " s "
-					<< std::fixed << "(in " << std::chrono::nanoseconds(ite->wake_up_date - PollClock::now()).count() / 1e6 << " ms)"
+					<< std::fixed << duration_s(ite->wake_up_date.time_since_epoch()) << " s "
+					<< std::fixed << "(in " << duration_ms(ite->wake_up_date - PollClock::now()) << " ms)"
 					<< std::endl;
 			}
 		}
 		else
 		{
 			cout5 << "Event heartbeat, next wake_up at "
-			<< std::fixed << std::chrono::nanoseconds(ite->wake_up_date.time_since_epoch()).count() / 1e9 << " s "
-			<< std::fixed << "(in " << std::chrono::nanoseconds(ite->wake_up_date - PollClock::now()).count() / 1e6 << " ms)"
+			<< std::fixed << duration_s(ite->wake_up_date.time_since_epoch()) << " s "
+			<< std::fixed << "(in " << duration_ms(ite->wake_up_date - PollClock::now()) << " ms)"
 			<< std::endl;
 		}
 
@@ -1351,7 +1351,7 @@ void PollThread::compute_sleep_time()
 
         if (sleep.has_value())
         {
-            cout5 << "Sleep for : " << std::fixed << std::chrono::nanoseconds(*sleep).count() / 1e9 << "s" << std::endl;
+            cout5 << "Sleep for : " << std::fixed << duration_s(*sleep) << "s" << std::endl;
         }
         else
         {
@@ -1476,7 +1476,7 @@ void PollThread::err_out_of_sync(WorkItem &to_do)
 
 void PollThread::poll_cmd(WorkItem &to_do)
 {
-	cout5 << "----------> Time = " << std::fixed << std::chrono::nanoseconds(now.time_since_epoch()).count() / 1e9 << " s"
+	cout5 << "----------> Time = " << std::fixed << duration_s(now.time_since_epoch()) << " s"
 		<< ", Dev name = " << to_do.dev->get_name()
 		<< ", Cmd name = " << to_do.name[0]
 		<< std::endl;
@@ -1553,7 +1553,7 @@ void PollThread::poll_attr(WorkItem &to_do)
             att_list = att_list + ", ";
     }
 
-	cout5 << "----------> Time = " << std::fixed << std::chrono::nanoseconds(now.time_since_epoch()).count() / 1e9 << " s"
+	cout5 << "----------> Time = " << std::fixed << duration_s(now.time_since_epoch()) << " s"
 		<< ", Dev name = " << to_do.dev->get_name()
 		<< ", Attr name = " << att_list
 		<< std::endl;
@@ -1902,7 +1902,7 @@ void PollThread::poll_attr(WorkItem &to_do)
 
 void PollThread::eve_heartbeat()
 {
-	cout5 << "----------> Time = " << std::fixed << std::chrono::nanoseconds(now.time_since_epoch()).count() / 1e9 << " s"
+	cout5 << "----------> Time = " << std::fixed << duration_s(now.time_since_epoch()) << " s"
 		<< " Sending event heartbeat" << std::endl;
 
 	EventSupplier *event_supplier;
@@ -1933,7 +1933,7 @@ void PollThread::store_subdev()
 {
 	static bool ignore_call = true;
 
-	cout5 << "----------> Time = " << std::fixed << std::chrono::nanoseconds(now.time_since_epoch()).count() / 1e9 << " s"
+	cout5 << "----------> Time = " << std::fixed << duration_s(now.time_since_epoch()) << " s"
 		<< " Store sub device property data if needed!" << std::endl;
 
 

--- a/cppapi/server/pollthread.h
+++ b/cppapi/server/pollthread.h
@@ -69,7 +69,7 @@ struct PollThCmd
 	long			index;			// Index in the device poll_list
 	std::string			name;			// Object name
 	PollObjType		type;			// Object type (cmd/attr)
-	int				new_upd;		// New update period (For upd period com.)
+	PollClock::duration				new_upd;		// New update period (For upd period com.)
 };
 
 
@@ -77,11 +77,11 @@ struct WorkItem
 {
 	DeviceImpl			*dev;			// The device pointer (servant)
 	std::vector<PollObj *> 	*poll_list;		// The device poll list
-	struct timeval		wake_up_date;	// The next wake up date
-	int 				update;			// The update period (mS)
+	PollClock::time_point		wake_up_date;	// The next wake up date
+	PollClock::duration 		update;			// The update period (mS)
 	PollObjType			type;			// Object type (command/attr)
 	std::vector<std::string>		name;			// Object name(s)
-	struct timeval		needed_time;	// Time needed to execute action
+	PollClock::duration needed_time;	// Time needed to execute action
 };
 
 enum PollCmdType
@@ -117,9 +117,7 @@ protected:
 	PollCmdType get_command();
 	void one_more_poll();
 	void one_more_trigg();
-	void compute_new_date(struct timeval &,int);
 	void compute_sleep_time();
-	void time_diff(struct timeval &,struct timeval &,struct timeval &);
 	void poll_cmd(WorkItem &);
 	void poll_attr(WorkItem &);
 	void eve_heartbeat();
@@ -129,7 +127,7 @@ protected:
 	void print_list();
 	void insert_in_list(WorkItem &);
 	void add_insert_in_list(WorkItem &);
-	void tune_list(bool,long);
+	void tune_list(bool);
 	void err_out_of_sync(WorkItem &);
 
     template <typename T> void robb_data(T &,T &);
@@ -143,14 +141,10 @@ protected:
 
 	PollThCmd			local_cmd;
 
-#ifdef _TG_WINDOWS_
-	struct _timeb		now_win;
-	struct _timeb		after_win;
-	double				ctr_frequency;
-#endif
-	struct timeval		now;
-	struct timeval		after;
-	tango_optional<long>				sleep;
+	PollClock::time_point now;
+	PollClock::time_point after;
+	tango_optional<PollClock::duration> sleep;
+
 	bool				polling_stop;
 
 private:
@@ -162,14 +156,15 @@ private:
 	AttributeValue_5	dummy_att5;
 	long				tune_ctr;
 	bool				need_two_tuning;
-	std::vector<long>		auto_upd;
-	std::vector<std::string>      auto_name;
-	std::vector<long>        rem_upd;
-	std::vector<std::string>      rem_name;
 	bool				send_heartbeat;
 	u_int				heartbeat_ctr;
 	u_int               previous_nb_late;
 	bool                polling_bef_9;
+
+	std::vector<PollClock::duration> auto_upd;
+	std::vector<std::string> auto_name;
+	std::vector<PollClock::duration> rem_upd;
+	std::vector<std::string> rem_name;
 
 	ClntIdent 			dummy_cl_id;
 	CppClntIdent 		cci;

--- a/cppapi/server/pollthread.h
+++ b/cppapi/server/pollthread.h
@@ -45,8 +45,7 @@
 #include <utility>
 
 #ifdef _TG_WINDOWS_
-	#include <sys/types.h>
-	#include <sys/timeb.h>
+#include <sys/types.h>
 #endif
 
 namespace Tango

--- a/cppapi/server/pollthread.h
+++ b/cppapi/server/pollthread.h
@@ -42,6 +42,7 @@
 #include <poll_clock.h>
 
 #include <list>
+#include <utility>
 
 #ifdef _TG_WINDOWS_
 	#include <sys/types.h>
@@ -161,10 +162,8 @@ private:
 	u_int               previous_nb_late;
 	bool                polling_bef_9;
 
-	std::vector<PollClock::duration> auto_upd;
-	std::vector<std::string> auto_name;
-	std::vector<PollClock::duration> rem_upd;
-	std::vector<std::string> rem_name;
+	std::vector<std::pair<PollClock::duration, std::string>> auto_upd;
+	std::vector<std::pair<PollClock::duration, std::string>> rem_upd;
 
 	ClntIdent 			dummy_cl_id;
 	CppClntIdent 		cci;

--- a/cppapi/server/pollthread.h
+++ b/cppapi/server/pollthread.h
@@ -38,6 +38,7 @@
 #include <tango.h>
 #include <pollobj.h>
 #include <utils.h>
+#include <tango_optional.h>
 
 #include <list>
 
@@ -112,7 +113,7 @@ public:
 	void set_polling_bef_9(bool _v) {polling_bef_9 = _v;}
 
 protected:
-	PollCmdType get_command(long);
+	PollCmdType get_command();
 	void one_more_poll();
 	void one_more_trigg();
 	void compute_new_date(struct timeval &,int);
@@ -148,7 +149,7 @@ protected:
 #endif
 	struct timeval		now;
 	struct timeval		after;
-	long				sleep;
+	tango_optional<long>				sleep;
 	bool				polling_stop;
 
 private:

--- a/cppapi/server/pollthread.h
+++ b/cppapi/server/pollthread.h
@@ -39,6 +39,7 @@
 #include <pollobj.h>
 #include <utils.h>
 #include <tango_optional.h>
+#include <poll_clock.h>
 
 #include <list>
 

--- a/cppapi/server/pollthread.h
+++ b/cppapi/server/pollthread.h
@@ -174,47 +174,6 @@ public:
 	static PollObjType	type_to_del;
 };
 
-//
-// Three macros
-//
-
-#define T_DIFF(A,B,C)                                                      \
-  do                                                                       \
-  {                                                                        \
-    long delta_sec = B.tv_sec - A.tv_sec;                                  \
-    if (delta_sec == 0)                                                    \
-      C = B.tv_usec - A.tv_usec;                                           \
-    else                                                                   \
-    {                                                                      \
-      C = ((delta_sec - 1) * 1000000) + (1000000 - A.tv_usec) + B.tv_usec; \
-    }                                                                      \
-  }                                                                        \
-  while(0)
-
-#define T_ADD(A,B)                     \
-  do                                   \
-  {                                    \
-    A.tv_usec = A.tv_usec + B;         \
-    while (A.tv_usec > 1000000)        \
-    {                                  \
-      A.tv_sec++;                      \
-      A.tv_usec = A.tv_usec - 1000000; \
-    }                                  \
-  }                                    \
-  while(0)
-
-#define T_DEC(A,B)                     \
-  do                                   \
-  {                                    \
-    A.tv_usec = A.tv_usec - B;         \
-    if (A.tv_usec < 0)                 \
-    {                                  \
-      A.tv_sec--;                      \
-      A.tv_usec = 1000000 + A.tv_usec; \
-    }                                  \
-  }                                    \
-  while(0)
-
 } // End of Tango namespace
 
 #endif /* _POLLTHREAD_ */

--- a/cppapi/server/pollthread.h
+++ b/cppapi/server/pollthread.h
@@ -62,26 +62,26 @@ namespace Tango
 
 struct PollThCmd
 {
-	bool			cmd_pending;	// The new command flag
-	bool			trigger;		// The external trigger flag
-	PollCmdCode		cmd_code;		// The command code
-	DeviceImpl		*dev;			// The device pointer (servant)
-	long			index;			// Index in the device poll_list
-	std::string			name;			// Object name
-	PollObjType		type;			// Object type (cmd/attr)
-	PollClock::duration				new_upd;		// New update period (For upd period com.)
+	bool cmd_pending;               // The new command flag
+	bool trigger;                   // The external trigger flag
+	PollCmdCode cmd_code;           // The command code
+	DeviceImpl* dev;                // The device pointer (servant)
+	long index;	                    // Index in the device poll_list
+	std::string name;               // Object name
+	PollObjType type;               // Object type (cmd/attr)
+	PollClock::duration new_upd;    // New update period (For upd period com.)
 };
 
 
 struct WorkItem
 {
-	DeviceImpl			*dev;			// The device pointer (servant)
-	std::vector<PollObj *> 	*poll_list;		// The device poll list
-	PollClock::time_point		wake_up_date;	// The next wake up date
-	PollClock::duration 		update;			// The update period (mS)
-	PollObjType			type;			// Object type (command/attr)
-	std::vector<std::string>		name;			// Object name(s)
-	PollClock::duration needed_time;	// Time needed to execute action
+	DeviceImpl* dev;                    // The device pointer (servant)
+	std::vector<PollObj*>* poll_list;   // The device poll list
+	PollClock::time_point wake_up_date; // The next wake up date
+	PollClock::duration update;         // The update period (mS)
+	PollObjType type;                   // Object type (command/attr)
+	std::vector<std::string> name;      // Object name(s)
+	PollClock::duration needed_time;    // Time needed to execute action
 };
 
 enum PollCmdType

--- a/cppapi/server/pollthread.h
+++ b/cppapi/server/pollthread.h
@@ -39,7 +39,7 @@
 #include <pollobj.h>
 #include <utils.h>
 #include <tango_optional.h>
-#include <poll_clock.h>
+#include <tango_clock.h>
 
 #include <list>
 #include <utility>

--- a/cppapi/server/tango_clock.h
+++ b/cppapi/server/tango_clock.h
@@ -95,6 +95,18 @@ inline std::chrono::system_clock::time_point make_system_time(::timeval tv)
     return detail::make_system_time(tv.tv_sec, tv.tv_usec, 0);
 }
 
+template <typename Rep, typename Period>
+double constexpr duration_s(std::chrono::duration<Rep, Period> dur)
+{
+    return std::chrono::nanoseconds(dur).count() / 1e9;
+}
+
+template <typename Rep, typename Period>
+double constexpr duration_ms(std::chrono::duration<Rep, Period> dur)
+{
+    return std::chrono::nanoseconds(dur).count() / 1e6;
+}
+
 } // namespace Tango
 
 #endif

--- a/cppapi/server/tango_clock.h
+++ b/cppapi/server/tango_clock.h
@@ -1,5 +1,5 @@
-#ifndef _POLL_CLOCK_H
-#define _POLL_CLOCK_H
+#ifndef _TANGO_CLOCK_H
+#define _TANGO_CLOCK_H
 
 #include <chrono>
 #include <ratio>

--- a/cppapi/server/tango_clock.h
+++ b/cppapi/server/tango_clock.h
@@ -16,7 +16,7 @@ static_assert(
     std::ratio_less_equal<PollClock::duration::period, std::micro>::value,
     "Polling thread requires microsecond precision");
 
-namespace __detail
+namespace detail
 {
 
 template <typename A, typename B>
@@ -51,7 +51,7 @@ std::chrono::system_clock::time_point make_system_time(TS sec, TU usec, TN nsec)
     return system_clock::time_point{timestamp_sys};
 }
 
-} // namespace __detail
+} // namespace detail
 
 template <typename Clock, typename Dur>
 TimeVal make_TimeVal(std::chrono::time_point<Clock, Dur> tp)
@@ -59,7 +59,7 @@ TimeVal make_TimeVal(std::chrono::time_point<Clock, Dur> tp)
     constexpr std::chrono::nanoseconds::rep NANOS_IN_SEC = 1000*1000*1000;
     constexpr std::chrono::nanoseconds::rep NANOS_IN_USEC = 1000;
 
-    auto wall_tp = __detail::convert_time_point<std::chrono::system_clock::time_point>(tp);
+    auto wall_tp = detail::convert_time_point<std::chrono::system_clock::time_point>(tp);
     auto time_ns = std::chrono::nanoseconds(wall_tp.time_since_epoch()).count();
     TimeVal tv{};
     tv.tv_sec = time_ns / NANOS_IN_SEC;
@@ -80,19 +80,19 @@ template <typename Clock, typename Dur>
 
 inline PollClock::time_point make_poll_time(::timeval tv)
 {
-    auto sys_time = __detail::make_system_time(tv.tv_sec, tv.tv_usec, 0);
-    return __detail::convert_time_point<PollClock::time_point>(sys_time);
+    auto sys_time = detail::make_system_time(tv.tv_sec, tv.tv_usec, 0);
+    return detail::convert_time_point<PollClock::time_point>(sys_time);
 }
 
 inline PollClock::time_point make_poll_time(TimeVal tv)
 {
-    auto sys_time = __detail::make_system_time(tv.tv_sec, tv.tv_usec, tv.tv_nsec);
-    return __detail::convert_time_point<PollClock::time_point>(sys_time);
+    auto sys_time = detail::make_system_time(tv.tv_sec, tv.tv_usec, tv.tv_nsec);
+    return detail::convert_time_point<PollClock::time_point>(sys_time);
 }
 
 inline std::chrono::system_clock::time_point make_system_time(::timeval tv)
 {
-    return __detail::make_system_time(tv.tv_sec, tv.tv_usec, 0);
+    return detail::make_system_time(tv.tv_sec, tv.tv_usec, 0);
 }
 
 } // namespace Tango

--- a/cppapi/server/tango_clock.h
+++ b/cppapi/server/tango_clock.h
@@ -84,7 +84,7 @@ inline PollClock::time_point make_poll_time(::timeval tv)
     return detail::convert_time_point<PollClock::time_point>(sys_time);
 }
 
-inline PollClock::time_point make_poll_time(TimeVal tv)
+inline PollClock::time_point make_poll_time(const TimeVal& tv)
 {
     auto sys_time = detail::make_system_time(tv.tv_sec, tv.tv_usec, tv.tv_nsec);
     return detail::convert_time_point<PollClock::time_point>(sys_time);

--- a/cppapi/server/tango_clock.h
+++ b/cppapi/server/tango_clock.h
@@ -54,7 +54,7 @@ std::chrono::system_clock::time_point make_system_time(TS sec, TU usec, TN nsec)
 } // namespace __detail
 
 template <typename Clock, typename Dur>
-inline TimeVal make_TimeVal(std::chrono::time_point<Clock, Dur> tp)
+TimeVal make_TimeVal(std::chrono::time_point<Clock, Dur> tp)
 {
     constexpr std::chrono::nanoseconds::rep NANOS_IN_SEC = 1000*1000*1000;
     constexpr std::chrono::nanoseconds::rep NANOS_IN_USEC = 1000;
@@ -68,6 +68,16 @@ inline TimeVal make_TimeVal(std::chrono::time_point<Clock, Dur> tp)
     return tv;
 }
 
+template <typename Clock, typename Dur>
+::timeval make_timeval(std::chrono::time_point<Clock, Dur> tp)
+{
+    auto tv = make_TimeVal(tp);
+    ::timeval result{};
+    result.tv_sec = tv.tv_sec;
+    result.tv_usec = tv.tv_usec;
+    return result;
+}
+
 inline PollClock::time_point make_poll_time(::timeval tv)
 {
     auto sys_time = __detail::make_system_time(tv.tv_sec, tv.tv_usec, 0);
@@ -78,6 +88,11 @@ inline PollClock::time_point make_poll_time(TimeVal tv)
 {
     auto sys_time = __detail::make_system_time(tv.tv_sec, tv.tv_usec, tv.tv_nsec);
     return __detail::convert_time_point<PollClock::time_point>(sys_time);
+}
+
+inline std::chrono::system_clock::time_point make_system_time(::timeval tv)
+{
+    return __detail::make_system_time(tv.tv_sec, tv.tv_usec, 0);
 }
 
 } // namespace Tango

--- a/cppapi/server/tango_const.h.in
+++ b/cppapi/server/tango_const.h.in
@@ -83,11 +83,8 @@ const char* const LOCAL_POLL_REQUEST	   = "_local";
 const int   LOCAL_REQUEST_STR_SIZE		   = 6;
 
 const int   MIN_POLL_PERIOD                = 5;
-const int   DELTA_T                        = 1002000000;
-const int   MIN_DELTA_WORK                 = 20000;
 const int   TIME_HEARTBEAT                 = 2000;
 const int   POLL_LOOP_NB                   = 500;
-const int   ONE_SECOND                     = 1000000;
 const double   DISCARD_THRESHOLD           = 0.02;
 
 const int   DEFAULT_TIMEOUT                = 3200;

--- a/cppapi/server/tango_const.h.in
+++ b/cppapi/server/tango_const.h.in
@@ -123,8 +123,6 @@ const char* const DEFAULT_OMNI_CONF_FILE   = "/etc/omniORB.cfg";
 const int   EVENT_HEARTBEAT_PERIOD         = 10;
 const int   EVENT_RESUBSCRIBE_PERIOD       = 600;
 const int   DEFAULT_EVENT_PERIOD           = 1000;
-const double   DELTA_PERIODIC              = 0.98;  // Using a delta of 2% only for times < 5000 ms
-const int   DELTA_PERIODIC_LONG            = 100;   // For times > 5000ms only keep a delta of 100ms
 const char* const HEARTBEAT                = "Event heartbeat";
 
 //

--- a/cppapi/server/tango_const.h.in
+++ b/cppapi/server/tango_const.h.in
@@ -172,12 +172,6 @@ const int   DB_TIMEOUT                     = 13000;
 const int   DB_START_PHASE_RETRIES         = 3;
 
 //
-// Time to wait before trying to reconnect after
-// a connevtion failure
-//
-const int   RECONNECTION_DELAY             = 1000;   //ms. Only try to reconnect every second
-
-//
 // Access Control related defines
 // WARNING: these string are also used within the Db stored procedure
 // introduced in Tango V6.1. If you chang eit here, don't forget to

--- a/cppapi/server/tango_const.h.in
+++ b/cppapi/server/tango_const.h.in
@@ -83,9 +83,6 @@ const char* const LOCAL_POLL_REQUEST	   = "_local";
 const int   LOCAL_REQUEST_STR_SIZE		   = 6;
 
 const int   MIN_POLL_PERIOD                = 5;
-const int   TIME_HEARTBEAT                 = 2000;
-const int   POLL_LOOP_NB                   = 500;
-const double   DISCARD_THRESHOLD           = 0.02;
 
 const int   DEFAULT_TIMEOUT                = 3200;
 const int   DEFAULT_POLL_OLD_FACTOR        = 4;

--- a/cppapi/server/tango_optional.h
+++ b/cppapi/server/tango_optional.h
@@ -1,0 +1,90 @@
+#ifndef _TANGO_OPTIONAL_H
+#define _TANGO_OPTIONAL_H
+
+#include <utility>
+#include <cassert>
+
+namespace Tango
+{
+
+struct tango_nullopt_t
+{
+    struct prevent_init {};
+    explicit constexpr tango_nullopt_t(prevent_init) {}
+};
+
+constexpr tango_nullopt_t tango_nullopt{ tango_nullopt_t::prevent_init{} };
+
+template <typename T>
+class tango_optional
+{
+public:
+    tango_optional()
+        : has_value_(false)
+        , value_()
+    {
+    }
+
+    tango_optional(tango_nullopt_t)
+        : has_value_(false)
+        , value_()
+    {
+    }
+
+    tango_optional(T value)
+        : has_value_(true)
+        , value_(std::move(value))
+    {
+    }
+
+    tango_optional& operator=(tango_nullopt_t)
+    {
+        has_value_ = false;
+        value_ = {};
+        return *this;
+    }
+
+    tango_optional& operator=(T value)
+    {
+        has_value_ = true;
+        value_ = std::move(value);
+        return *this;
+    }
+
+    bool has_value() const
+    {
+        return has_value_;
+    }
+
+    T& operator*()
+    {
+        assert(has_value_);
+        return value_;
+    }
+
+    const T& operator*() const
+    {
+        assert(has_value_);
+        return value_;
+    }
+
+    T* operator->()
+    {
+        assert(has_value_);
+        return &operator*();
+    }
+
+    const T* operator->() const
+    {
+        assert(has_value_);
+        return &operator*();
+    }
+
+private:
+    bool has_value_;
+    T value_;
+};
+
+}
+
+#endif

--- a/cppapi/server/utils.cpp
+++ b/cppapi/server/utils.cpp
@@ -45,11 +45,9 @@
 #ifndef _TG_WINDOWS_
 #include <unistd.h>
 #include <assert.h>
-#include <sys/time.h>
 #include <netdb.h>
 #include <sys/socket.h>
 #else
-#include <sys/timeb.h>
 #include <process.h>
 #include <coutbuf.h>
 #include <ntservice.h>

--- a/cppapi/server/utils.tpp
+++ b/cppapi/server/utils.tpp
@@ -32,6 +32,8 @@
 #ifndef _UTILS_TPP
 #define _UTILS_TPP
 
+#include <poll_clock.h>
+
 namespace Tango
 {
 
@@ -198,9 +200,6 @@ void Util::fill_attr_polling_buffer(DeviceImpl *dev,std::string &att_name,AttrHi
     Tango::DevFailed *save_except;
     AttributeIdlData aid;
     bool attr_failed;
-
-    struct timeval zero,when;
-    zero.tv_sec = zero.tv_usec = 0;
 
 //
 // Take the device monitor before the loop
@@ -426,27 +425,27 @@ void Util::fill_attr_polling_buffer(DeviceImpl *dev,std::string &att_name,AttrHi
             {
             	if (idl_vers >= 5)
 				{
-                    when.tv_sec  = (*aid.data_5)[0].time.tv_sec - DELTA_T;
-                    when.tv_usec = (*aid.data_5)[0].time.tv_usec;
+                    auto when = make_poll_time((*aid.data_5)[0].time);
+                    auto zero = PollClock::duration::zero();
                     (*ite)->insert_data(aid.data_5,when,zero);
 				}
                 else if (idl_vers == 4)
                 {
-                    when.tv_sec  = (*aid.data_4)[0].time.tv_sec - DELTA_T;
-                    when.tv_usec = (*aid.data_4)[0].time.tv_usec;
+                    auto when = make_poll_time((*aid.data_4)[0].time);
+                    auto zero = PollClock::duration::zero();
                     (*ite)->insert_data(aid.data_4,when,zero);
                 }
                 else
                 {
-                    when.tv_sec  = (*aid.data_3)[0].time.tv_sec - DELTA_T;
-                    when.tv_usec = (*aid.data_3)[0].time.tv_usec;
+                    auto when = make_poll_time((*aid.data_3)[0].time);
+                    auto zero = PollClock::duration::zero();
                     (*ite)->insert_data(aid.data_3,when,zero);
                 }
             }
             else
             {
-                when = (data.get_data())[i].t_val;
-                when.tv_sec = when.tv_sec - DELTA_T;
+                auto when = make_poll_time((data.get_data())[i].t_val);
+                auto zero = PollClock::duration::zero();
                 (*ite)->insert_except(save_except,when,zero);
             }
         }
@@ -548,9 +547,6 @@ void Util::fill_cmd_polling_buffer(DeviceImpl *dev,std::string &cmd_name,CmdHist
     bool cmd_failed;
     CORBA::Any *any_ptr;
 
-    struct timeval zero,when;
-    zero.tv_sec = zero.tv_usec = 0;
-
     for (i = 0;i < nb_elt;i++)
     {
         save_except = NULL;
@@ -608,8 +604,8 @@ void Util::fill_cmd_polling_buffer(DeviceImpl *dev,std::string &cmd_name,CmdHist
         try
         {
             std::vector<PollObj *>::iterator ite = dev->get_polled_obj_by_type_name(Tango::POLL_CMD,obj_name);
-            when.tv_sec = (data.get_data())[i].t_val.tv_sec - DELTA_T;
-            when.tv_usec = (data.get_data())[i].t_val.tv_usec;
+            auto when = make_poll_time((data.get_data())[i].t_val);
+            auto zero = PollClock::duration::zero();
             if (cmd_failed == false)
                 (*ite)->insert_data(any_ptr,when,zero);
             else

--- a/cppapi/server/utils.tpp
+++ b/cppapi/server/utils.tpp
@@ -32,7 +32,7 @@
 #ifndef _UTILS_TPP
 #define _UTILS_TPP
 
-#include <poll_clock.h>
+#include <tango_clock.h>
 
 namespace Tango
 {

--- a/cppapi/server/utils_polling.cpp
+++ b/cppapi/server/utils_polling.cpp
@@ -34,7 +34,7 @@
 #endif
 
 #include <tango.h>
-#include <poll_clock.h>
+#include <tango_clock.h>
 
 #include <iostream>
 #include <algorithm>

--- a/cppapi/server/utils_polling.cpp
+++ b/cppapi/server/utils_polling.cpp
@@ -34,6 +34,7 @@
 #endif
 
 #include <tango.h>
+#include <poll_clock.h>
 
 #include <iostream>
 #include <algorithm>
@@ -469,8 +470,8 @@ void Util::trigger_attr_polling(Tango::DeviceImpl *dev,const std::string &name)
 // Check that it is an externally triggered polling object. If it is not the case, throw exception
 //
 
-	long tmp_upd = (*ite)->get_upd();
-	if (tmp_upd != 0)
+	auto tmp_upd = (*ite)->get_upd();
+	if (tmp_upd != PollClock::duration::zero())
 	{
 		TangoSys_OMemStream o;
 
@@ -627,8 +628,8 @@ void Util::trigger_cmd_polling(Tango::DeviceImpl *dev,const std::string &name)
 // Check that it is an externally triggered polling object. If it is not the case, throw exception
 //
 
-	long tmp_upd = (*ite)->get_upd();
-	if (tmp_upd != 0)
+	auto tmp_upd = (*ite)->get_upd();
+	if (tmp_upd != PollClock::duration::zero())
 	{
 		TangoSys_OMemStream o;
 

--- a/cppapi/server/utils_spec.tpp
+++ b/cppapi/server/utils_spec.tpp
@@ -32,7 +32,7 @@
 #ifndef _UTILS_SPEC_TPP
 #define _UTILS_SPEC_TPP
 
-#include <poll_clock.h>
+#include <tango_clock.h>
 
 namespace Tango
 {

--- a/cppapi/server/utils_spec.tpp
+++ b/cppapi/server/utils_spec.tpp
@@ -32,6 +32,8 @@
 #ifndef _UTILS_SPEC_TPP
 #define _UTILS_SPEC_TPP
 
+#include <poll_clock.h>
+
 namespace Tango
 {
 
@@ -117,9 +119,6 @@ inline void Util::fill_cmd_polling_buffer(DeviceImpl *dev,std::string &cmd_name,
     bool cmd_failed;
     CORBA::Any *any_ptr;
 
-    struct timeval zero,when;
-    zero.tv_sec = zero.tv_usec = 0;
-
     for (i = 0;i < nb_elt;i++)
     {
         save_except = NULL;
@@ -178,8 +177,8 @@ inline void Util::fill_cmd_polling_buffer(DeviceImpl *dev,std::string &cmd_name,
         try
         {
             std::vector<PollObj *>::iterator ite = dev->get_polled_obj_by_type_name(Tango::POLL_CMD,obj_name);
-            when.tv_sec = (data.get_data())[i].t_val.tv_sec - DELTA_T;
-            when.tv_usec = (data.get_data())[i].t_val.tv_usec;
+            auto when = make_poll_time(data.get_data()[i].t_val);
+            auto zero = PollClock::duration::zero();
             if (cmd_failed == false)
                 (*ite)->insert_data(any_ptr,when,zero);
             else
@@ -261,9 +260,6 @@ inline void Util::fill_cmd_polling_buffer(DeviceImpl *dev,std::string &cmd_name,
     bool cmd_failed;
     CORBA::Any *any_ptr;
 
-    struct timeval zero,when;
-    zero.tv_sec = zero.tv_usec = 0;
-
     for (i = 0;i < nb_elt;i++)
     {
         save_except = NULL;
@@ -322,8 +318,8 @@ inline void Util::fill_cmd_polling_buffer(DeviceImpl *dev,std::string &cmd_name,
         try
         {
             std::vector<PollObj *>::iterator ite = dev->get_polled_obj_by_type_name(Tango::POLL_CMD,obj_name);
-            when.tv_sec = (data.get_data())[i].t_val.tv_sec - DELTA_T;
-            when.tv_usec = (data.get_data())[i].t_val.tv_usec;
+            auto when = make_poll_time(data.get_data()[i].t_val);
+            auto zero = PollClock::duration::zero();
             if (cmd_failed == false)
                 (*ite)->insert_data(any_ptr,when,zero);
             else

--- a/cppapi/server/w_attribute.cpp
+++ b/cppapi/server/w_attribute.cpp
@@ -51,10 +51,7 @@
 
 #ifdef _TG_WINDOWS_
 #include <sys/types.h>
-#include <sys/timeb.h>
 #include <float.h>
-#else
-#include <sys/time.h>
 #endif /* _TG_WINDOWS_ */
 
 namespace Tango

--- a/cppapi/server/w_attribute.h
+++ b/cppapi/server/w_attribute.h
@@ -976,12 +976,6 @@ private:
 	bool						mem_write_failed;		// Flag set to true if the memorized att setting failed
 };
 
-
-#define COMPUTE_TIME_DIFF(RESULT,BEFORE,AFTER) \
-long bef = ((BEFORE.tv_sec - 1095000000) * 1000) + (BEFORE.tv_usec / 1000); \
-long after = ((AFTER.tv_sec - 1095000000) * 1000) + (AFTER.tv_usec / 1000); \
-RESULT = after - bef;
-
 } // End of Tango namespace
 
 #endif // _WATTRIBUTE_H

--- a/cppapi/server/zmqeventsupplier.cpp
+++ b/cppapi/server/zmqeventsupplier.cpp
@@ -38,11 +38,9 @@
 #include <iterator>
 
 #ifdef _TG_WINDOWS_
-#include <sys/timeb.h>
 #include <ws2tcpip.h>
 #else
 #include <arpa/inet.h>
-#include <sys/time.h>
 #include <netdb.h>
 #include <sys/socket.h>
 #include <netinet/in.h>

--- a/cppapi/server/zmqeventsupplier.cpp
+++ b/cppapi/server/zmqeventsupplier.cpp
@@ -1647,7 +1647,7 @@ bool ZmqEventSupplier::update_connected_client(client_addr *cl)
 
     con_client.remove_if([&](ConnectedClient &cc)
         {
-            return now - cc.date > std::chrono::seconds(500);
+            return (now - cc.date) > std::chrono::seconds(500);
         });
 
     return ret;


### PR DESCRIPTION
We have five different types to represent time in Tango (time_t, timeval, long (ms), double (s), Tango::TimeVal) and we convert between them a lot in the whole codebase. Sometimes we also need to shift timestamps by DELTA_T to avoid overflows. All this is error-prone and requires a lot of duplicated code.

This changes polling thread and related classes to operate on std::chrono `duration`s and `time_point`s .

Follow-up of #704.
Fixes #675.