### PR TITLE
Require C++14 standard

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,8 @@ cmake_minimum_required(VERSION 3.7 FATAL_ERROR)
 
 project(cppTango)
 
-set(CXX_STANDARD_REQUIRED 11)
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 include(CTest)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,8 +2,7 @@ cmake_minimum_required(VERSION 3.7 FATAL_ERROR)
 
 project(cppTango)
 
-# C++17 and higher support is currently not possible as omniorb uses
-# throw specifications and these are not supported anymore.
+# omniORB>=4.2.4 is required for compilation in C++17 (or better) mode.
 if (NOT DEFINED CMAKE_CXX_STANDARD)
     set(CMAKE_CXX_STANDARD 14)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,7 @@ project(cppTango)
 # throw specifications and these are not supported anymore.
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
 include(CTest)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,9 @@ project(cppTango)
 
 # C++17 and higher support is currently not possible as omniorb uses
 # throw specifications and these are not supported anymore.
-set(CMAKE_CXX_STANDARD 14)
+if (NOT DEFINED CMAKE_CXX_STANDARD)
+    set(CMAKE_CXX_STANDARD 14)
+endif()
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,9 @@ cmake_minimum_required(VERSION 3.7 FATAL_ERROR)
 
 project(cppTango)
 
-set(CMAKE_CXX_STANDARD 11)
+# C++17 and higher support is currently not possible as omniorb uses
+# throw specifications and these are not supported anymore.
+set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 include(CTest)

--- a/configure/CMakeLists.txt
+++ b/configure/CMakeLists.txt
@@ -193,14 +193,6 @@ if(${FAILED})
 endif()
 
 if(NOT WIN32)
-    include(CheckCXXCompilerFlag)
-    # C++17 and higher support is currently not possible as omniorb uses
-    # throw specifications and these are not supported anymore.
-    CHECK_CXX_COMPILER_FLAG("-std=c++14" COMPILER_SUPPORTS_CXX14)
-    if(COMPILER_SUPPORTS_CXX14)
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")
-    endif()
-
     if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
         message("found GNU compiler ...")
         if(CMAKE_BUILD_TYPE STREQUAL "Release")

--- a/configure/cmake_pch_linux.cmake
+++ b/configure/cmake_pch_linux.cmake
@@ -50,6 +50,7 @@ function(tango_add_pch pch_target ref_target pch_extra_cxx_flags)
         ${pch_compile_opts}
         ${pch_extra_cxx_flags}
         -x c++-header
+        -std=c++${CMAKE_CXX_STANDARD}
         -c
         -o ${tango_pch_file})
 


### PR DESCRIPTION
As decided in last Tango Kernel meeting, we now require C++14 to compile cppTango.

https://github.com/tango-controls/tango-kernel-followup/blob/master/2020/2020-06-25/Minutes.md#recent-developments