### PR TITLE
Restore event subscriptions after device server rename and restart

### DIFF
--- a/cppapi/client/event.cpp
+++ b/cppapi/client/event.cpp
@@ -388,8 +388,8 @@ void EventConsumer::shutdown_keep_alive_thread()
 
 void EventConsumer::connect(DeviceProxy *device_proxy,std::string &d_name,DeviceData &dd,std::string &adm_name,bool &necm)
 {
+	// We always assume that the channel name is a fully qualified admin device name.
 	std::string channel_name = adm_name;
-
 
 //
 // If no connection exists to this channel then connect to it. Sometimes, this method is called in order to reconnect


### PR DESCRIPTION
If event channel is renamed (admin device name is changed), we now
detect this, create new Device Proxy to the admin device and update
internal structures accordingly.

Fixes #679.