### PR TITLE
log4tango: Use BUILD_TESTING option

### DIFF
--- a/log4tango/CMakeLists.txt
+++ b/log4tango/CMakeLists.txt
@@ -12,6 +12,7 @@ include(${CMAKE_CURRENT_SOURCE_DIR}/config/config.cmake)
 
 add_subdirectory(include)
 add_subdirectory(src)
-if (NOT WIN32)
+
+if(BUILD_TESTING)
     add_subdirectory(tests)
-endif(NOT WIN32)
+endif()


### PR DESCRIPTION
We don't want to determine that by the platform. Accompanying fix to
a81c1584 (CMakeLists.txt: Rework test suite handling, 2020-01-23).

Backport of #741.