### PR TITLE
Event unsubscription from DeviceProxy destructor

### DIFF
--- a/cpp_test_suite/new_tests/cxx_dserver_misc.cpp
+++ b/cpp_test_suite/new_tests/cxx_dserver_misc.cpp
@@ -394,6 +394,38 @@ cout << "str = " << str << endl;
         TS_ASSERT_EQUALS(3, callback2.num_of_all_events);
         TS_ASSERT_EQUALS(0, callback2.num_of_error_events);
     }
+
+    void test_unsubscription_multiple_subscriptions_with_single_proxy()
+    {
+        EventCallback<Tango::EventData> callback1{};
+        EventCallback<Tango::EventData> callback2{};
+
+        const std::string attribute_name = "event_change_tst";
+
+        auto proxy = std::make_unique<DeviceProxy>(device1_name);
+
+        TS_ASSERT_THROWS_NOTHING(proxy->subscribe_event(
+            attribute_name, Tango::USER_EVENT, &callback1));
+        TS_ASSERT_THROWS_NOTHING(proxy->subscribe_event(
+            attribute_name, Tango::USER_EVENT, &callback2));
+
+        TS_ASSERT_THROWS_NOTHING(device1->command_inout("IOPushEvent"));
+        Tango_sleep(1);
+        TS_ASSERT_EQUALS(2, callback1.num_of_all_events);
+        TS_ASSERT_EQUALS(0, callback1.num_of_error_events);
+        TS_ASSERT_EQUALS(2, callback2.num_of_all_events);
+        TS_ASSERT_EQUALS(0, callback2.num_of_error_events);
+
+        proxy.reset(nullptr);
+
+        TS_ASSERT_THROWS_NOTHING(device1->command_inout("IOPushEvent"));
+        Tango_sleep(1);
+        TS_ASSERT_EQUALS(2, callback1.num_of_all_events);
+        TS_ASSERT_EQUALS(0, callback1.num_of_error_events);
+        TS_ASSERT_EQUALS(2, callback2.num_of_all_events);
+        TS_ASSERT_EQUALS(0, callback2.num_of_error_events);
+    }
+
 };
 #undef cout
 #endif // DServerMiscTestSuite_h

--- a/cppapi/client/event.cpp
+++ b/cppapi/client/event.cpp
@@ -1677,7 +1677,6 @@ int EventConsumer::connect_event(DeviceProxy *device,
     EventSubscribeStruct new_ess;
 
     new_event_callback.received_from_admin = received_from_admin;
-    new_event_callback.device = device;
     new_event_callback.obj_name = obj_name_lower;
     new_event_callback.event_name = event_name;
     new_event_callback.channel_name = evt_it->first;
@@ -1705,6 +1704,7 @@ int EventConsumer::connect_event(DeviceProxy *device,
 
     new_ess.callback = callback;
     new_ess.ev_queue = ev_queue;
+    new_ess.device = device;
 
 	connect_event_system(device_name,obj_name_lower,event_name,filters,evt_it,new_event_callback,dd,valid_endpoint_nb);
 

--- a/cppapi/client/event.cpp
+++ b/cppapi/client/event.cpp
@@ -1586,7 +1586,7 @@ int EventConsumer::connect_event(DeviceProxy *device,
 
 	if (iter != event_callback_map.end())
 	{
-		int new_event_id = add_new_callback(iter, callback, ev_queue, event_id);
+		int new_event_id = add_new_callback(device, iter, callback, ev_queue, event_id);
 		get_fire_sync_event(device,
 							callback,
 							ev_queue,
@@ -1674,7 +1674,7 @@ int EventConsumer::connect_event(DeviceProxy *device,
 //
 
     EventCallBackStruct new_event_callback;
-    EventSubscribeStruct new_ess;
+    EventSubscribeStruct new_ess{};
 
     new_event_callback.received_from_admin = received_from_admin;
     new_event_callback.obj_name = obj_name_lower;
@@ -3046,6 +3046,7 @@ TimeVal EventConsumer::get_last_event_date(int event_id)
 //
 // argument :
 //		in :
+//			- device : Device proxy used for subscription
 //			- iter : Iterator in the callback map
 //			- callback : Pointer to the Callback object
 //			- ev_queue : Pointer to the event queue
@@ -3053,9 +3054,9 @@ TimeVal EventConsumer::get_last_event_date(int event_id)
 //
 //--------------------------------------------------------------------------------------------------------------------
 
-int EventConsumer::add_new_callback(EvCbIte &iter,CallBack *callback,EventQueue *ev_queue,int event_id)
+int EventConsumer::add_new_callback(DeviceProxy *device, EvCbIte &iter,CallBack *callback,EventQueue *ev_queue,int event_id)
 {
-	EventSubscribeStruct ess;
+	EventSubscribeStruct ess{};
 	int ret_event_id = event_id;
 
 	if (ret_event_id <= 0)
@@ -3064,6 +3065,7 @@ int EventConsumer::add_new_callback(EvCbIte &iter,CallBack *callback,EventQueue 
 		ret_event_id = subscribe_event_id;
 	}
 
+	ess.device = device;
 	ess.id = ret_event_id;
 	ess.callback = callback;
 	ess.ev_queue = ev_queue;

--- a/cppapi/client/event.cpp
+++ b/cppapi/client/event.cpp
@@ -4118,5 +4118,10 @@ void PipeEventData::set_time()
 #endif
 }
 
-} /* End of Tango namespace */
+DeviceProxy& EventCallBackBase::get_device_proxy()
+{
+    assert(!callback_list.empty());
+    return *callback_list[0].device;
+}
 
+} /* End of Tango namespace */

--- a/cppapi/client/eventconsumer.h
+++ b/cppapi/client/eventconsumer.h
@@ -345,6 +345,7 @@ typedef struct event_callback_base
 	TangoMonitor					*callback_monitor;
 	std::vector<EventSubscribeStruct>	callback_list;
 	bool							alias_used;
+	DeviceProxy& get_device_proxy();
 } EventCallBackBase;
 
 typedef struct event_callback_zmq

--- a/cppapi/client/eventconsumer.h
+++ b/cppapi/client/eventconsumer.h
@@ -485,7 +485,7 @@ protected :
 	std::string 													obj_name_lower;
     int                                                     thread_id;
 
-	int add_new_callback(EvCbIte &,CallBack *,EventQueue *,int);
+	int add_new_callback(DeviceProxy*, EvCbIte &,CallBack *,EventQueue *,int);
 	void get_fire_sync_event(DeviceProxy *,CallBack *,EventQueue *,EventType,std::string &,const std::string &,EventCallBackStruct &,std::string &);
 
 	virtual void connect_event_channel(std::string &,Database *,bool,DeviceData &) = 0;

--- a/cppapi/client/eventconsumer.h
+++ b/cppapi/client/eventconsumer.h
@@ -332,11 +332,11 @@ typedef struct event_subscribe
 	EventQueue						*ev_queue;
 	CallBack						*callback;
 	int								id;
+ 	DeviceProxy 					*device;
 } EventSubscribeStruct;
 
 typedef struct event_callback_base
 {
- 	DeviceProxy 					*device;
 	std::string 							obj_name;
 	std::string 							event_name;
 	std::string 							channel_name;
@@ -651,7 +651,7 @@ private :
     friend class DelayEvent;
 
     FwdEventData *newFwdEventData(zmq::message_t &event_data,
-                                  const std::string &new_tango_host,
+                                  DeviceProxy* device,
                                   DevErrorList &errors,
                                   std::string &event_name,
                                   std::string &full_att_name,

--- a/cppapi/client/eventkeepalive.cpp
+++ b/cppapi/client/eventkeepalive.cpp
@@ -107,7 +107,7 @@ bool EventConsumerKeepAliveThread::reconnect_to_channel(EvChanIte &ipos,EventCon
 				    DeviceData dummy;
 					std::string adm_name = ipos->second.full_adm_name;
 					event_consumer->connect_event_channel(adm_name,
-									      epos->second.callback_list[0].device->get_device_db(),
+									      epos->second.get_device_proxy().get_device_db(),
 									      true,dummy);
 
 					if (ipos->second.adm_device_proxy != NULL)
@@ -176,7 +176,7 @@ bool EventConsumerKeepAliveThread::reconnect_to_zmq_channel(EvChanIte &ipos,Even
 				{
                     DeviceData subscriber_in,subscriber_out;
                     std::vector<std::string> subscriber_info;
-                    subscriber_info.push_back(epos->second.callback_list[0].device->dev_name());
+                    subscriber_info.push_back(epos->second.get_device_proxy().dev_name());
                     subscriber_info.push_back(epos->second.obj_name);
                     subscriber_info.push_back("subscribe");
                     subscriber_info.push_back(epos->second.event_name);
@@ -198,7 +198,7 @@ bool EventConsumerKeepAliveThread::reconnect_to_zmq_channel(EvChanIte &ipos,Even
                     catch (Tango::DevFailed &e) {}
 #endif
 					event_consumer->connect_event_channel(adm_name,
-									      epos->second.callback_list[0].device->get_device_db(),
+									      epos->second.get_device_proxy().get_device_db(),
 									      true,subscriber_out);
 
                     dd = subscriber_out;
@@ -439,7 +439,7 @@ void EventConsumerKeepAliveThread::reconnect_to_zmq_event(EvChanIte &ipos,EventC
 
 						vs.push_back(std::string("reconnect"));
 
-						std::string d_name = epos->second.callback_list[0].device->dev_name();
+						std::string d_name = epos->second.get_device_proxy().dev_name();
 						std::string &fqen = epos->second.fully_qualified_event_name;
 						std::string::size_type pos = fqen.find('/');
 						pos = pos + 2;
@@ -879,7 +879,7 @@ void EventConsumerKeepAliveThread::confirm_subscription(ZmqEventConsumer *event_
 
 				if (ipos->second.channel_type == ZMQ)
 				{
-					cmd_params.push_back(epos->second.callback_list[0].device->dev_name());
+					cmd_params.push_back(epos->second.get_device_proxy().dev_name());
 					cmd_params.push_back(epos->second.obj_name);
 					cmd_params.push_back(epos->second.event_name);
 
@@ -889,7 +889,7 @@ void EventConsumerKeepAliveThread::confirm_subscription(ZmqEventConsumer *event_
 				{
 					DeviceData subscriber_in;
 					std::vector<std::string> subscriber_info;
-					subscriber_info.push_back(epos->second.callback_list[0].device->dev_name());
+					subscriber_info.push_back(epos->second.get_device_proxy().dev_name());
 					subscriber_info.push_back(epos->second.obj_name);
 					subscriber_info.push_back("subscribe");
 					subscriber_info.push_back(epos->second.event_name);
@@ -1377,7 +1377,7 @@ void EventConsumerKeepAliveThread::re_subscribe_after_reconnect(ZmqEventConsumer
 {
 	DeviceData subscriber_in;
 	std::vector<std::string> subscriber_info;
-	auto& device = *epos->second.callback_list[0].device;
+	auto& device = epos->second.get_device_proxy();
 	subscriber_info.push_back(device.dev_name());
 	subscriber_info.push_back(epos->second.obj_name);
 	subscriber_info.push_back("subscribe");

--- a/cppapi/client/eventkeepalive.cpp
+++ b/cppapi/client/eventkeepalive.cpp
@@ -107,7 +107,7 @@ bool EventConsumerKeepAliveThread::reconnect_to_channel(EvChanIte &ipos,EventCon
 				    DeviceData dummy;
 					std::string adm_name = ipos->second.full_adm_name;
 					event_consumer->connect_event_channel(adm_name,
-									      epos->second.device->get_device_db(),
+									      epos->second.callback_list[0].device->get_device_db(),
 									      true,dummy);
 
 					if (ipos->second.adm_device_proxy != NULL)
@@ -176,7 +176,7 @@ bool EventConsumerKeepAliveThread::reconnect_to_zmq_channel(EvChanIte &ipos,Even
 				{
                     DeviceData subscriber_in,subscriber_out;
                     std::vector<std::string> subscriber_info;
-                    subscriber_info.push_back(epos->second.device->dev_name());
+                    subscriber_info.push_back(epos->second.callback_list[0].device->dev_name());
                     subscriber_info.push_back(epos->second.obj_name);
                     subscriber_info.push_back("subscribe");
                     subscriber_info.push_back(epos->second.event_name);
@@ -198,7 +198,7 @@ bool EventConsumerKeepAliveThread::reconnect_to_zmq_channel(EvChanIte &ipos,Even
                     catch (Tango::DevFailed &e) {}
 #endif
 					event_consumer->connect_event_channel(adm_name,
-									      epos->second.device->get_device_db(),
+									      epos->second.callback_list[0].device->get_device_db(),
 									      true,subscriber_out);
 
                     dd = subscriber_out;
@@ -439,7 +439,7 @@ void EventConsumerKeepAliveThread::reconnect_to_zmq_event(EvChanIte &ipos,EventC
 
 						vs.push_back(std::string("reconnect"));
 
-						std::string d_name = epos->second.device->dev_name();
+						std::string d_name = epos->second.callback_list[0].device->dev_name();
 						std::string &fqen = epos->second.fully_qualified_event_name;
 						std::string::size_type pos = fqen.find('/');
 						pos = pos + 2;
@@ -879,7 +879,7 @@ void EventConsumerKeepAliveThread::confirm_subscription(ZmqEventConsumer *event_
 
 				if (ipos->second.channel_type == ZMQ)
 				{
-					cmd_params.push_back(epos->second.device->dev_name());
+					cmd_params.push_back(epos->second.callback_list[0].device->dev_name());
 					cmd_params.push_back(epos->second.obj_name);
 					cmd_params.push_back(epos->second.event_name);
 
@@ -889,7 +889,7 @@ void EventConsumerKeepAliveThread::confirm_subscription(ZmqEventConsumer *event_
 				{
 					DeviceData subscriber_in;
 					std::vector<std::string> subscriber_info;
-					subscriber_info.push_back(epos->second.device->dev_name());
+					subscriber_info.push_back(epos->second.callback_list[0].device->dev_name());
 					subscriber_info.push_back(epos->second.obj_name);
 					subscriber_info.push_back("subscribe");
 					subscriber_info.push_back(epos->second.event_name);
@@ -1166,7 +1166,7 @@ void EventConsumerKeepAliveThread::main_reconnect(ZmqEventConsumer *event_consum
 
 					if (event_name == CONF_TYPE_EVENT)
 					{
-						FwdAttrConfEventData *event_data = new FwdAttrConfEventData(epos->second.device,
+						FwdAttrConfEventData *event_data = new FwdAttrConfEventData(esspos->device,
 																			domain_name,
 																			event_name,
 																			dev_attr_conf,
@@ -1200,7 +1200,7 @@ void EventConsumerKeepAliveThread::main_reconnect(ZmqEventConsumer *event_consum
 					}
 					else if (event_name == DATA_READY_TYPE_EVENT)
 					{
-						DataReadyEventData *event_data = new DataReadyEventData(epos->second.device,NULL,event_name,errors);
+						DataReadyEventData *event_data = new DataReadyEventData(esspos->device,NULL,event_name,errors);
 						// if a callback method was specified, call it!
 						if (callback != NULL )
 						{
@@ -1229,7 +1229,7 @@ void EventConsumerKeepAliveThread::main_reconnect(ZmqEventConsumer *event_consum
 					}
 					else if (event_name == EventName[INTERFACE_CHANGE_EVENT])
 					{
-						DevIntrChangeEventData *event_data = new DevIntrChangeEventData(epos->second.device,
+						DevIntrChangeEventData *event_data = new DevIntrChangeEventData(esspos->device,
 																			event_name,domain_name,
 																			(CommandInfoList *)NULL,
 																			(AttributeInfoListEx *)NULL,
@@ -1262,7 +1262,7 @@ void EventConsumerKeepAliveThread::main_reconnect(ZmqEventConsumer *event_consum
 					}
 					else if (event_name == EventName[PIPE_EVENT])
 					{
-						PipeEventData *event_data = new PipeEventData(epos->second.device,
+						PipeEventData *event_data = new PipeEventData(esspos->device,
 										domain_name,
 										event_name,
 										dev_pipe,
@@ -1297,7 +1297,7 @@ void EventConsumerKeepAliveThread::main_reconnect(ZmqEventConsumer *event_consum
 					}
 					else
 					{
-						FwdEventData *event_data = new FwdEventData(epos->second.device,
+						FwdEventData *event_data = new FwdEventData(esspos->device,
 										domain_name,
 										event_name,
 										dev_attr,
@@ -1377,7 +1377,8 @@ void EventConsumerKeepAliveThread::re_subscribe_after_reconnect(ZmqEventConsumer
 {
 	DeviceData subscriber_in;
 	std::vector<std::string> subscriber_info;
-	subscriber_info.push_back(epos->second.device->dev_name());
+	auto& device = *epos->second.callback_list[0].device;
+	subscriber_info.push_back(device.dev_name());
 	subscriber_info.push_back(epos->second.obj_name);
 	subscriber_info.push_back("subscribe");
 	subscriber_info.push_back(epos->second.event_name);
@@ -1427,13 +1428,13 @@ void EventConsumerKeepAliveThread::re_subscribe_after_reconnect(ZmqEventConsumer
 			DevErrorList err;
 			err.length(0);
 
-			bool old_transp = epos->second.device->get_transparency_reconnection();
-			epos->second.device->set_transparency_reconnection(true);
+			bool old_transp = device.get_transparency_reconnection();
+			device.set_transparency_reconnection(true);
 
 			try
 			{
 				da = new DeviceAttribute();
-				*da = epos->second.device->read_attribute(epos->second.obj_name.c_str());
+				*da = device.read_attribute(epos->second.obj_name.c_str());
 
                 if (da->has_failed() == true)
                     err = da->get_err_stack();
@@ -1449,7 +1450,7 @@ void EventConsumerKeepAliveThread::re_subscribe_after_reconnect(ZmqEventConsumer
 			{
 				err = e.errors;
 			}
-			epos->second.device->set_transparency_reconnection(old_transp);
+			device.set_transparency_reconnection(old_transp);
 
 			// if callback methods were specified, call them!
 			unsigned int cb_nb = epos->second.callback_list.size();
@@ -1466,7 +1467,7 @@ void EventConsumerKeepAliveThread::re_subscribe_after_reconnect(ZmqEventConsumer
 					da_copy = new DeviceAttribute();
 					da_copy->deep_copy(*da);
 
-					event_data = new FwdEventData(epos->second.device,
+					event_data = new FwdEventData(esspos->device,
 									domain_name,
 									ev_name,
 									da_copy,
@@ -1474,7 +1475,7 @@ void EventConsumerKeepAliveThread::re_subscribe_after_reconnect(ZmqEventConsumer
 				}
 				else
 				{
-					event_data = new FwdEventData(epos->second.device,
+					event_data = new FwdEventData(esspos->device,
 									domain_name,
 									ev_name,
 									da,
@@ -1527,13 +1528,13 @@ void EventConsumerKeepAliveThread::re_subscribe_after_reconnect(ZmqEventConsumer
 				prefix = notifd_event_consumer->env_var_fqdn_prefix[0];
 			else
             {
-                if (epos->second.device->get_from_env_var() == false)
+                if (device.get_from_env_var() == false)
                 {
                     prefix = "tango://";
-                    if (epos->second.device->is_dbase_used() == false)
-                        prefix = prefix + epos->second.device->get_dev_host() + ':' + epos->second.device->get_dev_port() + '/';
+                    if (device.is_dbase_used() == false)
+                        prefix = prefix + device.get_dev_host() + ':' + device.get_dev_port() + '/';
                     else
-                        prefix = prefix + epos->second.device->get_db_host() + ':' + epos->second.device->get_db_port() + '/';
+                        prefix = prefix + device.get_db_host() + ':' + device.get_db_port() + '/';
                 }
                 else
                 {
@@ -1541,18 +1542,18 @@ void EventConsumerKeepAliveThread::re_subscribe_after_reconnect(ZmqEventConsumer
                 }
             }
 
-			std::string dom_name = prefix + epos->second.device->dev_name();
-            if (epos->second.device->is_dbase_used() == false)
+			std::string dom_name = prefix + device.dev_name();
+            if (device.is_dbase_used() == false)
                 dom_name = dom_name + MODIFIER_DBASE_NO;
 			dom_name = dom_name + "/" + epos->second.obj_name;
 
-			bool old_transp = epos->second.device->get_transparency_reconnection();
-			epos->second.device->set_transparency_reconnection(true);
+			bool old_transp = device.get_transparency_reconnection();
+			device.set_transparency_reconnection(true);
 
 			try
 			{
 				aie = new AttributeInfoEx();
-				*aie = epos->second.device->get_attribute_config(epos->second.obj_name);
+				*aie = device.get_attribute_config(epos->second.obj_name);
 
 //
 // The reconnection worked fine. The heartbeat should come back now, when the notifd has not closed the connection.
@@ -1566,7 +1567,7 @@ void EventConsumerKeepAliveThread::re_subscribe_after_reconnect(ZmqEventConsumer
 			{
 				err = e.errors;
 			}
-			epos->second.device->set_transparency_reconnection(old_transp);
+			device.set_transparency_reconnection(old_transp);
 
 			unsigned int cb_nb = epos->second.callback_list.size();
 			unsigned int cb_ctr = 0;
@@ -1585,7 +1586,7 @@ void EventConsumerKeepAliveThread::re_subscribe_after_reconnect(ZmqEventConsumer
 				{
 					aie_copy = new AttributeInfoEx;
 					*aie_copy = *aie;
-					event_data = new FwdAttrConfEventData(epos->second.device,
+					event_data = new FwdAttrConfEventData(esspos->device,
 									dom_name,
 									ev_name,
 									aie_copy,
@@ -1593,7 +1594,7 @@ void EventConsumerKeepAliveThread::re_subscribe_after_reconnect(ZmqEventConsumer
 				}
 				else
 				{
-					event_data = new FwdAttrConfEventData(epos->second.device,
+					event_data = new FwdAttrConfEventData(esspos->device,
 									dom_name,
 									ev_name,
 									aie,
@@ -1642,15 +1643,15 @@ void EventConsumerKeepAliveThread::re_subscribe_after_reconnect(ZmqEventConsumer
 			DevErrorList err;
 			err.length(0);
 			std::string prefix = event_consumer->env_var_fqdn_prefix[0];
-			std::string dom_name = prefix + epos->second.device->dev_name();
+			std::string dom_name = prefix + device.dev_name();
 
-			bool old_transp = epos->second.device->get_transparency_reconnection();
-			epos->second.device->set_transparency_reconnection(true);
+			bool old_transp = device.get_transparency_reconnection();
+			device.set_transparency_reconnection(true);
 
 			try
 			{
-				aie = epos->second.device->attribute_list_query_ex();
-				cil = epos->second.device->command_list_query();
+				aie = device.attribute_list_query_ex();
+				cil = device.command_list_query();
 			}
 			catch (DevFailed &e)
 			{
@@ -1661,7 +1662,7 @@ void EventConsumerKeepAliveThread::re_subscribe_after_reconnect(ZmqEventConsumer
 
 				err = e.errors;
 			}
-			epos->second.device->set_transparency_reconnection(old_transp);
+			device.set_transparency_reconnection(old_transp);
 
 			unsigned int cb_nb = epos->second.callback_list.size();
 			unsigned int cb_ctr = 0;
@@ -1680,14 +1681,14 @@ void EventConsumerKeepAliveThread::re_subscribe_after_reconnect(ZmqEventConsumer
 					*aie_copy = *aie;
 					cil_copy = new CommandInfoList;
 					*cil_copy = *cil;
-					event_data = new DevIntrChangeEventData(epos->second.device,
+					event_data = new DevIntrChangeEventData(esspos->device,
 									ev_name,dom_name,
 									cil_copy,aie_copy,true,
 									err);
 				}
 				else
 				{
-					event_data = new DevIntrChangeEventData(epos->second.device,
+					event_data = new DevIntrChangeEventData(esspos->device,
 									ev_name,dom_name,
 									cil,aie,true,
 									err);
@@ -1744,19 +1745,19 @@ void EventConsumerKeepAliveThread::re_subscribe_after_reconnect(ZmqEventConsumer
 			DevErrorList err;
 			err.length(0);
 
-			bool old_transp = epos->second.device->get_transparency_reconnection();
-			epos->second.device->set_transparency_reconnection(true);
+			bool old_transp = device.get_transparency_reconnection();
+			device.set_transparency_reconnection(true);
 
 			try
 			{
 				dp = new DevicePipe();
-				*dp = epos->second.device->read_pipe(epos->second.obj_name);
+				*dp = device.read_pipe(epos->second.obj_name);
 			}
 			catch (DevFailed &e)
 			{
 				err = e.errors;
 			}
-			epos->second.device->set_transparency_reconnection(old_transp);
+			device.set_transparency_reconnection(old_transp);
 
 			unsigned int cb_nb = epos->second.callback_list.size();
 			unsigned int cb_ctr = 0;
@@ -1773,7 +1774,7 @@ void EventConsumerKeepAliveThread::re_subscribe_after_reconnect(ZmqEventConsumer
 					dp_copy = new DevicePipe();
 					*dp_copy = *dp;
 
-					event_data = new PipeEventData(epos->second.device,
+					event_data = new PipeEventData(esspos->device,
 									domain_name,
 									epos->second.event_name,
 									dp_copy,
@@ -1781,7 +1782,7 @@ void EventConsumerKeepAliveThread::re_subscribe_after_reconnect(ZmqEventConsumer
 				}
 				else
 				{
-					event_data = new PipeEventData(epos->second.device,
+					event_data = new PipeEventData(esspos->device,
 									domain_name,
 									epos->second.event_name,
 									dp,

--- a/cppapi/client/notifdeventconsumer.cpp
+++ b/cppapi/client/notifdeventconsumer.cpp
@@ -995,7 +995,7 @@ void NotifdEventConsumer::push_structured_event(const CosNotification::Structure
 									dev_attr_copy->deep_copy(*dev_attr);
 								}
 
-								event_data = new EventData(event_callback_map[attr_event_name].device,
+								event_data = new EventData(esspos->device,
 												      				fq_dev_name,
 												      				event_name,
 												      				dev_attr_copy,
@@ -1003,7 +1003,7 @@ void NotifdEventConsumer::push_structured_event(const CosNotification::Structure
 							}
 							else
 							{
-								event_data = new EventData (event_callback_map[attr_event_name].device,
+								event_data = new EventData (esspos->device,
 																  fq_dev_name,
 																  event_name,
 																  dev_attr,
@@ -1040,7 +1040,7 @@ void NotifdEventConsumer::push_structured_event(const CosNotification::Structure
 							{
 								AttributeInfoEx *attr_info_copy = new AttributeInfoEx();
 								*attr_info_copy = *attr_info_ex;
-								event_data = new AttrConfEventData(event_callback_map[attr_event_name].device,
+								event_data = new AttrConfEventData(esspos->device,
 																  fq_dev_name,
 																  event_name,
 																  attr_info_copy,
@@ -1048,7 +1048,7 @@ void NotifdEventConsumer::push_structured_event(const CosNotification::Structure
 							}
 							else
 							{
-								event_data = new AttrConfEventData(event_callback_map[attr_event_name].device,
+								event_data = new AttrConfEventData(esspos->device,
 																  fq_dev_name,
 																  event_name,
 																  attr_info_ex,
@@ -1080,7 +1080,7 @@ void NotifdEventConsumer::push_structured_event(const CosNotification::Structure
 						}
 						else
 						{
-							DataReadyEventData *event_data = new DataReadyEventData(event_callback_map[attr_event_name].device,
+							DataReadyEventData *event_data = new DataReadyEventData(esspos->device,
 																	att_ready,event_name,errors);
 							// if a callback method was specified, call it!
 							if (callback != NULL )


### PR DESCRIPTION
The pointer to device proxy used for event subscription is now stored in
EventSubscribeStruct (which is unique entry per subscription) instead of
EventCallBackStruct (which is shared between all subscriptions to the
same event).

Ability to associate subscriptions with device proxies is needed to
correctly unsubscribe from events inside device proxy destructor.

Fixes #353