### PR TITLE
Remove conditional constexpr define

### DIFF
--- a/configure/CMakeLists.txt
+++ b/configure/CMakeLists.txt
@@ -214,14 +214,6 @@ if(WARNINGS_AS_ERRORS)
   endif()
 endif()
 
-if(cxx_relaxed_constexpr IN_LIST CMAKE_CXX_COMPILE_FEATURES)
-  set(TANGO_CXX_HAS_RELAXED_CONSTEXPR TRUE)
-else()
-  set(TANGO_CXX_HAS_RELAXED_CONSTEXPR FALSE)
-endif()
-
-message(STATUS "Check if the compiler supports C++14 relaxed constexpr: ${TANGO_CXX_HAS_RELAXED_CONSTEXPR}")
-
 include(GNUInstallDirs)
 include(configure/coveralls.cmake)
 

--- a/cppapi/server/tango_const.h.in
+++ b/cppapi/server/tango_const.h.in
@@ -147,15 +147,6 @@ const int   SUB_SEND_HWM                   = 10000;
 
 #cmakedefine TANGO_ZMQ_HAS_DISCONNECT
 
-#cmakedefine TANGO_CXX_HAS_RELAXED_CONSTEXPR
-
-// C++14 style relaxed constexpr
-#ifdef TANGO_CXX_HAS_RELAXED_CONSTEXPR
-  #define TANGO_CONSTEXPR constexpr
-#else
-  #define TANGO_CONSTEXPR
-#endif
-
 //
 // Event when using a file as database stuff
 //
@@ -1066,7 +1057,7 @@ const char * const CmdArgTypeName[] = {
 };
 
 /// Convert data types to strings
-inline TANGO_CONSTEXPR const char * data_type_to_string(int type)
+inline constexpr const char * data_type_to_string(int type)
 {
     return (type >= DEV_VOID
             && type < (static_cast<int>(sizeof(CmdArgTypeName) / sizeof(CmdArgTypeName[0]))))


### PR DESCRIPTION
We now allow a couple of C++14 features so we can remove the conditional
handling for C++14 style constexpr. As pointed out by Michal Liszcz
conditional constexpr also does not allow us internally to rely on
functions being constexpr.

@mliszcz IIRC conclusion was to make this change or?