### PR TITLE
Bugfix/fix abi checking

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -48,8 +48,3 @@ jobs:
       run: .travis/install_tango_idl.sh
     - name: Check ABI/API compliance
       run: docker exec -w /home/tango/src cpp_tango .travis/check-ABI-API-compliance.sh || true
-    - name: Upload compliance report
-      uses: actions/upload-artifact@v1
-      with:
-        name: ABI-API compliance report
-        path: compat_reports

--- a/.travis/check-ABI-API-compliance.sh
+++ b/.travis/check-ABI-API-compliance.sh
@@ -23,7 +23,7 @@ function generate_info() {
   local prefix=$1
   local revision=$2
 
-  git worktree remove $prefix-branch || true
+  git worktree remove --force $prefix-branch || true
   git -c advice.detachedHead=false worktree add ${prefix}-branch ${revision}
   mkdir ${prefix}-branch/build
   cd ${prefix}-branch/build

--- a/.travis/check-ABI-API-compliance.sh
+++ b/.travis/check-ABI-API-compliance.sh
@@ -12,11 +12,8 @@ then
   export CMAKE_BUILD_PARALLEL_LEVEL=$(grep -c ^processor /proc/cpuinfo)
 fi
 
-function print_abi_api_breakages() {
-   echo "ABI breakages detected:"
-   cat compat_reports/libtango/${old_revision}_to_${new_revision}/abi_affected.txt | c++filt
-   echo "API breakages detected:"
-   cat compat_reports/libtango/${old_revision}_to_${new_revision}/src_affected.txt | c++filt
+function exit_on_abi_api_breakages() {
+   echo "ABI/API breakages detected!"
    exit 1
 }
 
@@ -54,6 +51,6 @@ generate_info "old" ${old_revision}
 generate_info "new" ${new_revision}
 
 # Compare results
-abi-compliance-checker -l libtango -old ${base}/libtango-old-${old_revision}.dump \
-                                   -new ${base}/libtango-new-${new_revision}.dump \
-                                   -list-affected || print_abi_api_breakages
+sed "s/${old_revision}/fixed/g" ${base}/libtango-old-${old_revision}.dump > old.dump
+sed "s/${new_revision}/fixed/g" ${base}/libtango-new-${new_revision}.dump > new.dump
+diff -Nur old.dump new.dump || exit_on_abi_api_breakages


### PR DESCRIPTION
So here is my stab at fixing the ABI checking.

This PR includes a commit which breaks the ABI, just to see that it is working better now. Judging from the open issues on the involved projects I doubt that this is foolproof, but at least I could get it working now. If we decide that this approach is too kludgy we can also just remove it again.

I'm getting the following now when I include the breaking commit

```diff
--- old.dump    2020-08-27 21:25:02.180190259 +0200
+++ new.dump    2020-08-27 21:25:02.296190257 +0200
@@ -6743,7 +6743,7 @@
                                             'Class' => '1040135',
                                             'Header' => undef,
                                             'Line' => '115',
-                                            'MnglName' => '_ZN5Tango7ApiUtil18get_asynch_repliesEl',
+                                            'MnglName' => '_ZN5Tango7ApiUtil18get_asynch_repliesEi',
                                             'Param' => {
                                                          '0' => {
                                                                   'name' => 'this',
@@ -6751,7 +6751,7 @@
                                                                 },
                                                          '1' => {
                                                                   'name' => 'call_timeout',
-                                                                  'type' => '18757'
+                                                                  'type' => '18744'
                                                                 }
                                                        },
                                             'Return' => '1',
@@ -237394,7 +237394,7 @@
                                                   '_ZN5Tango7ApiUtil14device_to_attrERKNS_15DeviceAttributeERNS_16AttributeValue_4E' => 1,                                                                                                                                      
                                                   '_ZN5Tango7ApiUtil14get_ip_from_ifERSt6vectorINSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEESaIS7_EE' => 1,                                                                                                             
                                                   '_ZN5Tango7ApiUtil15set_sig_handlerEv' => 1,
-                                                  '_ZN5Tango7ApiUtil18get_asynch_repliesEl' => 1,
+                                                  '_ZN5Tango7ApiUtil18get_asynch_repliesEi' => 1,
                                                   '_ZN5Tango7ApiUtil18get_asynch_repliesEv' => 1,
                                                   '_ZN5Tango7ApiUtil19attr_to_device_baseINS_16AttributeValue_4EEEvPKT_PNS_15DeviceAttributeE' => 1,                                                                                                                            
                                                   '_ZN5Tango7ApiUtil19attr_to_device_baseINS_16AttributeValue_5EEEvPKT_PNS_15DeviceAttributeE' => 1,                                                                                                                            
ABI/API breakages detected!
```

and no complaint when I revert the ABI breaking commit.

This approach does give quite some false positives, but I don't see how I can get the original approach working.