### PR TITLE
Musl fixes

### DIFF
--- a/cppapi/client/api_util.cpp
+++ b/cppapi/client/api_util.cpp
@@ -484,7 +484,7 @@ void ApiUtil::get_asynch_replies()
     }
     catch (CORBA::BAD_INV_ORDER &e)
     {
-        if (e.minor() != omni::BAD_INV_ORDER_RequestNotSentYet)
+        if ((e.minor)() != omni::BAD_INV_ORDER_RequestNotSentYet)
         {
             throw;
         }
@@ -647,7 +647,7 @@ void ApiUtil::get_asynch_replies(long call_timeout)
                 }
                 catch (CORBA::BAD_INV_ORDER &e)
                 {
-                    if (e.minor() != omni::BAD_INV_ORDER_RequestNotSentYet)
+                    if ((e.minor)() != omni::BAD_INV_ORDER_RequestNotSentYet)
                     {
                         throw;
                     }
@@ -713,7 +713,7 @@ void ApiUtil::get_asynch_replies(long call_timeout)
                 }
                 catch (CORBA::BAD_INV_ORDER &e)
                 {
-                    if (e.minor() != omni::BAD_INV_ORDER_RequestNotSentYet)
+                    if ((e.minor)() != omni::BAD_INV_ORDER_RequestNotSentYet)
                     {
                         throw;
                     }

--- a/log4tango/include/log4tango/FileAppender.hh
+++ b/log4tango/include/log4tango/FileAppender.hh
@@ -30,6 +30,7 @@
 
 #include <log4tango/Portability.hh>
 #include <log4tango/LayoutAppender.hh>
+#include <sys/stat.h>
 
 namespace log4tango {
 


### PR DESCRIPTION
Close #767.

The full patch file looks like

```diff
--- git/cppapi/server/dserversignal.h.orig      2017-03-20 14:14:54.391119329 -0700
+++ git/cppapi/server/dserversignal.h   2017-03-20 14:15:30.485906208 -0700
@@ -151,12 +151,10 @@
        }
 #endif
 
-#if (defined __GLIBC__ || defined __darwin__ || defined __freebsd__)
-       static inline bool auth_signal(TANGO_UNUSED(long s)) {return true;}
-#endif
-
 #ifdef _TG_WINDOWS_
        static inline bool auth_signal(long s) {return true;}
+#else
+       static inline bool auth_signal(TANGO_UNUSED(long s)) {return true;}
 #endif
 
        static string                   sig_name[_NSIG];
--- git/log4tango/include/log4tango/FileAppender.hh.orig        2017-03-20 14:20:16.676090311 -0700
+++ git/log4tango/include/log4tango/FileAppender.hh     2017-03-20 14:20:38.331336173 -0700
@@ -30,6 +30,7 @@
 
 #include <log4tango/Portability.hh>
 #include <log4tango/LayoutAppender.hh>
+#include <sys/stat.h>
 
 namespace log4tango {
 
--- git/log4tango/config/config.cmake.orig      2017-03-21 09:30:05.585083001 -0700
+++ git/log4tango/config/config.cmake   2017-03-21 09:30:54.796083001 -0700
@@ -34,9 +34,7 @@
 check_library_exists(pthread pthread_create "" HAVE_PTHREAD_CREATE)
 check_include_file("pthread.h;pthread_np.h" HAVE_PTHREAD_NP_H)
 
-if(CMAKE_THREAD_LIBS_INIT)
     set(LOG4TANGO_HAVE_THREADING "/**/")
-endif()
 
 #check compiler features
 macro (LOG4TANGO_CHECK_COMPILER_FEATURE source var)
--- git/cppapi/client/api_util.cpp.orig 2017-03-21 09:44:20.044360695 -0700
+++ git/cppapi/client/api_util.cpp      2017-03-21 09:46:56.713360695 -0700
@@ -479,7 +479,7 @@
        }
        catch (CORBA::BAD_INV_ORDER &e)
        {
-               if (e.minor() != omni::BAD_INV_ORDER_RequestNotSentYet)
+               if ((e.minor)() != omni::BAD_INV_ORDER_RequestNotSentYet)
                        throw;
        }
 
@@ -640,7 +640,7 @@
                                }
                                catch (CORBA::BAD_INV_ORDER &e)
                                {
-                                       if (e.minor() != omni::BAD_INV_ORDER_RequestNotSentYet)
+                                       if ((e.minor)() != omni::BAD_INV_ORDER_RequestNotSentYet)
                                                throw;
                                }
                        }
@@ -704,7 +704,7 @@
                                }
                                catch (CORBA::BAD_INV_ORDER &e)
                                {
-                                       if (e.minor() != omni::BAD_INV_ORDER_RequestNotSentYet)
+                                       if ((e.minor)() != omni::BAD_INV_ORDER_RequestNotSentYet)
                                                throw;
                                }
                        }
```

1. Not included as that is already removed since 918e6459 (Remove auth_signal() function... and associated dead code Following a suggestion from @mliszcz, 2020-04-28).
2. Done
3. Not done, as that is being reworked and fixed in #759.
4. Done