### PR TITLE
configure/CMakeLists.txt: Enforce a minimum libzmq version

### DIFF
--- a/configure/CMakeLists.txt
+++ b/configure/CMakeLists.txt
@@ -149,6 +149,26 @@ if(NOT WIN32)
               LINK_LIBRARIES "${ZMQ_PKG_LIBRARIES}")
 
   message(STATUS "Check if zmq::socket has a disconnect method: ${TANGO_ZMQ_HAS_DISCONNECT}")
+
+  set(ZMQ_MIN_VER_MAJOR 4)
+  set(ZMQ_MIN_VER_MINOR 0)
+  set(ZMQ_MIN_VER_PATCH 5)
+
+  try_compile(TANGO_ZMQ_USABLE_VERSION ${CMAKE_BINARY_DIR}/test_zmq_version
+              SOURCES ${CMAKE_SOURCE_DIR}/configure/test_zmq_version.cpp
+              COMPILE_DEFINITIONS "-I ${ZMQ_BASE}/include
+              -DMINIMUM_VERSION_MAJOR=${ZMQ_MIN_VER_MAJOR}
+              -DMINIMUM_VERSION_MINOR=${ZMQ_MIN_VER_MINOR}
+              -DMINIMUM_VERSION_PATCH=${ZMQ_MIN_VER_PATCH}"
+              LINK_LIBRARIES "${ZMQ_PKG_LIBRARIES}")
+
+  set(msg "Check if libzmq version is >= ${ZMQ_MIN_VER_MAJOR}.${ZMQ_MIN_VER_MINOR}.${ZMQ_MIN_VER_PATCH}: ${TANGO_ZMQ_USABLE_VERSION}")
+
+  if(${TANGO_ZMQ_USABLE_VERSION})
+    message(STATUS ${msg})
+  else()
+    message(FATAL_ERROR ${msg})
+  endif()
 else()
   set(TANGO_ZMQ_HAS_DISCONNECT TRUE)
   message(STATUS "Check if zmq::socket has a disconnect method: ${TANGO_ZMQ_HAS_DISCONNECT} (hardcoded)")

--- a/configure/test_zmq_version.cpp
+++ b/configure/test_zmq_version.cpp
@@ -1,0 +1,15 @@
+#include <zmq.h>
+
+// Check libzmq version using plain C++03
+
+#define MINIMUM_VERSION ZMQ_MAKE_VERSION(MINIMUM_VERSION_MAJOR, MINIMUM_VERSION_MINOR, MINIMUM_VERSION_PATCH)
+#define FOUND_VERSION ZMQ_MAKE_VERSION(ZMQ_VERSION_MAJOR, ZMQ_VERSION_MINOR, ZMQ_VERSION_PATCH)
+
+#if FOUND_VERSION < MINIMUM_VERSION
+#error "Old version"
+#endif
+
+int main(int, char**)
+{
+	return 0;
+}


### PR DESCRIPTION
The autotools build system of the tango source distribution already
enforces a minimum libzmq version of 4.0.5.

We now do the same for the CMake build system.

This is a pure compile time check, so it works with cross compiling. And
as it does not use pkg-config, it can also later be ported to other
non-linux platforms like Windows.

Close #788.