### PR TITLE
cpp_test_suite/event/event_lock.cpp: Make it compile on 32-bit linux

### DIFF
--- a/cpp_test_suite/event/event_lock.cpp
+++ b/cpp_test_suite/event/event_lock.cpp
@@ -48,10 +48,10 @@ void EventCallback::push_event(Tango::EventData *ed)
 void set_abs_change(std::string device_name, std::string attribute_name)
 {
     Tango::DbDatum attribute_datum(attribute_name);
-    attribute_datum << 1;
+    attribute_datum << 1ul;
 
     Tango::DbDatum change_datum("abs_change");
-    change_datum << 1;
+    change_datum << 1ul;
 
     Tango::DbData data;
     data.push_back(attribute_datum);


### PR DESCRIPTION
The following compile error with gcc 8.3 is generated:

/home/firma/devel/cppTango/cpp_test_suite/event/event_lock.cpp: In function ‘void set_abs_change(std::__cxx11::string, std::__cxx11::string)’:
/home/firma/devel/cppTango/cpp_test_suite/event/event_lock.cpp:51:21: error: ambiguous overload for ‘operator<<’ (operand types are ‘Tango::DbDatum’ a
nd ‘unsigned int’)
     attribute_datum << 1u;
     ~~~~~~~~~~~~~~~~^~~~~
In file included from /home/firma/devel/cppTango/cppapi/server/tango.h:97,
                 from /home/firma/devel/cppTango/cpp_test_suite/event/event_lock.cpp:17:
/home/firma/devel/cppTango/cppapi/client/dbapi.h:528:7: note: candidate: ‘void Tango::DbDatum::operator<<(bool)’
  void operator << (bool val);
       ^~~~~~~~
/home/firma/devel/cppTango/cppapi/client/dbapi.h:637:7: note: candidate: ‘void Tango::DbDatum::operator<<(short int)’
  void operator << (short);
       ^~~~~~~~
/home/firma/devel/cppTango/cppapi/client/dbapi.h:638:7: note: candidate: ‘void Tango::DbDatum::operator<<(unsigned char)’
  void operator << (unsigned char);
       ^~~~~~~~
/home/firma/devel/cppTango/cppapi/client/dbapi.h:639:7: note: candidate: ‘void Tango::DbDatum::operator<<(short unsigned int)’
  void operator << (unsigned short);
       ^~~~~~~~
/home/firma/devel/cppTango/cppapi/client/dbapi.h:640:7: note: candidate: ‘void Tango::DbDatum::operator<<(Tango::DevLong)’
  void operator << (DevLong);
       ^~~~~~~~
/home/firma/devel/cppTango/cppapi/client/dbapi.h:641:7: note: candidate: ‘void Tango::DbDatum::operator<<(Tango::DevULong)’
  void operator << (DevULong);
       ^~~~~~~~
/home/firma/devel/cppTango/cppapi/client/dbapi.h:642:7: note: candidate: ‘void Tango::DbDatum::operator<<(Tango::DevLong64)’
  void operator << (DevLong64);
       ^~~~~~~~
/home/firma/devel/cppTango/cppapi/client/dbapi.h:643:7: note: candidate: ‘void Tango::DbDatum::operator<<(Tango::DevULong64)’
  void operator << (DevULong64);
       ^~~~~~~~
/home/firma/devel/cppTango/cppapi/client/dbapi.h:644:7: note: candidate: ‘void Tango::DbDatum::operator<<(float)’
  void operator << (float);
       ^~~~~~~~
/home/firma/devel/cppTango/cppapi/client/dbapi.h:645:7: note: candidate: ‘void Tango::DbDatum::operator<<(double)’
  void operator << (double);

By making the fed in variable unsigned long we avoid the error.