### PR TITLE
Search docker for tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,12 @@ add_subdirectory("log4tango")
 add_subdirectory("cppapi")
 
 if(BUILD_TESTING)
+
+  find_program(DOCKER_BINARY docker)
+  if(NOT DOCKER_BINARY)
+      message(WARNING "The tests can not be run as docker is missing.")
+  endif()
+
   if(BUILD_SHARED_LIBS)
     add_subdirectory("cpp_test_suite")
   else()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,7 +57,7 @@ if(BUILD_TESTING)
     add_subdirectory("cpp_test_suite")
   else()
     message(WARNING "Not building the tests, because that is currently supported only when BUILD_SHARED_LIBS is ON")
-    SET(BUILD_TESTING OFF)
+    set(BUILD_TESTING OFF)
   endif()
 endif()
 

--- a/cpp_test_suite/environment/run_with_fixture.sh.cmake
+++ b/cpp_test_suite/environment/run_with_fixture.sh.cmake
@@ -8,6 +8,11 @@ if [ $# -lt 1 ]; then
     exit 1
 fi
 
+if ! hash docker 2>/dev/null; then
+  echo "Can not run the tests as docker is missing"
+  exit 1
+fi
+
 tc_program="$1"
 tc_run_name="$(basename "$tc_program")_$(date '+%Y%m%d.%H%M%S.%N')"
 shift 1

--- a/cpp_test_suite/environment/setup_database.sh.cmake
+++ b/cpp_test_suite/environment/setup_database.sh.cmake
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 # vim: syntax=sh
 
+if ! hash docker 2>/dev/null; then
+  echo "Can not run the tests as docker is missing"
+  exit 1
+fi
+
 mysql_container="${1:-mysql_db}"
 tango_container="${2:-tango_cs}"
 


### PR DESCRIPTION
I had that issue when I played around with cppTango on my mac. We now warn when building the tests and docker is not present, and also error out when running the tests and docker is missing.