### PR TITLE
cppapi/server/jpeg_mmx/jpeg_dct_mmx.cpp: Avoid using the wrong GCC fu…

### DIFF
--- a/cppapi/server/jpeg_mmx/jpeg_dct_mmx.cpp
+++ b/cppapi/server/jpeg_mmx/jpeg_dct_mmx.cpp
@@ -253,17 +253,10 @@ ALIGN8 short __jpmm_row_tab_frw[] = {  // forward_dct coeff table
 	"pmulhw	"#REG1", QWORD PTR [esp]	\n" \
 	"add	esp,8	\n"
 
-#if __GNUC__ > 3
-#define lea_addr_in_reg(REG1) \
-	"call	__i686.get_pc_thunk.bx	\n" \
-	"add    ebx,_GLOBAL_OFFSET_TABLE_	\n" \
-	"lea	"#REG1",__jpmm_row_tab_frw@GOTOFF	\n"
-#else
 #define lea_addr_in_reg(REG1) \
 	"call	__tg_get_pc	\n" \
 	"add    ebx,_GLOBAL_OFFSET_TABLE_	\n" \
 	"lea	"#REG1",__jpmm_row_tab_frw@GOTOFF	\n"
-#endif
 
 #else /* __PIC__ */
 
@@ -1062,21 +1055,12 @@ void jpeg_fdct_mmx( short *block )
   );
 
 #ifdef __PIC__
-#if __GNUC__ > 3
- __asm__(
- 	"push 	%ebx		\n"
-	"call	__i686.get_pc_thunk.bx	\n"
-	"add    $_GLOBAL_OFFSET_TABLE_, %ebx	\n"
-	"lea	__jpmm_row_tab_frw@GOTOFF(%ebx),%ebx	\n"
-   );
-#else
  __asm__(
  	"push 	%ebx		\n"
 	"call	__tg_get_pc	\n"
 	"add    $_GLOBAL_OFFSET_TABLE_, %ebx	\n"
 	"lea	__jpmm_row_tab_frw@GOTOFF(%ebx),%ebx	\n"
    );
-#endif
 #endif /* __PIC__ */
 
   // Rows
@@ -1278,15 +1262,6 @@ ALIGN8 short __jpmm_offset128[]  = { 128,128,128,128 };
 	"paddw	"#REG1", QWORD PTR [esp]	\n" \
 	"add	esp,8	\n"
 
-#if __GNUC__ > 3
-#define lea_addr_in_regs(REG1,REG2) \
-    "push 	ebx		\n" \
-	"call	__i686.get_pc_thunk.bx	\n" \
-	"add    ebx,_GLOBAL_OFFSET_TABLE_	\n" \
-	"lea	"#REG1",__jpmm_row_tabs@GOTOFF	\n" \
-	"lea	"#REG2",__jpmm_rounder@GOTOFF	\n" \
-	"pop	ebx   \n"
-#else
 #define lea_addr_in_regs(REG1,REG2) \
     "push 	ebx		\n" \
 	"call	__tg_get_pc	\n" \
@@ -1294,7 +1269,6 @@ ALIGN8 short __jpmm_offset128[]  = { 128,128,128,128 };
 	"lea	"#REG1",__jpmm_row_tabs@GOTOFF	\n" \
 	"lea	"#REG2",__jpmm_rounder@GOTOFF	\n" \
 	"pop	ebx   \n"
-#endif
 
 
 #else /* __PIC__ */
@@ -1754,18 +1728,6 @@ __mmx_idct_cols:
 #else
 
 #ifdef __PIC__
-#if __GNUC__ > 3
- __asm__(
- 	"push 	%ebx		\n"
-    "push 	%ecx		\n"
-	"call	__i686.get_pc_thunk.bx	\n"
-	"add    $_GLOBAL_OFFSET_TABLE_, %ebx	\n"
-	"lea	__jpmm_row_tabs@GOTOFF(%ebx),%eax	\n"
-	"lea	__jpmm_rounder@GOTOFF(%ebx),%ecx	\n"
-	"mov	%ecx,%ebx	\n"
-	"pop	%ecx   \n"
-   );
-#else
  __asm__(
  	"push 	%ebx		\n"
     "push 	%ecx		\n"
@@ -1776,7 +1738,6 @@ __mmx_idct_cols:
 	"mov	%ecx,%ebx	\n"
 	"pop	%ecx   \n"
    );
-#endif
 #endif /* __PIC__ */
   // gcc inline assembly code (32bits)
   // Rows


### PR DESCRIPTION
…nction

The JPEG code has MMX assembler routines which have optimized code for
32bit intel architectures.

This code uses GCC internals like __i686.get_pc_thunk.bx, which loads
the position of the code into a register. This is required for position
independent code [1].

The name of that function changed in the GCC repository in a3330c9d
(morestack.S (__i686.get_pc_thunk.bx): Rename to..., 2011-05-04).

But the new name is only present since 4.7.0. So we would need to either
support both names or realize that we already have a fallback.

By using the fallback which uses the exact same code as GCC we have less
code and less branching on versions.

This bug was already reported earlier [2], but the fix never made it
into the code.

[1]: https://stackoverflow.com/questions/6679846/what-is-i686-get-pc-thunk-bx-why-do-we-need-this-call
[2]: https://sourceforge.net/p/tango-cs/bugs/811/

Backport of #783.